### PR TITLE
#80 Update conformance rules ui implementation

### DIFF
--- a/menas/ui/components/dataset/conformanceRule/ConcatenationConformanceRule/add.fragment.xml
+++ b/menas/ui/components/dataset/conformanceRule/ConcatenationConformanceRule/add.fragment.xml
@@ -15,9 +15,13 @@
 
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core">
     <core:Fragment type="XML" fragmentName="components.dataset.conformanceRule.add.commonRuleFields"/>
-    <Button id="addInputColumn" icon="sap-icon://add"/>
-    <Label text="Concatenation column"/>
-    <Input type="Text" value="{/newRule/inputColumns/0}"/>
-    <Label text="Concatenation column"/>
-    <Input type="Text" value="{/newRule/inputColumns/1}"/>
+    <Button id="addInputColumn" icon="sap-icon://add" press="onAddInputColumn"/>
+    <Label text="Concatenation columns"/>
+    <List mode="Delete" items="{/newRule/inputColumns}" delete="onDeleteInputColumn">
+        <items>
+            <CustomListItem>
+                    <Input type="Text" value="{}"/>
+            </CustomListItem>
+        </items>
+    </List>
 </core:FragmentDefinition>

--- a/menas/ui/components/dataset/conformanceRule/MappingConformanceRule/joinConditions.fragment.xml
+++ b/menas/ui/components/dataset/conformanceRule/MappingConformanceRule/joinConditions.fragment.xml
@@ -13,14 +13,19 @@
   ~ limitations under the License.
   -->
 
-<core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:form="sap.ui.layout.form" xmlns:l="sap.ui.layout"
-                         xmlns:table="sap.ui.table" xmlns:cust="http://schemas.sap.com/sapui5/extension/sap.ui.core.CustomData/1">
+<core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core">
     <Label text="Data can have Null values in join conditions"/>
     <CheckBox selected="{/newRule/isNullSafe}"/>
-    <Button id="addJoinCondition" icon="sap-icon://add"/>
-    <Label text="Join Condition"/>
-    <HBox justifyContent="SpaceAround">
-        <Input type="Text" value="{/newRule/joinConditions/0/mappingTableField}" placeholder="Mapping Table Column"/>
-        <Input type="Text" value="{/newRule/joinConditions/0/datasetField}" placeholder="Dataset Column"/>
-    </HBox>
+    <Button id="addJoinCondition" icon="sap-icon://add" press="onAddJoinCondition"/>
+    <Label text="Join Conditions"/>
+    <List mode="Delete" items="{/newRule/newJoinConditions}" delete="onDeleteJoinCondition">
+        <items>
+            <CustomListItem>
+                <HBox justifyContent="SpaceAround">
+                    <Input type="Text" value="{mappingTableField}" placeholder="Mapping Table Column"/>
+                    <Input type="Text" value="{datasetField}" placeholder="Dataset Column"/>
+                </HBox>
+            </CustomListItem>
+        </items>
+    </List>
 </core:FragmentDefinition>

