### PR TITLE
#26 Performance optimisation for standardisation

### DIFF
--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -184,8 +184,8 @@ object StandardizationJob {
     }
 
     // If the meta data value sourcecolumn is set override source data column name with the field name
-    val stdRenameSourceColumns = std.select(schema.fields.map{
-      field => renameSourceColumn(std, field, true)
+    val stdRenameSourceColumns = std.select(schema.fields.map { field =>
+      renameSourceColumn(std, field, true)
     }: _*)
 
     stdRenameSourceColumns.setCheckpoint("Standardization Finish", persistInDatabase = false)
@@ -233,15 +233,15 @@ object StandardizationJob {
     log.warn(s"Converting to Parquet in temporary dir: $tempParquetDir")
 
     // Handle renaming of source columns in case there are columns that will break because of issues in column names like spaces
-    df.select(schema.fields.map{
-      field => renameSourceColumn(df, field, false)
+    df.select(schema.fields.map { field =>
+      renameSourceColumn(df, field, false)
     }: _*).write.parquet(tempParquetDir)
 
     FileSystemVersionUtils.deleteOnExit(tempParquetDir)
     // Reload from temp parquet and reverse column renaming above
     val dfTmp = spark.read.parquet(tempParquetDir)
-    dfTmp.select(schema.fields.map{
-      field => reverseRenameSourceColumn(dfTmp, field)
+    dfTmp.select(schema.fields.map { field =>
+      reverseRenameSourceColumn(dfTmp, field)
     }: _*)
   }
 

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -17,7 +17,7 @@ package za.co.absa.enceladus.standardization
 
 import java.io.{File, PrintWriter, StringWriter}
 
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types.{StructField, StructType}
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
 import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
@@ -184,7 +184,9 @@ object StandardizationJob {
     }
 
     // If the meta data value sourcecolumn is set override source data column name with the field name
-    val stdRenameSourceColumns = schema.foldLeft(std)((std, field) => renameSourceColumns(std, field, true))
+    val stdRenameSourceColumns = std.select(schema.fields.map{
+      field => renameSourceColumn(std, field, true)
+    }: _*)
 
     stdRenameSourceColumns.setCheckpoint("Standardization Finish", persistInDatabase = false)
 
@@ -231,33 +233,35 @@ object StandardizationJob {
     log.warn(s"Converting to Parquet in temporary dir: $tempParquetDir")
 
     // Handle renaming of source columns in case there are columns that will break because of issues in column names like spaces
-    schema.foldLeft(df)((df, field) => renameSourceColumns(df, field, false)).write.parquet(tempParquetDir)
+    df.select(schema.fields.map{
+      field => renameSourceColumn(df, field, false)
+    }: _*).write.parquet(tempParquetDir)
 
     FileSystemVersionUtils.deleteOnExit(tempParquetDir)
     // Reload from temp parquet and reverse column renaming above
-    schema.foldLeft(spark.read.parquet(tempParquetDir))(reverseRenameSourceColumns)
+    val dfTmp = spark.read.parquet(tempParquetDir)
+    dfTmp.select(schema.fields.map{
+      field => reverseRenameSourceColumn(dfTmp, field)
+    }: _*)
   }
 
-  private def renameSourceColumns(df: DataFrame, field: StructField, registerWithATUM: Boolean): DataFrame = {
-    val renameDf = if (field.metadata.contains("sourcecolumn")) {
-      log.info(s"schema field : ${field.name} : rename : ${field.metadata.getString("sourcecolumn")}")
-      df.withColumnRenamed(field.metadata.getString("sourcecolumn"), field.name) //rename column in DF
-    } else df
-
-    if (registerWithATUM && field.metadata.contains("sourcecolumn"))
-      renameDf.registerColumnRename(field.metadata.getString("sourcecolumn"), field.name) // register rename with ATUM
-        // Re-add meta data
-        .withColumn(field.name, renameDf.col(field.name).as("", field.metadata))
-    else renameDf
-  }
-
-  private def reverseRenameSourceColumns(df: DataFrame, field: StructField): DataFrame = {
+  private def renameSourceColumn(df: DataFrame, field: StructField, registerWithATUM: Boolean): Column = {
     if (field.metadata.contains("sourcecolumn")) {
-      log.info(s"schema field : ${field.metadata.getString("sourcecolumn")} : reverse rename : ${field.name}")
-      df.withColumnRenamed(field.name, field.metadata.getString("sourcecolumn")) // reverse rename column in DF
-    } else {
-      df
-    }
+      val sourceColumnName = field.metadata.getString("sourcecolumn")
+      log.info(s"schema field : ${field.name} : rename : ${sourceColumnName}")
+      if (registerWithATUM) {
+        df.registerColumnRename(sourceColumnName, field.name) //register rename with ATUM
+      }
+      df.col(sourceColumnName).as(field.name, field.metadata)
+    } else df.col(field.name)
+  }
+
+  private def reverseRenameSourceColumn(df: DataFrame, field: StructField): Column = {
+    if (field.metadata.contains("sourcecolumn")) {
+      val sourceColumnName = field.metadata.getString("sourcecolumn")
+      log.info(s"schema field : ${sourceColumnName} : reverse rename : ${field.name}")
+      df.col(field.name).as(sourceColumnName)
+    } else df.col(field.name)
   }
 
   def buildRawPath(cmd: CmdConfig, dataset: Dataset, dateTokens: Array[String]): String = {

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -184,7 +184,7 @@ object StandardizationJob {
     }
 
     // If the meta data value sourcecolumn is set override source data column name with the field name
-    val stdRenameSourceColumns = std.select(schema.fields.map { field =>
+    val stdRenameSourceColumns: DataFrame = std.select(schema.fields.map { field: StructField =>
       renameSourceColumn(std, field, true)
     }: _*)
 
@@ -233,14 +233,14 @@ object StandardizationJob {
     log.warn(s"Converting to Parquet in temporary dir: $tempParquetDir")
 
     // Handle renaming of source columns in case there are columns that will break because of issues in column names like spaces
-    df.select(schema.fields.map { field =>
+    df.select(schema.fields.map { field: StructField =>
       renameSourceColumn(df, field, false)
     }: _*).write.parquet(tempParquetDir)
 
     FileSystemVersionUtils.deleteOnExit(tempParquetDir)
     // Reload from temp parquet and reverse column renaming above
     val dfTmp = spark.read.parquet(tempParquetDir)
-    dfTmp.select(schema.fields.map { field =>
+    dfTmp.select(schema.fields.map { field: StructField =>
       reverseRenameSourceColumn(dfTmp, field)
     }: _*)
   }

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
@@ -77,22 +77,22 @@ object StandardizationInterpreter {
 
     // TODO: remove when spark-xml handles empty arrays
     val df1 = if (inputType.toLowerCase() == "xml") {
-      df.select(expSchema.fields.map{
-        field => SparkXMLHack.hack(field, "", df).as(field.name)
+      df.select(expSchema.fields.map { field =>
+        SparkXMLHack.hack(field, "", df).as(field.name)
       }: _*)
     } else df
 
     logger.info(s"Step 2: Standardization")
     // step 2 - standardize
-    val std = df1.select(expSchema.fields.flatMap{
-      field => logger.info(s"Standardizing field: ${field.name}")
-        if (field.name == ErrorMessage.errorColumnName) {
-          Some(df1.col(field.name))
-        } else {
-          val stdOutput = TypeParser.standardize(field, "", df.schema)
-          logger.info(s"Applying standardization plan for ${field.name}")
-          stdApplyLogic(stdOutput, field)
-        }
+    val std = df1.select(expSchema.fields.flatMap { field =>
+      logger.info(s"Standardizing field: ${field.name}")
+      if (field.name == ErrorMessage.errorColumnName) {
+        Seq(df1.col(field.name))
+      } else {
+        val stdOutput = TypeParser.standardize(field, "", df.schema)
+        logger.info(s"Applying standardization plan for ${field.name}")
+        stdApplyLogic(stdOutput, field)
+      }
     }: _*)
 
     // step 3 drop intermediate error columns


### PR DESCRIPTION
replace usage of .foldLeft over columns to .select(map...) where it is critical. Tested on synthetic and real data: standardisation takes linear time on the number of columns (polynomial previously). For the real dataset with 717 columns the time has reduced from 3 hours to 4 minutes.