### PR TITLE
#149 Persist conformance rules order

### DIFF
--- a/menas/ui/components/dataset/datasetMain.controller.js
+++ b/menas/ui/components/dataset/datasetMain.controller.js
@@ -97,9 +97,9 @@ sap.ui.controller("components.dataset.datasetMain", {
 
   ruleAddSubmit: function () {
     // if (this.validateNewRule) {
-    let currentDatasetName = this._model.getProperty("/currentDataset/name");
-    let currentRule = this._model.getProperty("/newRule");
-    RuleService.createRule(currentDatasetName, currentRule);
+    let currentDataset = this._model.getProperty("/currentDataset");
+    let newRule = this._model.getProperty("/newRule");
+    RuleService.createRule(currentDataset, newRule);
     // }
     this.ruleAddCancel();
   },

--- a/menas/ui/service/DatasetService.js
+++ b/menas/ui/service/DatasetService.js
@@ -32,7 +32,7 @@ var DatasetService = new function() {
 
     this.getLatestDatasetVersion = function(sId) {
         Functions.ajax("api/dataset/detail/" + encodeURI(sId) + "/latest", "GET", {}, function(oData) {
-          model.setProperty("/currentDataset", oData);
+          DatasetService.setCurrentDataset(oData);
         }, function() {
             sap.m.MessageBox.error("Failed to get the detail of the dataset. Please wait a moment and try reloading the application");
             window.location.hash = "#/dataset"
@@ -98,7 +98,7 @@ var DatasetService = new function() {
         }, function(oData) {
             DatasetService.getDatasetList();
             SchemaService.getSchemaVersion(oData.schemaName, oData.schemaVersion, "/currentDataset/schema");
-            model.setProperty("/currentDataset", oData);
+            DatasetService.setCurrentDataset(oData);
             sap.m.MessageToast.show("Dataset created.");
         }, function() {
             sap.m.MessageBox.error("Failed to create the dataset, try reloading the application or try again later.")
@@ -108,11 +108,17 @@ var DatasetService = new function() {
     this.editDataset = function(oDataset) {
       Functions.ajax("api/dataset/edit", "POST", oDataset, function(oData) {
             DatasetService.getDatasetList();
-            model.setProperty("/currentDataset", oData);
+            DatasetService.setCurrentDataset(oData);
             SchemaService.getSchemaVersion(oData.schemaName, oData.schemaVersion, "/currentDataset/schema");
             sap.m.MessageToast.show("Dataset updated.");
         }, function() {
             sap.m.MessageBox.error("Failed to update the dataset, try reloading the application or try again later.")
         })
     };
+
+  this.setCurrentDataset = function(oDataset) {
+    oDataset.conformance = oDataset.conformance.sort((first, second) => first.order > second.order);
+    model.setProperty("/currentDataset", oDataset);
+  };
+
 }();

--- a/menas/ui/service/RuleService.js
+++ b/menas/ui/service/RuleService.js
@@ -55,7 +55,7 @@ var RuleService = new function () {
     let conformance = oCurrentDataset["conformance"]
       .filter((_, index) => index !== iRuleIndex)
       .sort((first, second) => first.order > second.order)
-      .map((currElement, index) =>  {return {...currElement, order: index}});
+      .map((currElement, index) => {return {...currElement, order: index}});
 
     return {...oCurrentDataset, conformance: conformance};
   };
@@ -80,7 +80,7 @@ var RuleService = new function () {
       delete oRule.joinConditions;
     }
 
-    Functions.ajax("api/dataset/" + oCurrentDataset.name + "/rule/create", "POST", oRule,
+    Functions.ajax("api/dataset/" + encodeURI(oCurrentDataset.name) + "/rule/create", "POST", oRule,
       function (oData) {
       DatasetService.getDatasetList();
       SchemaService.getSchemaVersion(oData.schemaName, oData.schemaVersion, "/currentDataset/schema");


### PR DESCRIPTION
### [#149 Persist conformance rules order](https://github.com/AbsaOSS/enceladus/issues/149)
- Assign correct order number to each conformance rule

### Test plan: 
**1. Run tests:**
- go to enceladus dir
- mvn -DskipTests clean package
- mvn verify
- **Expected result**: All tests should pass

**2. Create/Remove rules:**
- Run application
- Log in 
- Go to Dataset tab 
- Pick one of the datasets (or Create new dataset)
- Go to Conformance Rules
- Create at least 3 rules 
- **Expected result**: Each rule should have correct order number in DB (Create A, Create B, Create C => A.order:0, B.order:1, C.order:2). They should display in correct order.
- Delete middle rule
- **Expected result**: Each rule should have correct order number in DB (Create A, Create B, Create C => A.order:0, B.order:1, C.order:2 => Delete B => A.order:0, C.order:1). They should display in correct order.
- Delete first rule
- **Expected result**: Each rule should have correct order number in DB (Create A, Create B, Create C => A.order:0, B.order:1, C.order:2 => Delete B => A.order:0, C.order:1 => Delete A => C.order:0 ). They should display in correct order.