### PR TITLE
#261 Removed prepare step in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,11 +22,6 @@ pipeline {
         timestamps()
     }
     stages {
-        stage ('Prepare') {
-            steps {
-                enceladusCreateConfigurationFiles()
-            }
-        }
         stage ('Build') {
             steps {
                 configFileProvider([configFile(fileId: "${mavenSettingsId}", variable: 'MAVEN_SETTINGS_XML')]) {


### PR DESCRIPTION
As there has been an update to automatically moved .template files, the prepare step is no longer needed as it just calls a function which has the same behaviour.