### PR TITLE
Patch missing additional info value from _INFO file

### DIFF
--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -172,6 +172,7 @@ object DynamicConformanceJob {
     val publishDirSize = FileSystemVersionUtils.getDirectorySize(publishPath)
     performance.finishMeasurement(publishDirSize, recordCount)
     addPerformanceMetadata(spark, publishDirSize, publishPath)
+    withPartCols.writeInfoFile(publishPath)
     cmd.performanceMetricsFile.foreach(fileName => {
       try {
         performance.writeMetricsToFile(fileName)

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -203,6 +203,7 @@ object StandardizationJob {
     cmd.rowTag.foreach(rowTag => Atum.setAdditionalInfo("xml_row_tag" -> rowTag))
     if (cmd.csvDelimiter.isDefined) cmd.csvDelimiter.foreach(deLimiter => Atum.setAdditionalInfo("csv_delimiter" -> deLimiter))
     addPerformanceMetadata(spark, rawDirSize, stdDirSize, stdPath)
+    stdRenameSourceColumns.writeInfoFile(stdPath)
     cmd.performanceMetricsFile.foreach(fileName => {
       try {
         performance.writeMetricsToFile(fileName)


### PR DESCRIPTION
Atum fails to write the Additional Information added at the end of each job to the _INFO file. This happens because we rely on the destination being inferred from the where the resulting parquet is being written. This works like a charm, but we have some additional info that we want to add after the final write. Atum writes outstanding checkpoints on exit, but fails to do so without an explicit destination for the _INFO file (can't infer).

This is a fix, calling Atum to explicitly write the _INFO file until we get Atum to handle this automatically.