### PR TITLE
#11 View updates even from canceled edit window

### DIFF
--- a/menas/ui/components/dataset/conformanceRule/upsert.controller.js
+++ b/menas/ui/components/dataset/conformanceRule/upsert.controller.js
@@ -107,7 +107,7 @@ sap.ui.define([
 
     onRuleSubmit: function () {
       let currentDataset = this._model.getProperty("/currentDataset");
-      let newRule = JSON.parse(JSON.stringify(this._model.getProperty("/newRule")));
+      let newRule = $.extend(true, {}, this._model.getProperty("/newRule"));
       this.beforeSubmitChanges(newRule);
       if(this._model.getProperty("/newRule/isEdit")) {
         this.updateRule(currentDataset, newRule);

--- a/menas/ui/components/dataset/datasetMain.controller.js
+++ b/menas/ui/components/dataset/datasetMain.controller.js
@@ -64,7 +64,7 @@ sap.ui.controller("components.dataset.datasetMain", {
       let old = this._model.getProperty(sBindPath);
       this.fetchSchema();
       this._model.setProperty("/newRule", {
-        ...JSON.parse(JSON.stringify(old)),
+        ...$.extend(true, {}, old),
         title: "Edit",
         isEdit: true,
       });

--- a/menas/ui/components/dataset/datasetMain.controller.js
+++ b/menas/ui/components/dataset/datasetMain.controller.js
@@ -205,7 +205,7 @@ sap.ui.controller("components.dataset.datasetMain", {
     current.isEdit = true;
     current.title = "Edit";
 
-    this._addDialog.setModel(new sap.ui.model.json.JSONModel(current), "entity");
+    this._addDialog.setModel(new sap.ui.model.json.JSONModel(jQuery.extend(true, {}, current)), "entity");
 
     SchemaService.getAllSchemaVersions(current.schemaName, sap.ui.getCore().byId("schemaVersionSelect"));
 

--- a/menas/ui/components/mappingTable/mappingTableMain.controller.js
+++ b/menas/ui/components/mappingTable/mappingTableMain.controller.js
@@ -314,7 +314,7 @@ sap.ui.controller("components.mappingTable.mappingTableMain", {
     current.isEdit = true;
     current.title = "Edit";
 
-    this._model.setProperty("/newMappingTable", current);
+    this._model.setProperty("/newMappingTable", jQuery.extend(true, {}, current));
 
     SchemaService.getAllSchemaVersions(current.schemaName, sap.ui.getCore().byId("newMappingTableSchemaVersionSelect"))
 

--- a/menas/ui/components/schema/schemaMain.controller.js
+++ b/menas/ui/components/schema/schemaMain.controller.js
@@ -55,7 +55,8 @@ sap.ui.controller("components.schema.schemaMain", {
   },
 
   onEditPress: function() {
-    this._model.setProperty("/newSchema", this._model.getProperty("/currentSchema"));
+    //here perform deep copy of the object, otherwise 2 ways binding will update the referenced path
+    this._model.setProperty("/newSchema", jQuery.extend(true, {}, this._model.getProperty("/currentSchema")));
     this._editDialog.open();
   },
 


### PR DESCRIPTION
Perform deep copy of the current entity objects to ensure
that two-way binding doesn't affect the un-saved changes.