--- a/menas/ui/components/dataset/conformanceRule/upsert.controller.js
+++ b/menas/ui/components/dataset/conformanceRule/upsert.controller.js
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+sap.ui.define([
+  "sap/ui/core/mvc/Controller"
+], function (Controller) {
+  return Controller.extend("components.dataset.conformanceRule.upsert", {
+
+    rules: [
+      {_t: "CastingConformanceRule"},
+      {_t: "ConcatenationConformanceRule"},
+      {_t: "DropConformanceRule"},
+      {_t: "LiteralConformanceRule"},
+      {_t: "MappingConformanceRule"},
+      {_t: "NegationConformanceRule"},
+      {_t: "SingleColumnConformanceRule"},
+      {_t: "SparkSessionConfConformanceRule"},
+      {_t: "UppercaseConformanceRule"}
+    ],
+
+    dataTypes: [
+      {type: "boolean"},
+      {type: "byte"},
+      {type: "short"},
+      {type: "integer"},
+      {type: "long"},
+      {type: "float"},
+      {type: "double"},
+      {type: "decimal(38,18)"},
+      {type: "char"},
+      {type: "string"},
+      {type: "date"},
+      {type: "timestamp"}
+    ],
+
+    constructor: function () {
+      this._model = sap.ui.getCore().getModel();
+      this._model.setProperty("/rules", this.rules);
+      this._model.setProperty("/dataTypes", this.dataTypes);
+      this._formFragments = {};
+    },
+
+    onBeforeOpen: function () {
+      this._dialog = sap.ui.getCore().byId("upsertConformanceRuleDialog");
+      this._ruleForm = sap.ui.getCore().byId("ruleForm");
+      MappingTableService.getMappingTableList(true, true);
+      if(this._model.getProperty("/newRule/isEdit")) {
+        this.showFormFragment(this._model.getProperty("/newRule/_t"));
+      } else {
+        this._model.setProperty("/newRule/_t", this.rules[0]._t);
+        this.showFormFragment(this.rules[0]._t);
+      }
+      this._dialog.setEscapeHandler(() => this.onClosePress());
+    },
+
+    onAfterOpen: function () {
+      let schemaFieldSelectorSupportedRules =
+        ["CastingConformanceRule", "NegationConformanceRule", "SingleColumnConformanceRule", "UppercaseConformanceRule"];
+      let newRule = this._model.getProperty("/newRule");
+      if(newRule.isEdit && schemaFieldSelectorSupportedRules.includes(newRule._t))
+        this.preselectSchemaFieldSelector(newRule._t);
+    },
+
+    onClosePress: function () {
+      this.resetRuleForm();
+      this._dialog.close();
+    },
+
+    onRuleSubmit: function () {
+      let currentDataset = this._model.getProperty("/currentDataset");
+      let newRule = JSON.parse(JSON.stringify(this._model.getProperty("/newRule")));
+      this.beforeSubmitChanges(newRule);
+      if(this._model.getProperty("/newRule/isEdit")) {
+        this.updateRule(currentDataset, newRule);
+      } else {
+        this.addRule(currentDataset, newRule);
+      }
+      this.onClosePress();
+    },
+
+    onAddInputColumn: function () {
+      let currentRule = this._model.getProperty("/newRule");
+      let inputColumnSize = currentRule.inputColumns.length;
+      let pathToNewInputColumn = "/newRule/inputColumns/" + inputColumnSize;
+      this._model.setProperty(pathToNewInputColumn, "");
+    },
+
+    onAddJoinCondition: function () {
+      let currentRule = this._model.getProperty("/newRule");
+      let joinConditionsSize = currentRule.newJoinConditions.length;
+      let pathToNewJoinCondition = "/newRule/newJoinConditions/" + joinConditionsSize;
+      this._model.setProperty(pathToNewJoinCondition, {mappingTableField: "", datasetField: ""});
+    },
+
+    onMappingTableSelect: function (oEv) {
+      let sMappingTableId = oEv.getParameter("selectedItem").getKey();
+      MappingTableService.getAllMappingTableVersions(sMappingTableId, sap.ui.getCore().byId("schemaVersionSelect"));
+    },
+
+    onRuleSelect: function () {
+      this.resetRuleForm();
+      this.showFormFragment(this._model.getProperty("/newRule/_t"));
+    },
+
+    onDeleteInputColumn: function (oEv) {
+      let sBindPath = oEv.getParameter("listItem").getBindingContext().getPath();
+      let toks = sBindPath.split("/");
+      let inputColumnIndex = parseInt(toks[toks.length - 1]);
+      let oldInputColumns = this._model.getProperty("/newRule/inputColumns");
+
+      let newInputColumns = oldInputColumns.filter((_, index) => index !== inputColumnIndex);
+      this._model.setProperty("/newRule/inputColumns", newInputColumns);
+    },
+
+    onDeleteJoinCondition: function (oEv) {
+      let sBindPath = oEv.getParameter("listItem").getBindingContext().getPath();
+      let toks = sBindPath.split("/");
+      let inputColumnIndex = parseInt(toks[toks.length - 1]);
+      let oldInputColumns = this._model.getProperty("/newRule/newJoinConditions");
+
+      let newInputColumns = oldInputColumns.filter((_, index) => index !== inputColumnIndex);
+      this._model.setProperty("/newRule/newJoinConditions", newInputColumns);
+    },
+
+    onSchemaFieldSelect: function (oEv) {
+      let bind = oEv.getParameter("listItem").getBindingContext().getPath();
+      let modelPathBase = "/currentDataset/schema/fields/";
+      let model = sap.ui.getCore().getModel();
+      SchemaService.fieldSelect(bind, modelPathBase, model, "/newRule/inputColumn");
+    },
+
+    beforeShowFragmentChanges: function () {
+      let currentRule = this._model.getProperty("/newRule");
+      let newRule = currentRule;
+
+      if (currentRule._t === "ConcatenationConformanceRule" && !currentRule.isEdit) {
+        newRule.inputColumns = ["", ""];
+      }
+
+      if (currentRule._t === "MappingConformanceRule") {
+        if(!currentRule.isEdit){
+          newRule.newJoinConditions = [{mappingTableField: "", datasetField: ""}];
+          newRule.mappingTable = this._model.getProperty("/mappingTables")[0]._id;
+        } else {
+          let oAttributeMappings = newRule.attributeMappings;
+          let aNewJoinConditions = [];
+          for (let key in oAttributeMappings) {
+            aNewJoinConditions.push({
+              mappingTableField: key,
+              datasetField: oAttributeMappings[key]
+            });
+          }
+          newRule.newJoinConditions = aNewJoinConditions;
+        }
+        MappingTableService.getAllMappingTableVersions(newRule.mappingTable, sap.ui.getCore().byId("schemaVersionSelect"));
+      }
+
+      if(!currentRule.isEdit)
+        newRule.order = this._model.getProperty("/currentDataset").conformance.length;
+
+      this._model.setProperty("/newRule", newRule);
+    },
+
+    beforeSubmitChanges: function (newRule) {
+      if (newRule._t === "MappingConformanceRule") {
+        newRule.attributeMappings = {};
+        newRule.newJoinConditions.map(function(joinCondition) {
+          newRule.attributeMappings[joinCondition.mappingTableField] = joinCondition.datasetField
+        });
+        delete newRule.joinConditions;
+      }
+    },
+
+    addRule: function (currentDataset, newRule) {
+      currentDataset.conformance[newRule.order] = newRule;
+      DatasetService.editDataset(currentDataset);
+    },
+
+    updateRule: function (currentDataset, newRule) {
+      currentDataset.conformance[newRule.order] = newRule;
+      DatasetService.editDataset(currentDataset);
+    },
+
+    showFormFragment: function (sFragmentName) {
+      let aFragment = this.getFormFragment(sFragmentName);
+      aFragment.forEach(oElement =>
+        this._ruleForm.addContent(oElement)
+      );
+      this.beforeShowFragmentChanges();
+    },
+
+    getFormFragment: function (sFragmentName) {
+      let oFormFragment = this._formFragments[sFragmentName];
+      if (oFormFragment) {
+        return oFormFragment;
+      }
+
+      oFormFragment = sap.ui.xmlfragment( sFragmentName,"components.dataset.conformanceRule." + sFragmentName + ".add", this);
+      this._formFragments[sFragmentName] = oFormFragment;
+      return this._formFragments[sFragmentName];
+    },
+
+    resetRuleForm: function () {
+      // workaround for "Cannot read property 'setSelectedIndex' of undefined" error
+      const content = this._ruleForm.getContent();
+      content.filter(function (element) {
+        return element.sId.includes("FieldSelectScroll")
+      }).forEach(function (element) {
+        element.getContent().forEach(function (tree) {
+          let items = tree.getItems();
+          for (let i in items) {
+            items[i].setSelected(false);
+            items[i].setHighlight(sap.ui.core.MessageType.None)
+          }
+        })
+      });
+      this._ruleForm.removeAllContent();
+    },
+
+    preselectSchemaFieldSelector: function(ruleType) {
+      let sExpandTo= this._model.getProperty("/newRule/inputColumn");
+      let aTokens = sExpandTo.split(".");
+      let oCtl = sap.ui.getCore().byId(ruleType+"--schemaFieldSelector");
+      let oScr = sap.ui.getCore().byId(ruleType+"--defValFieldSelectScroll");
+      oCtl.collapseAll();
+
+      let _preselectRadioButton = function(aToks, oldSize, lastIndex) {
+        let newItems = oCtl.getItems();
+        let newSize = newItems.length - oldSize;
+        let uniqueItems = newItems.slice(lastIndex+1, lastIndex+newSize+1);
+        let itemToProcess = uniqueItems.find(item => item.getProperty("title") === aToks[0]);
+
+        if(aToks.length === 1){
+          itemToProcess.setSelected(true);
+          let delegate = {
+            onAfterRendering: function() {
+              oScr.scrollToElement(itemToProcess);
+              oCtl.removeEventDelegate(delegate);
+            }.bind(this)
+          };
+          oCtl.addEventDelegate(delegate);
+        } else {
+          let index = newItems.indexOf(itemToProcess);
+          let oldSize = newItems.length;
+          oCtl.expand(index);
+          _preselectRadioButton(aToks.slice(1), oldSize, index);
+        }
+      };
+
+      _preselectRadioButton(aTokens, 0, -1);
+    }
+
+  });
+});

