### PR TITLE
207 Fix conformance deserialization issue

### DIFF
--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -34,11 +34,6 @@
         </dependency>
         <dependency>
             <groupId>za.co.absa</groupId>
-            <artifactId>enceladus-dataModel</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>za.co.absa</groupId>
             <artifactId>enceladus-utils</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
The issue stems from the fact that the `enceladus-dataModel` dependency in the conformance job should be transitive from the `enceladus-dao` dependency. `enceladus-dao` shades the jackson library in order to comply with Spring's jackson version without conflicting with Spark's jackson version. When the `enceladus-dataModel` dependency is explicitly present, the jackson annotations  on the models are unshaded and the shaded `enceldaus-dao` jackson does not recognize them, hence fails to deserialize. 