### PR TITLE
Feature/125 add pk based comparison

### DIFF
--- a/testutils/README.md
+++ b/testutils/README.md
@@ -43,6 +43,7 @@ spark-submit \
 --new-path /path/to/new/data/set \
 --ref-path /path/to/referential/data/set \
 --out-path /path/to/diff/output
+--keys key1,key2,key3
 ```
 
 #### Where
@@ -62,6 +63,9 @@ Usage: spark-submit [spark options] TestUtils.jar [options]
                                other folders. expected_minus_actual and actual_minus_expected.
                                Both hold parque data sets of differences. (minus as in is 
                                relative complement
+  --keys                   If there are know unique keys, they can be specified for better
+                               output. Keys should be specified one by one, with , (comma) 
+                               between them.
   --help                   prints this usage text
 
 ```

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/DataframeReader.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/DataframeReader.scala
@@ -55,16 +55,16 @@ class DataframeReader(datasetPath: String, inputSchema: Option[StructType] )
                                  sparkSession: SparkSession): DataFrameReader = {
     val dfReader = getStandardReader
 
-    if (inputSchema.isDefined) dfReader.schema(inputSchema.get)
-    else dfReader
+    if (inputSchema.isDefined) { dfReader.schema(inputSchema.get) }
+    else { dfReader }
   }
 
   private def getFixedWidthReader()(implicit dfReaderOptions: DataframeReaderOptions,
                                     sparkSession: SparkSession): DataFrameReader = {
     val dfReader = getStandardReader
 
-    if (dfReaderOptions.fixedWidthTrimValues.get) dfReader.option("trimValues", "true")
-    else dfReader
+    if (dfReaderOptions.fixedWidthTrimValues.get) { dfReader.option("trimValues", "true") }
+    else { dfReader }
   }
 
   private def getXmlReader()(implicit dfReaderOptions: DataframeReaderOptions,

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/DataframeReader.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/DataframeReader.scala
@@ -35,7 +35,8 @@ class DataframeReader(datasetPath: String, inputSchema: Option[StructType] )
     StructType(dataFrameSchema.map{ f => StructField(f.name, f.dataType, f.nullable) })
   }
 
