### PR TITLE
#215 Make Standardization and Conformance build fail if there is no application.conf

### DIFF
--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -129,6 +129,35 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven.enforcer.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-app-properties-exist</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireFilesExist>
+                                    <files>
+                                        <file>${project.basedir}/src/main/resources/application.conf</file>
+                                    </files>
+                                    <level>ERROR</level>
+                                    <message>/src/main/resources/application.conf not found.
+To build Conformance module it is required to have 'application.conf' in the resources directory.
+Please, copy the template file 'application.conf.template' into 'application.conf' and make changes
+corresponding to your use case.
+                                    </message>
+                                </requireFilesExist>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -258,6 +258,35 @@
                     <useDefaultDelimiters>false</useDefaultDelimiters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven.enforcer.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-app-properties-exist</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireFilesExist>
+                                    <files>
+                                        <file>${project.basedir}/src/main/resources/application.properties</file>
+                                    </files>
+                                    <level>ERROR</level>
+                                    <message>/src/main/resources/application.properties not found.
+To build Menas it is required to have 'application.properties' in the resources directory.
+Please, copy the template file 'application.properties.template' into 'application.properties' and make changes
+corresponding to your use case.
+                                    </message>
+                                </requireFilesExist>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <maven.scala.version>3.2.0</maven.scala.version>
         <maven.shade.version>2.3</maven.shade.version>
         <maven.war.version>2.2</maven.war.version>
+        <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
         <!--dependency versions-->
         <atum.version>0.1.3</atum.version>
         <junit.version>4.11</junit.version>

--- a/standardization/pom.xml
+++ b/standardization/pom.xml
@@ -145,6 +145,35 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven.enforcer.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-app-properties-exist</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireFilesExist>
+                                    <files>
+                                        <file>${project.basedir}/src/main/resources/application.conf</file>
+                                    </files>
+                                    <level>ERROR</level>
+                                    <message>/src/main/resources/application.conf not found.
+To build Standardization module it is required to have 'application.conf' in the resources directory.
+Please, copy the template file 'application.conf.template' into 'application.conf' and make changes
+corresponding to your use case.
+                                    </message>
+                                </requireFilesExist>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
This makes build fail if there are no 'application.conf' inside Standardization and Conformance resources folder.

This is likely to require changes on Jenkins side.