### PR TITLE
139 Turn off scalastyle for tests

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -152,5 +152,5 @@
       <parameter name="ignoreRegex">^""$</parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"/>
+  <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="false"/>
 </scalastyle>


### PR DESCRIPTION
Scalastyle is already off for tests, style warnings are not raised there. You may need to change your IDE code-inspection settings though (these are two separate issues). 
In IntelliJ:
![image](https://user-images.githubusercontent.com/20905867/52120585-061d4780-261d-11e9-959d-1112c036dc1f.png)