-  private def getDataFrameReader(implicit dfReaderOptions: DataframeReaderOptions, sparkSession: SparkSession): DataFrameReader = {
+  private def getDataFrameReader(implicit dfReaderOptions: DataframeReaderOptions,
+                                 sparkSession: SparkSession): DataFrameReader = {
     (dfReaderOptions.rawFormat: @switch) match {
       case "csv" => getCsvReader
       case "xml" => getXmlReader
@@ -45,32 +46,37 @@ class DataframeReader(datasetPath: String, inputSchema: Option[StructType] )
     }
   }
 
-  private def getStandardReader()(implicit dfReaderOptions: DataframeReaderOptions, sparkSession: SparkSession): DataFrameReader = {
+  private def getStandardReader()(implicit dfReaderOptions: DataframeReaderOptions,
+                                  sparkSession: SparkSession): DataFrameReader = {
     sparkSession.read.format(dfReaderOptions.rawFormat)
   }
 
-  private def getParquetReader()(implicit dfReaderOptions: DataframeReaderOptions, sparkSession: SparkSession): DataFrameReader = {
+  private def getParquetReader()(implicit dfReaderOptions: DataframeReaderOptions,
+                                 sparkSession: SparkSession): DataFrameReader = {
     val dfReader = getStandardReader
 
     if (inputSchema.isDefined) dfReader.schema(inputSchema.get)
     else dfReader
   }
 
-  private def getFixedWidthReader()(implicit dfReaderOptions: DataframeReaderOptions, sparkSession: SparkSession): DataFrameReader = {
+  private def getFixedWidthReader()(implicit dfReaderOptions: DataframeReaderOptions,
+                                    sparkSession: SparkSession): DataFrameReader = {
     val dfReader = getStandardReader
 
     if (dfReaderOptions.fixedWidthTrimValues.get) dfReader.option("trimValues", "true")
     else dfReader
   }
 
-  private def getXmlReader()(implicit dfReaderOptions: DataframeReaderOptions, sparkSession: SparkSession): DataFrameReader = {
+  private def getXmlReader()(implicit dfReaderOptions: DataframeReaderOptions,
+                             sparkSession: SparkSession): DataFrameReader = {
     getStandardReader.option("rowTag", dfReaderOptions.rowTag.get)
   }
 
-  private def getCsvReader()(implicit dfReaderOptions: DataframeReaderOptions, sparkSession: SparkSession): DataFrameReader = {
+  private def getCsvReader()(implicit dfReaderOptions: DataframeReaderOptions,
+                             sparkSession: SparkSession): DataFrameReader = {
     val dfReader = getStandardReader.option("delimiter", dfReaderOptions.csvDelimiter.get)
 
-    if (dfReaderOptions.csvHeader.isDefined) dfReader.option("header", dfReaderOptions.csvHeader.get)
-    else dfReader
+    if (dfReaderOptions.csvHeader.isDefined) { dfReader.option("header", dfReaderOptions.csvHeader.get) }
+    else { dfReader }
   }
 }

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/DataframeReader.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/DataframeReader.scala
@@ -55,16 +55,20 @@ class DataframeReader(datasetPath: String, inputSchema: Option[StructType] )
                                  sparkSession: SparkSession): DataFrameReader = {
     val dfReader = getStandardReader
 
-    if (inputSchema.isDefined) { dfReader.schema(inputSchema.get) }
-    else { dfReader }
+    inputSchema match {
+      case Some(schema) => dfReader.schema(schema)
+      case None         => dfReader
+    }
   }
 
   private def getFixedWidthReader()(implicit dfReaderOptions: DataframeReaderOptions,
                                     sparkSession: SparkSession): DataFrameReader = {
     val dfReader = getStandardReader
 
-    if (dfReaderOptions.fixedWidthTrimValues.get) { dfReader.option("trimValues", "true") }
-    else { dfReader }
+    dfReaderOptions.fixedWidthTrimValues match {
+      case Some(trimValues) => dfReader.option("trimValues", trimValues)
+      case None             => dfReader
+    }
   }
 
   private def getXmlReader()(implicit dfReaderOptions: DataframeReaderOptions,
@@ -76,7 +80,9 @@ class DataframeReader(datasetPath: String, inputSchema: Option[StructType] )
                              sparkSession: SparkSession): DataFrameReader = {
     val dfReader = getStandardReader.option("delimiter", dfReaderOptions.csvDelimiter.get)
 
-    if (dfReaderOptions.csvHeader.isDefined) { dfReader.option("header", dfReaderOptions.csvHeader.get) }
-    else { dfReader }
+    dfReaderOptions.csvHeader match {
+      case Some(hasHeader) => dfReader.option("header", hasHeader)
+      case None            => dfReader
+    }
   }
 }

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/CmdConfig.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/CmdConfig.scala
@@ -30,7 +30,8 @@ case class CmdConfig(rawFormat: String = "xml",
                      fixedWidthTrimValues: Option[Boolean] = Some(false),
                      newPath: String = "",
                      refPath: String = "",
-                     outPath: String = "")
+                     outPath: String = "",
+                     keys: Option[Seq[String]] = None)
 
 object CmdConfig {
 
@@ -135,6 +136,11 @@ object CmdConfig {
         else
           success
       )
+
+    opt[String]("keys").action((value, config) => {
+      config.copy(keys = Some(value.split(",").toSeq))
+    }).text("If there are know unique keys, they can be specified for better output. Keys should " +
+      "be specified one by one, with , (comma) between them.")
 
     help("help").text("prints this usage text")
   }

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/CmdConfig.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/CmdConfig.scala
@@ -62,37 +62,42 @@ object CmdConfig {
     opt[String]("row-tag").optional.action((value, config) =>
       config.copy(rowTag = Some(value))).text("use the specific row tag instead of 'ROW' for XML format")
       .validate(value =>
-        if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("xml"))
+        if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("xml")) {
           success
-        else
+        } else {
           failure("The --row-tag option is supported only for XML raw data format")
+        }
       )
 
     opt[String]("delimiter").optional.action((value, config) =>
       config.copy(csvDelimiter = Some(value))).text("use the specific delimiter instead of ',' for CSV format")
       .validate(value =>
-        if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("csv"))
+        if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("csv")) {
           success
-        else
+        } else {
           failure("The --delimiter option is supported only for CSV raw data format")
+        }
       )
     // no need for validation for boolean since scopt itself will do
     opt[Boolean]("header").optional.action((value, config) =>
       config.copy(csvHeader = Some(value))).text("use the header option to consider CSV header")
       .validate(value =>
-        if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("csv"))
+        if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("csv")) {
           success
-        else
+        } else {
           failure("The --header option is supported only for CSV ")
+        }
       )
 
     opt[Boolean]("trim-values").optional.action((value, config) =>
-      config.copy(fixedWidthTrimValues = Some(value))).text("use --trimValues option to trim values in  fixed width file")
+      config.copy(fixedWidthTrimValues = Some(value)))
+      .text("use --trimValues option to trim values in  fixed width file")
       .validate(value =>
-        if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("fixed-width"))
+        if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("fixed-width")) {
           success
-        else
+        } else {
           failure("The --trimValues option is supported only for fixed-width files ")
+        }
       )
 
     opt[String]("new-path").required.action((value, config) => {
@@ -100,12 +105,13 @@ object CmdConfig {
       config.copy(newPath = value)
     }).text("Path to the new dataset, just generated and to be tested.")
       .validate(value =>
-        if (refPath.isDefined && refPath.get.equalsIgnoreCase(value))
+        if (refPath.isDefined && refPath.get.equalsIgnoreCase(value)) {
           failure("std-path and ref-path can not be equal")
-        else if (outPath.isDefined && outPath.get.equalsIgnoreCase(value))
+        } else if (outPath.isDefined && outPath.get.equalsIgnoreCase(value)) {
           failure("std-path and out-path can not be equal")
-        else
+        } else {
           success
+        }
       )
 
     opt[String]("ref-path").required.action((value, config) => {
@@ -113,12 +119,13 @@ object CmdConfig {
       config.copy(refPath = value)
     }).text("Path to supposedly correct data set.")
       .validate(value =>
-        if (newPath.isDefined && newPath.get.equalsIgnoreCase(value))
+        if (newPath.isDefined && newPath.get.equalsIgnoreCase(value)) {
           failure("ref-path and std-path can not be equal")
-        else if (outPath.isDefined && outPath.get.equalsIgnoreCase(value))
+        } else if (outPath.isDefined && outPath.get.equalsIgnoreCase(value)) {
           failure("ref-path and out-path can not be equal")
-        else
+        } else {
           success
+        }
       )
 
     opt[String]("out-path").required.action((value, config) => {
@@ -129,12 +136,13 @@ object CmdConfig {
             "two other folders. expected_minus_actual and actual_minus_expected. " +
             "Both hold parque data sets of differences. (minus as in is relative complement")
       .validate(value =>
-        if (newPath.isDefined && newPath.get.equalsIgnoreCase(value))
+        if (newPath.isDefined && newPath.get.equalsIgnoreCase(value)) {
           failure("out-path and std-path can not be equal")
-        else if (refPath.isDefined && refPath.get.equalsIgnoreCase(value))
+        } else if (refPath.isDefined && refPath.get.equalsIgnoreCase(value)) {
           failure("out-path and ref-path can not be equal")
-        else
+        } else {
           success
+        }
       )
 
     opt[String]("keys").action((value, config) => {

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
@@ -25,14 +25,14 @@ object ComparisonJob {
   val log: Logger = LogManager.getLogger("enceladus.testutils.ComparisonJob")
 
   private def renameColumns(dataSet: Dataset[Row], keys: Seq[String], prefix: String): DataFrame = {
-    val renamedColumnsExpected = dataSet.columns.map(c =>
+    val renamedColumns = dataSet.columns.map { c =>
       if (keys.contains(c)) {
         dataSet(c)
       } else {
         dataSet(c).as(s"$prefix$c")
-      })
+      }}
 
-    dataSet.select(renamedColumnsExpected: _*)
+    dataSet.select(renamedColumns: _*)
   }
 
   private def getKeyBasedOutput(expectedMinusActual: Dataset[Row],

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
@@ -26,8 +26,7 @@ object ComparisonJob {
     dataSet.columns.map(c =>
       if (keys.contains(c)) {
         dataSet(c)
-      }
-      else {
+      } else {
         dataSet(c).as(s"$prefix$c")
       })
   }

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
@@ -15,12 +15,14 @@
 
 package za.co.absa.enceladus.testutils.datasetComparison
 
+import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql._
 import za.co.absa.enceladus.testutils.exceptions.{CmpJobDatasetsDifferException, CmpJobSchemasDifferException}
 import za.co.absa.enceladus.testutils.{DataframeReader, DataframeReaderOptions}
 
 object ComparisonJob {
+  val log: Logger = LogManager.getLogger("enceladus.testutils.ComparisonJob")
 
   private def renameColumns(dataSet: Dataset[Row], keys: Seq[String], prefix: String): Array[Column] = {
     dataSet.columns.map(c =>
@@ -84,7 +86,7 @@ object ComparisonJob {
 
       throw CmpJobDatasetsDifferException(cmd.refPath, cmd.newPath, cmd.outPath, expectedDf.count(), actualDf.count())
     } else {
-      println("Expected and actual datasets are the same.")
+      log.info("Expected and actual datasets are the same.")
     }
   }
 }

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
@@ -22,7 +22,7 @@ import za.co.absa.enceladus.testutils.{DataframeReader, DataframeReaderOptions}
 
 object ComparisonJob {
 
-  def renameColumns(dataSet: Dataset[Row], keys: Seq[String], prefix: String): Array[Column] = {
+  private def renameColumns(dataSet: Dataset[Row], keys: Seq[String], prefix: String): Array[Column] = {
     dataSet.columns.map(c =>
       if (keys.contains(c)) {
         dataSet(c)
@@ -32,12 +32,12 @@ object ComparisonJob {
       })
   }
 
-  def getKeyBasedOutput(expectedMinusActual: Dataset[Row],
+  private def getKeyBasedOutput(expectedMinusActual: Dataset[Row],
                         actualMinusExpected: Dataset[Row],
                         keys: Seq[String]): DataFrame = {
-    val renamedColumnsExpected = renameColumns(expectedMinusActual ,keys, "expected_")
+    val renamedColumnsExpected = renameColumns(expectedMinusActual, keys, "expected_")
     val dfNewExpected = expectedMinusActual.select(renamedColumnsExpected: _*)
-    val renamedColumnsActual = renameColumns(actualMinusExpected ,keys, "actual_")
+    val renamedColumnsActual = renameColumns(actualMinusExpected, keys, "actual_")
     val dfNewColumnsActual = actualMinusExpected.select(renamedColumnsActual: _*)
 
     dfNewExpected.join(dfNewColumnsActual, keys,"full")

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
@@ -24,22 +24,22 @@ import za.co.absa.enceladus.testutils.{DataframeReader, DataframeReaderOptions}
 object ComparisonJob {
   val log: Logger = LogManager.getLogger("enceladus.testutils.ComparisonJob")
 
-  private def renameColumns(dataSet: Dataset[Row], keys: Seq[String], prefix: String): Array[Column] = {
-    dataSet.columns.map(c =>
+  private def renameColumns(dataSet: Dataset[Row], keys: Seq[String], prefix: String): DataFrame = {
+    val renamedColumnsExpected = dataSet.columns.map(c =>
       if (keys.contains(c)) {
         dataSet(c)
       } else {
         dataSet(c).as(s"$prefix$c")
       })
+
+    dataSet.select(renamedColumnsExpected: _*)
   }
 
   private def getKeyBasedOutput(expectedMinusActual: Dataset[Row],
                         actualMinusExpected: Dataset[Row],
                         keys: Seq[String]): DataFrame = {
-    val renamedColumnsExpected = renameColumns(expectedMinusActual, keys, "expected_")
-    val dfNewExpected = expectedMinusActual.select(renamedColumnsExpected: _*)
-    val renamedColumnsActual = renameColumns(actualMinusExpected, keys, "actual_")
-    val dfNewColumnsActual = actualMinusExpected.select(renamedColumnsActual: _*)
+    val dfNewExpected = renameColumns(expectedMinusActual, keys, "expected_")
+    val dfNewColumnsActual = renameColumns(actualMinusExpected, keys, "actual_")
 
     dfNewExpected.join(dfNewColumnsActual, keys,"full")
   }

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
@@ -85,7 +85,7 @@ object ComparisonJob {
 
       throw CmpJobDatasetsDifferException(cmd.refPath, cmd.newPath, cmd.outPath, expectedDf.count(), actualDf.count())
     } else {
-      System.out.println("Expected and actual datasets are the same.")
+      println("Expected and actual datasets are the same.")
     }
   }
 }

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/exceptions/CompareJobExceptions.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/exceptions/CompareJobExceptions.scala
@@ -33,7 +33,11 @@ final case class CmpJobSchemasDifferException(private val refPath: String,
                                               private val stdPath: String,
                                               private val diffSchema: Seq[StructField],
                                               private val cause: Throwable = None.orNull)
-  extends Exception("Expected and actual datasets differ in schemas.\n"+
+  extends Exception("Expected and actual datasets differ in schemas.\n" +
                     s"Reference path: $refPath\n" +
                     s"Actual dataset path: $stdPath\n" +
                     s"Difference is $diffSchema", cause)
+
+
+final case class DuplicateRowsInDF(private val path: String)
+  extends Exception(s"Provided dataset has duplicate rows. Specific rows written to $path")

--- a/testutils/src/test/resources/dataSample5.csv
+++ b/testutils/src/test/resources/dataSample5.csv
@@ -1,0 +1,11 @@
+id,first_name,last_name,email,gender,ip_address
+1,Pierette,Sawyer,psawyer0@wunderground.com,Female,117.99.152.18
+2,Jillian,Gorriessen,jgorriessen1@amazonaws.com,Female,48.45.211.100
+3,Ronnie,Meredyth,rmeredyth2@alexa.com,Female,218.245.148.50
+4,Elora,Willox,ewillox3@a8.net,Female,209.240.40.34
+5,Thom,Serraillier,tserraillier4@ibm.com,Male,144.244.50.93
+5,Thom,Serraillier,tserraillier4@ibm.com,Male,144.244.50.93
+6,Megan,Danhel,mdanhel5@sina.com.cn,Female,230.203.255.242
+7,Holly-anne,Whatman,hwhatman6@bluehost.com,Female,195.118.127.141
+8,Hedda,Flips,hflips7@weather.com,Female,117.97.47.64
+9,Heloise,Tims,htims8@amazonaws.com,Female,35.181.204.96

--- a/testutils/src/test/scala/za/co/absa/enceladus/testutils/datasetComparison/ConfigSuite.scala
+++ b/testutils/src/test/scala/za/co/absa/enceladus/testutils/datasetComparison/ConfigSuite.scala
@@ -36,7 +36,8 @@ class ConfigSuite extends FunSuite {
         "--raw-format", parquetFormat,
         "--new-path", newPath,
         "--ref-path", refPath,
-        "--out-path", outPath
+        "--out-path", outPath,
+        "--keys", "id"
       )
     )
 
@@ -44,6 +45,7 @@ class ConfigSuite extends FunSuite {
     assert(cmdConfig.newPath == newPath)
     assert(cmdConfig.refPath == refPath)
     assert(cmdConfig.outPath == outPath)
+    assert(cmdConfig.keys == Some(Seq("id")))
   }
 
   test("Csv with default header") {
@@ -53,7 +55,8 @@ class ConfigSuite extends FunSuite {
         "--delimiter", delimiter,
         "--new-path", newPath,
         "--ref-path", refPath,
-        "--out-path", outPath
+        "--out-path", outPath,
+        "--keys", "id,alfa"
       )
     )
 
@@ -63,6 +66,7 @@ class ConfigSuite extends FunSuite {
     assert(cmdConfig.newPath == newPath)
     assert(cmdConfig.refPath == refPath)
     assert(cmdConfig.outPath == outPath)
+    assert(cmdConfig.keys == Some(Seq("id","alfa")))
   }
 
   test("Csv with header") {


### PR DESCRIPTION
Based on a request from multiple sources.

Now with adding the keys option to the spark submit job, it generates one output `parquet` file with all differences grouped. All columns are renamed with prefixes of `actual_` or `expected_` depending if they are coming from `new-path` or `ref-path` respectively. 