### PR TITLE
#233 Fix Spline initialization

### DIFF
--- a/dataModel/pom.xml
+++ b/dataModel/pom.xml
@@ -38,11 +38,6 @@
             <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.mongodb.scala</groupId>
-            <artifactId>mongo-scala-driver_${scala.compat.version}</artifactId>
-            <version>${mongo.scala.driver.version}</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
There was a superfluous `mongo-scala-driver` dependency in the `dataModel` module, which conflicted with the `mongo-java-driver` used by spline.
Many thanks to @wajda and @yruslan for the help in figuring this out!