--- a/menas/ui/components/dataset/conformanceRule/upsert.controller.js
+++ b/menas/ui/components/dataset/conformanceRule/upsert.controller.js
@@ -18,15 +18,43 @@ sap.ui.define([
   return Controller.extend("components.dataset.conformanceRule.upsert", {
 
     rules: [
-      {_t: "CastingConformanceRule"},
-      {_t: "ConcatenationConformanceRule"},
-      {_t: "DropConformanceRule"},
-      {_t: "LiteralConformanceRule"},
-      {_t: "MappingConformanceRule"},
-      {_t: "NegationConformanceRule"},
-      {_t: "SingleColumnConformanceRule"},
-      {_t: "SparkSessionConfConformanceRule"},
-      {_t: "UppercaseConformanceRule"}
+      {
+        _t: "CastingConformanceRule",
+        schemaFieldSelectorSupportedRule: true
+      },
+      {
+        _t: "ConcatenationConformanceRule",
+        schemaFieldSelectorSupportedRule: false
+      },
+      {
+        _t: "DropConformanceRule",
+        schemaFieldSelectorSupportedRule: false
+      },
+      {
+        _t: "LiteralConformanceRule",
+        schemaFieldSelectorSupportedRule: false
+      },
+      {
+        _t: "MappingConformanceRule",
+        schemaFieldSelectorSupportedRule: false
+      },
+      {
+        _t: "NegationConformanceRule",
+        schemaFieldSelectorSupportedRule: true
+
+      },
+      {
+        _t: "SingleColumnConformanceRule",
+        schemaFieldSelectorSupportedRule: true
+      },
+      {
+        _t: "SparkSessionConfConformanceRule",
+        schemaFieldSelectorSupportedRule: false
+      },
+      {
+        _t: "UppercaseConformanceRule",
+        schemaFieldSelectorSupportedRule: true
+      }
     ],
 
     dataTypes: [
@@ -66,7 +94,7 @@ sap.ui.define([
 
     onAfterOpen: function () {
       let schemaFieldSelectorSupportedRules =
-        ["CastingConformanceRule", "NegationConformanceRule", "SingleColumnConformanceRule", "UppercaseConformanceRule"];
+        this.rules.filter(rule => rule.schemaFieldSelectorSupportedRule).map(rule => rule._t);
       let newRule = this._model.getProperty("/newRule");
       if(newRule.isEdit && schemaFieldSelectorSupportedRules.includes(newRule._t))
         this.preselectSchemaFieldSelector(newRule._t);
@@ -166,8 +194,9 @@ sap.ui.define([
         MappingTableService.getAllMappingTableVersions(newRule.mappingTable, sap.ui.getCore().byId("schemaVersionSelect"));
       }
 
-      if(!currentRule.isEdit)
+      if(!currentRule.isEdit) {
         newRule.order = this._model.getProperty("/currentDataset").conformance.length;
+      }
 
       this._model.setProperty("/newRule", newRule);
     },
@@ -183,8 +212,7 @@ sap.ui.define([
     },
 
     addRule: function (currentDataset, newRule) {
-      currentDataset.conformance[newRule.order] = newRule;
-      DatasetService.editDataset(currentDataset);
+      this.updateRule(currentDataset, newRule)
     },
 
     updateRule: function (currentDataset, newRule) {
@@ -206,7 +234,7 @@ sap.ui.define([
         return oFormFragment;
       }
 
-      oFormFragment = sap.ui.xmlfragment( sFragmentName,"components.dataset.conformanceRule." + sFragmentName + ".add", this);
+      oFormFragment = sap.ui.xmlfragment(sFragmentName, "components.dataset.conformanceRule." + sFragmentName + ".add", this);
       this._formFragments[sFragmentName] = oFormFragment;
       return this._formFragments[sFragmentName];
     },
@@ -231,8 +259,8 @@ sap.ui.define([
     preselectSchemaFieldSelector: function(ruleType) {
       let sExpandTo= this._model.getProperty("/newRule/inputColumn");
       let aTokens = sExpandTo.split(".");
-      let oCtl = sap.ui.getCore().byId(ruleType+"--schemaFieldSelector");
-      let oScr = sap.ui.getCore().byId(ruleType+"--defValFieldSelectScroll");
+      let oCtl = sap.ui.getCore().byId(ruleType + "--schemaFieldSelector");
+      let oScr = sap.ui.getCore().byId(ruleType + "--defValFieldSelectScroll");
       oCtl.collapseAll();
 
       let _preselectRadioButton = function(aToks, oldSize, lastIndex) {

--- a/menas/ui/components/dataset/conformanceRule/upsert.fragment.xml
+++ b/menas/ui/components/dataset/conformanceRule/upsert.fragment.xml
@@ -13,15 +13,15 @@
   ~ limitations under the License.
   -->
 
-<core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:form="sap.ui.layout.form" xmlns:l="sap.ui.layout"
-                         xmlns:table="sap.ui.table" xmlns:cust="http://schemas.sap.com/sapui5/extension/sap.ui.core.CustomData/1">
-    <Dialog id="addConformanceRuleDialog" title="{/newRule/title} Conformance Rule" resizable="true" draggable="true" class="minW40rem">
+<core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:form="sap.ui.layout.form">
+    <Dialog id="upsertConformanceRuleDialog" title="{/newRule/title} Conformance Rule" resizable="true"
+            draggable="true" class="minW40rem" beforeOpen="onBeforeOpen" afterOpen="onAfterOpen">
         <content>
             <form:SimpleForm id="addConformanceRuleForm" adjustLabelSpan="false" editable="true">
                 <form:content>
                     <Label text="Conformance Rule"/>
                     <Select id="newRuleSelect" showSecondaryValues="false" items="{/rules}"
-                            selectedKey="{/newRule/_t}">
+                            selectedKey="{/newRule/_t}" change="onRuleSelect" enabled="{=!${/newRule/isEdit}}">
                         <items>
                             <core:Item key="{_t}" text="{_t}" />
                         </items>
@@ -34,8 +34,8 @@
             </form:SimpleForm>
         </content>
         <buttons>
-            <Button id="newRuleAddButton" text="Save" icon="sap-icon://save"></Button>
-            <Button id="newRuleCancelButton" text="Cancel" icon="sap-icon://cancel"></Button>
+            <Button id="newRuleAddButton" text="Save" icon="sap-icon://save" press="onRuleSubmit"></Button>
+            <Button id="newRuleCancelButton" text="Cancel" icon="sap-icon://cancel" press="onClosePress"></Button>
         </buttons>
     </Dialog>
 </core:FragmentDefinition>

--- a/menas/ui/components/mappingTable/mappingTableMain.controller.js
+++ b/menas/ui/components/mappingTable/mappingTableMain.controller.js
@@ -110,7 +110,7 @@ sap.ui.controller("components.mappingTable.mappingTableMain", {
     return isOk;
   },
 
-  schemaFieldSelect : function(oEv) {
+  onSchemaFieldSelect : function(oEv) {
     let bind = oEv.getParameter("listItem").getBindingContext().getPath();
     let modelPathBase = "/currentMappingTable/schema/fields/";
     let model = sap.ui.getCore().getModel();

--- a/menas/ui/components/mappingTableSelector.fragment.xml
+++ b/menas/ui/components/mappingTableSelector.fragment.xml
@@ -16,7 +16,7 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core">
     <Label text="Mapping Table Name"/>
     <Select id="mappingTableNameSelect" showSecondaryValues="true" items="{/mappingTables}"
-            selectedKey="{/newRule/mappingTable}">
+            selectedKey="{/newRule/mappingTable}" change="onMappingTableSelect">
         <core:ListItem key="{_id}" text="{_id}" additionalText="Latest version: {latestVersion}"/>
     </Select>
     <Label text="Mapping Table Version"/>

--- a/menas/ui/components/schemaFieldSelector.fragment.xml
+++ b/menas/ui/components/schemaFieldSelector.fragment.xml
@@ -17,9 +17,9 @@
                          xmlns:cust="http://schemas.sap.com/sapui5/extension/sap.ui.core.CustomData/1">
     <ScrollContainer id="defValFieldSelectScroll" height="300px" vertical="true" horizontal="true" width="100%">
         <Tree id="schemaFieldSelector" mode="SingleSelect" enableBusyIndicator="true"
-              selectionChange="schemaFieldSelect"
+              selectionChange="onSchemaFieldSelect"
               items="{path: 'schema/fields', parameters:{arrayNames:['children']}}">
-            <StandardTreeItem title="{name}" type="active" cust:path="{path}"></StandardTreeItem>
+            <StandardTreeItem title="{name}" type="active" cust:path="{path}"/>
         </Tree>
     </ScrollContainer>
 </core:FragmentDefinition>

--- a/menas/ui/service/MappingTableService.js
+++ b/menas/ui/service/MappingTableService.js
@@ -20,7 +20,7 @@ var MappingTableService = new function () {
 
   this.getMappingTableList = function (bLoadFirst, bGetSchema) {
     Functions.ajax("api/mappingTable/list", "GET", {}, function (oData) {
-      model.setProperty("/mappingTables", oData)
+      model.setProperty("/mappingTables", oData);
       if (oData.length > 0 && bLoadFirst)
         MappingTableService.getMappingTableVersion(oData[0]._id, oData[0].latestVersion, bGetSchema)
     }, function () {

--- a/menas/ui/service/RuleService.js
+++ b/menas/ui/service/RuleService.js
@@ -70,16 +70,6 @@ var RuleService = new function () {
   };
 
   this.createRule = function (oCurrentDataset, oRule) {
-    oRule.order = oCurrentDataset.conformance.length;
-
-    if (oRule._t === "MappingConformanceRule") {
-      oRule.attributeMappings = {};
-      oRule.joinConditions.map(function(joinCondition) {
-        oRule.attributeMappings[joinCondition.mappingTableField] = joinCondition.datasetField
-      });
-      delete oRule.joinConditions;
-    }
-
     Functions.ajax("api/dataset/" + encodeURI(oCurrentDataset.name) + "/rule/create", "POST", oRule,
       function (oData) {
       DatasetService.getDatasetList();


### PR DESCRIPTION
### [#80 Update conformance rules ui implementation](https://github.com/absaoss/enceladus/issues/80)
Be gentle! :D 
### Changes: 
- Update conformance rules ui implementation (New feature)
- A lot of small fixes and refactorings:
  - Update/Create conformance rules code moved to fragment's controller
  - ConcatenationConformanceRule and MappingConformanceRule fragment redesigne
    - List is used instead of in code generated fragment parts
    - New button with remove input fields functionality
  - Removed rule specific logic from RuleService
  - Others ...

### Test plan: 
**1. Run tests:**
- go to enceladus dir
- mvn -DskipTests clean package
- mvn verify
- **Expected result**: All tests should pass

**2. Create rule for each rule type:**
- Run application
- Log in 
- Go to Dataset tab 
- Pick one of the datasets (or Create new dataset)
- Go to Conformance Rules
- Create rule 
- **Expected result**: 
  - Rule should be created/displayed with correct values. 

**2. Update rule (Test with each rule type):**
- Run application
- Log in 
- Go to Dataset tab 
- Pick one of the datasets (or Create new dataset)
- Go to Conformance Rules
- Click on update conformance rule button
- **Expected result**: 
  - Update fragment should be loaded with current values
  - Rule type select should be disabled
- Save changes
- **Expected result**: 
  - Rule should be updated/displayed with correct values. 