### PR TITLE
#256 Replace maven enforcer with antrun copy task

### DIFF
--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -140,6 +140,7 @@
                         <configuration>
                             <target>
                                 <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" overwrite="false" />
+                                <copy file="${project.basedir}/src/main/resources/spline.properties.template" tofile="${project.basedir}/src/main/resources/spline.properties" overwrite="false" />                                
                             </target>
                         </configuration>
                         <goals>

--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -139,9 +139,8 @@
                         <phase>validate</phase>
                         <configuration>
                             <target>
-                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" failonerror="false" overwrite="false" />
+                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" overwrite="false" />
                             </target>
-                            <failOnError>false</failOnError>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -131,30 +131,21 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven.enforcer.version}</version>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven.ant.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>enforce-app-properties-exist</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
+                        <id>copy</id>
+                        <phase>validate</phase>
                         <configuration>
-                            <rules>
-                                <requireFilesExist>
-                                    <files>
-                                        <file>${project.basedir}/src/main/resources/application.conf</file>
-                                    </files>
-                                    <level>ERROR</level>
-                                    <message>/src/main/resources/application.conf not found.
-To build Conformance module it is required to have 'application.conf' in the resources directory.
-Please, copy the template file 'application.conf.template' into 'application.conf' and make changes
-corresponding to your use case.
-                                    </message>
-                                </requireFilesExist>
-                            </rules>
-                            <fail>true</fail>
+                            <target>
+                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" failonerror="false" overwrite="false" />
+                            </target>
+                            <failOnError>false</failOnError>
                         </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -268,9 +268,8 @@
                         <phase>validate</phase>
                         <configuration>
                             <target>
-                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" failonerror="false" overwrite="false" />
+                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" overwrite="false" />
                             </target>
-                            <failOnError>false</failOnError>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -260,30 +260,21 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven.enforcer.version}</version>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven.ant.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>enforce-app-properties-exist</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
+                        <id>copy</id>
+                        <phase>validate</phase>
                         <configuration>
-                            <rules>
-                                <requireFilesExist>
-                                    <files>
-                                        <file>${project.basedir}/src/main/resources/application.properties</file>
-                                    </files>
-                                    <level>ERROR</level>
-                                    <message>/src/main/resources/application.properties not found.
-To build Menas it is required to have 'application.properties' in the resources directory.
-Please, copy the template file 'application.properties.template' into 'application.properties' and make changes
-corresponding to your use case.
-                                    </message>
-                                </requireFilesExist>
-                            </rules>
-                            <fail>true</fail>
+                            <target>
+                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" failonerror="false" overwrite="false" />
+                            </target>
+                            <failOnError>false</failOnError>
                         </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -268,7 +268,7 @@
                         <phase>validate</phase>
                         <configuration>
                             <target>
-                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" overwrite="false" />
+                                <copy file="${project.basedir}/src/main/resources/application.properties.template" tofile="${project.basedir}/src/main/resources/application.properties" overwrite="false" />
                             </target>
                         </configuration>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <maven.scala.version>3.2.0</maven.scala.version>
         <maven.shade.version>2.3</maven.shade.version>
         <maven.war.version>2.2</maven.war.version>
-        <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
         <maven.ant.plugin.version>1.8</maven.ant.plugin.version>
         <!--dependency versions-->
         <atum.version>0.1.3</atum.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <maven.shade.version>2.3</maven.shade.version>
         <maven.war.version>2.2</maven.war.version>
         <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
+        <maven.ant.plugin.version>1.8</maven.ant.plugin.version>
         <!--dependency versions-->
         <atum.version>0.1.3</atum.version>
         <junit.version>4.11</junit.version>

--- a/standardization/pom.xml
+++ b/standardization/pom.xml
@@ -155,9 +155,8 @@
                         <phase>validate</phase>
                         <configuration>
                             <target>
-                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" failonerror="false" overwrite="false" />
+                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" overwrite="false" />
                             </target>
-                            <failOnError>false</failOnError>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/standardization/pom.xml
+++ b/standardization/pom.xml
@@ -147,30 +147,21 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven.enforcer.version}</version>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven.ant.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>enforce-app-properties-exist</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
+                        <id>copy</id>
+                        <phase>validate</phase>
                         <configuration>
-                            <rules>
-                                <requireFilesExist>
-                                    <files>
-                                        <file>${project.basedir}/src/main/resources/application.conf</file>
-                                    </files>
-                                    <level>ERROR</level>
-                                    <message>/src/main/resources/application.conf not found.
-To build Standardization module it is required to have 'application.conf' in the resources directory.
-Please, copy the template file 'application.conf.template' into 'application.conf' and make changes
-corresponding to your use case.
-                                    </message>
-                                </requireFilesExist>
-                            </rules>
-                            <fail>true</fail>
+                            <target>
+                                <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" failonerror="false" overwrite="false" />
+                            </target>
+                            <failOnError>false</failOnError>
                         </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/standardization/pom.xml
+++ b/standardization/pom.xml
@@ -156,6 +156,7 @@
                         <configuration>
                             <target>
                                 <copy file="${project.basedir}/src/main/resources/application.conf.template" tofile="${project.basedir}/src/main/resources/application.conf" overwrite="false" />
+                                <copy file="${project.basedir}/src/main/resources/spline.properties.template" tofile="${project.basedir}/src/main/resources/spline.properties" overwrite="false" />
                             </target>
                         </configuration>
                         <goals>


### PR DESCRIPTION
Let's replace the enforcer plugin, which fails the build if the
application.conf is missing from the main resources.

Rather let's materialize the template on the first build, which
will provide reasonable defaults without necessary providing
custom configs while preserving existing files.

This means that people should be able to clone and build the
project (incl tests) out of the box.

Signed-off-by: Jan Scherbaum <kmoj02@gmail.com>