### PR TITLE
#186: Epoch standardisation doesn't pass with pattern "epoch"

### DIFF
--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -27,38 +27,38 @@
         <version>0.99.0-SNAPSHOT</version>
     </parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.github.scopt</groupId>
-			<artifactId>scopt_${scala.compat.version}</artifactId>
-			<version>${scopt.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>za.co.absa</groupId>
-			<artifactId>enceladus-utils</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.lihaoyi</groupId>
-			<artifactId>requests_${scala.compat.version}</artifactId>
-			<version>${requests.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.lihaoyi</groupId>
-			<artifactId>ujson_${scala.compat.version}</artifactId>
-			<version>${ujson.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.gnieh</groupId>
-			<artifactId>diffson_${scala.compat.version}</artifactId>
-			<version>${diffson.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.spray</groupId>
-			<artifactId>spray-json_${scala.compat.version}</artifactId>
-			<version>${spray.json.version}</version>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>com.github.scopt</groupId>
+            <artifactId>scopt_${scala.compat.version}</artifactId>
+            <version>${scopt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>za.co.absa</groupId>
+            <artifactId>enceladus-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.lihaoyi</groupId>
+            <artifactId>requests_${scala.compat.version}</artifactId>
+            <version>${requests.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.lihaoyi</groupId>
+            <artifactId>ujson_${scala.compat.version}</artifactId>
+            <version>${ujson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gnieh</groupId>
+            <artifactId>diffson_${scala.compat.version}</artifactId>
+            <version>${diffson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.spray</groupId>
+            <artifactId>spray-json_${scala.compat.version}</artifactId>
+            <version>${spray.json.version}</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <sourceDirectory>src/main/scala</sourceDirectory>

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/EnceladusDateParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/EnceladusDateParser.scala
@@ -26,7 +26,6 @@ import java.time.format.DateTimeFormatter
   * @param pattern  the formatting string, in case it's an epoch format the values wil need to be convertible to Long
   */
 case class EnceladusDateParser(pattern: Format) {
-  //TODO use Option.when with Scala 2.13
   private val formatter: Option[SimpleDateFormat] = if (pattern.isEpoch) {
     None
   } else {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/EnceladusDateParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/EnceladusDateParser.scala
@@ -18,6 +18,7 @@ package za.co.absa.enceladus.utils.types
 import java.text.SimpleDateFormat
 import java.sql.Date
 import java.sql.Timestamp
+import java.time.format.DateTimeFormatter
 
 /**
   * Enables to parse string to date and timestamp based on the provided format
@@ -25,14 +26,17 @@ import java.sql.Timestamp
   * @param pattern  the formatting string, in case it's an epoch format the values wil need to be convertible to Long
   */
 case class EnceladusDateParser(pattern: Format) {
-  private val simpleDateFormat: Option[SimpleDateFormat] = if (pattern.isEpoch) {
+  //TODO use Option.when with Scala 2.13
+  private val formatter: Option[SimpleDateFormat] = if (pattern.isEpoch) {
     None
   } else {
     Some(new SimpleDateFormat(pattern))
   }
 
   private def convertValue(value: String): Long = {
-    simpleDateFormat.map(_.parse(value).getTime).getOrElse(value.toLong * (1000 / pattern.epochFactor))
+    formatter.map(_.parse(value).getTime).getOrElse(
+      value.toLong * pattern.epochMilliFactor
+    )
   }
 
   def parseDate(dateValue: String): Date = {
@@ -41,6 +45,12 @@ case class EnceladusDateParser(pattern: Format) {
 
   def parseTimestamp(timestampValue: String): Timestamp = {
     new Timestamp(convertValue(timestampValue))
+  }
+
+  def format(time: java.util.Date): String = {
+    formatter.map(_.format(time)).getOrElse(
+      (time.getTime / pattern.epochMilliFactor).toString
+    )
   }
 }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/Format.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/Format.scala
@@ -38,9 +38,15 @@ class Format(val pattern: Option[String], val forType: Option[DataType] = None){
   def epochFactor: Long = {
     Format.epochFactor(get)
   }
+
+  def epochMilliFactor: Long = {
+    Format.epochMilliFactor(get)
+  }
 }
 
 object Format {
+  private val thousand = 1000
+
   def apply(structField: StructField ): Format = {
     val formatString: Option[String] = Try(structField.metadata.getString("pattern")).toOption
     val dataType: DataType = structField.dataType
@@ -61,7 +67,15 @@ object Format {
   def epochFactor(format: String): Long = {
     format.toLowerCase match {
       case "epoch"      => 1
-      case "milliepoch" => 1000
+      case "milliepoch" => thousand
+      case _            => throw new InvalidParameterException(s"'$format' is not an epoch format")
+    }
+  }
+
+  def epochMilliFactor(format: String): Long = {
+    format.toLowerCase match {
+      case "epoch"      => thousand
+      case "milliepoch" => 1
       case _            => throw new InvalidParameterException(s"'$format' is not an epoch format")
     }
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/Format.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/Format.scala
@@ -45,7 +45,8 @@ class Format(val pattern: Option[String], val forType: Option[DataType] = None){
 }
 
 object Format {
-  private val thousand = 1000
+  private val epochUnitFactor = 1
+  private val epochThousandFactor = 1000
 
   def apply(structField: StructField ): Format = {
     val formatString: Option[String] = Try(structField.metadata.getString("pattern")).toOption
@@ -66,16 +67,16 @@ object Format {
 
   def epochFactor(format: String): Long = {
     format.toLowerCase match {
-      case "epoch"      => 1
-      case "milliepoch" => thousand
+      case "epoch"      => epochUnitFactor
+      case "milliepoch" => epochThousandFactor
       case _            => throw new InvalidParameterException(s"'$format' is not an epoch format")
     }
   }
 
   def epochMilliFactor(format: String): Long = {
     format.toLowerCase match {
-      case "epoch"      => thousand
-      case "milliepoch" => 1
+      case "epoch"      => epochThousandFactor
+      case "milliepoch" => epochUnitFactor
       case _            => throw new InvalidParameterException(s"'$format' is not an epoch format")
     }
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/DateTimeValidators.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/DateTimeValidators.scala
@@ -17,6 +17,9 @@ package za.co.absa.enceladus.utils.validation
 
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
+import java.sql.Timestamp
+
+import za.co.absa.enceladus.utils.types.EnceladusDateParser
 
 import scala.util.control.NonFatal
 
@@ -26,8 +29,7 @@ import scala.util.control.NonFatal
 object DateTimeValidators {
 
   // This is an example date that can be used for checking pattern conversion
-  private val exampleDate: ZonedDateTime = Instant.ofEpochMilli(1511864185000L)
-    .atZone(ZoneOffset.UTC)
+  private val exampleDate: Timestamp = new Timestamp(System.currentTimeMillis)
 
   /**
     * Checks if date/time pattern is valid and can be used, i.e., using it does not raise an exception.
@@ -40,11 +42,11 @@ object DateTimeValidators {
   def isDateTimePatternValid(pattern: String, default: Option[String] = None): Option[ValidationIssue] ={
     try {
       // Checking pattern syntax
-      val dateFormat = DateTimeFormatter.ofPattern(pattern)
+      val parser = EnceladusDateParser(pattern)
       // Checking pattern's ability to be used in formatting date/time values
-      dateFormat.format(exampleDate)
+      parser.format(exampleDate)
       // Checking default value correctness
-      default.map( dateFormat.parse(_) )
+      default.map( parser.parseDate )
       // Success
       None
     }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/EnceladusDateParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/EnceladusDateParserSuite.scala
@@ -28,7 +28,7 @@ class EnceladusDateParserSuite extends FunSuite{
   test("EnceladusDateParser class epoch") {
     val parser: EnceladusDateParser = EnceladusDateParser("epoch")
 
-    val value: String = "1547553153";
+    val value: String = "1547553153"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = new Date(119, 0, 15) //2019-01-19
     assert(resultDate.toString == expectedDate.toString)
@@ -41,7 +41,7 @@ class EnceladusDateParserSuite extends FunSuite{
   test("EnceladusDateParser class milliepoch") {
     val parser: EnceladusDateParser = EnceladusDateParser("milliepoch")
 
-    val value: String = "1547553153198";
+    val value: String = "1547553153198"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = new Date(119, 0, 15) //2019-01-19
     assert(resultDate.toString == expectedDate.toString)
@@ -51,10 +51,10 @@ class EnceladusDateParserSuite extends FunSuite{
     assert(resultTimestamp.toString == expectedTimestamp.toString)
   }
 
-  test("EnceladusDateParser class actual patter") {
+  test("EnceladusDateParser class actual pattern") {
     val parser: EnceladusDateParser = EnceladusDateParser("yyyy_MM_dd:HH.mm.ss")
 
-    val value: String = "2019_01_15:11.52.33";
+    val value: String = "2019_01_15:11.52.33"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = new Date(119, 0, 15) //2019-01-19
     assert(resultDate.toString == expectedDate.toString)
@@ -63,4 +63,15 @@ class EnceladusDateParserSuite extends FunSuite{
     val expectedTimestamp: Timestamp = new Timestamp(119, 0, 15, 11,52 , 33, 0 ) //2019-01-19 11:52:33
     assert(resultTimestamp.toString == expectedTimestamp.toString)
   }
+
+  test("format") {
+    val t = new Timestamp(70, 0, 2, 1, 0, 0, 0) //25 hours to epoch
+    val parser1 = EnceladusDateParser("yyyy-MM-dd HH:mm:ss")
+    assert(parser1.format(t) == "1970-01-02 01:00:00")
+    val parser2 = EnceladusDateParser("epoch")
+    assert(parser2.format(t) == "90000")
+    val parser3 = EnceladusDateParser("milliepoch")
+    assert(parser3.format(t) == "90000000")
+  }
+
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/FormatSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/FormatSuite.scala
@@ -33,6 +33,10 @@ class FormatSuite extends FunSuite {
       Format.epochFactor(format)
     }
     assert(caught.getMessage == expectedMessage)
+    val caught2 = intercept[InvalidParameterException] {
+      Format.epochMilliFactor(format)
+    }
+    assert(caught2.getMessage == expectedMessage)
   }
 
 
@@ -48,6 +52,10 @@ class FormatSuite extends FunSuite {
       Format.epochFactor(format)
     }
     assert(caught.getMessage == expectedMessage)
+    val caught2 = intercept[InvalidParameterException] {
+      Format.epochMilliFactor(format)
+    }
+    assert(caught2.getMessage == expectedMessage)
   }
 
   test("Format class with default value - timestamp") {
@@ -61,6 +69,10 @@ class FormatSuite extends FunSuite {
       Format.epochFactor(format)
     }
     assert(caught.getMessage == expectedMessage)
+    val caught2 = intercept[InvalidParameterException] {
+      Format.epochMilliFactor(format)
+    }
+    assert(caught2.getMessage == expectedMessage)
   }
 
   test("Format class with default value - date") {
@@ -74,6 +86,10 @@ class FormatSuite extends FunSuite {
       Format.epochFactor(format)
     }
     assert(caught.getMessage == expectedMessage)
+    val caught2 = intercept[InvalidParameterException] {
+      Format.epochMilliFactor(format)
+    }
+    assert(caught2.getMessage == expectedMessage)
   }
 
   test("Format class with default value - double") {
@@ -107,13 +123,21 @@ class FormatSuite extends FunSuite {
   test("Format.epochFactor returns expected values.") {
     val result1 = Format.epochFactor("Epoch")
     assert(result1 == 1L)
-    val result1000 = Format.epochFactor("mIlLiEpOcH")
-    assert(result1000 == 1000L)
+    val result2 = Format.epochFactor("mIlLiEpOcH")
+    assert(result2 == 1000L)
+    val result3 = Format.epochMilliFactor("Epoch")
+    assert(result3 == 1000L)
+    val result4 = Format.epochMilliFactor("mIlLiEpOcH")
+    assert(result4 == 1L)
     val formatString = "xxxx"
     val expectedMessage = s"'$formatString' is not an epoch format"
     val caught = intercept[InvalidParameterException] {
       Format.epochFactor(formatString)
     }
     assert(caught.getMessage == expectedMessage)
+    val caught2 = intercept[InvalidParameterException] {
+      Format.epochMilliFactor(formatString)
+    }
+    assert(caught2.getMessage == expectedMessage)
   }
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/DateTimeValidatorsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/DateTimeValidatorsSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.validation
+
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
+
+class DateTimeValidatorsSuite extends FunSuite {
+  TimeZoneNormalizer.normalizeJVMTimeZone()
+
+  test("epoch pattern") {
+    assert(DateTimeValidators.isDateTimePatternValid("epoch").isEmpty)
+    //with default
+    assert(DateTimeValidators.isDateTimePatternValid("epoch", Some("5545556")).isEmpty)
+  }
+
+  test("milliepoch pattern") {
+    assert(DateTimeValidators.isDateTimePatternValid("milliepoch").isEmpty)
+    //with default
+    assert(DateTimeValidators.isDateTimePatternValid("milliepoch", Some("55455560000")).isEmpty)
+  }
+
+  test("date pattern") {
+    //no default
+    assert(DateTimeValidators.isDateTimePatternValid("yyyy-MM-dd").isEmpty)
+    //default as date
+    assert(DateTimeValidators.isDateTimePatternValid("dd.MM.yy", Some("01.05.18"))isEmpty)
+    //default as timestamp
+    assert(DateTimeValidators.isDateTimePatternValid("yyyy/dd/MM", Some("2010/21/11 04:00:00")).isEmpty) //TODO Correct?
+  }
+
+  test("timestamp pattern") {
+    //no default
+    assert(DateTimeValidators.isDateTimePatternValid("yyyy-MM-dd hh:mm:ss").isEmpty)
+    //default as timestamp
+    assert(DateTimeValidators.isDateTimePatternValid("hh-mm-ss~~dd.MM.yyyy", Some("23-10-11~~31.12.2004")).isEmpty)
+    //extra chars in default
+    assert(DateTimeValidators.isDateTimePatternValid("hh-mm-ss~~dd.MM.yyyy", Some("23-10-11~~31.12.2004kkkkk")).isEmpty)
+  }
+
+  test("timestamp with time zone pattern") {
+    //no default
+    assert(DateTimeValidators.isDateTimePatternValid("yyyy-MM-dd hh:mm:ss zz").isEmpty)
+    //default as timestamp
+    assert(DateTimeValidators.isDateTimePatternValid("hh-mm-ss~~dd.MM.yyyy+zz", Some("23-10-11~~31.12.2004+CET")).isEmpty)
+    //extra chars in default
+    assert(DateTimeValidators.isDateTimePatternValid("yyMMdd_hhmmss_zz", Some("190301_194533_EST!!!!")).isEmpty)
+  }
+
+  test("invalid pattern") {
+    assert(DateTimeValidators.isDateTimePatternValid("fubar").nonEmpty)
+    assert(DateTimeValidators.isDateTimePatternValid("yyMMdd_hhmmss_zz_xx").nonEmpty)
+  }
+
+  test("invalid default") {
+    //empty default
+    assert(DateTimeValidators.isDateTimePatternValid("yyMMdd_hhmmss_zz", Some("")).nonEmpty)
+    //wrong default
+    assert(DateTimeValidators.isDateTimePatternValid("yyyy/MM/dd", Some("1999-12-31")).nonEmpty)
+    //invalid epoch default
+    assert(DateTimeValidators.isDateTimePatternValid("epoch", Some("2019-01-01")).nonEmpty)
+    //timestamp pattern, date default
+    assert(DateTimeValidators.isDateTimePatternValid("dd.MM.yyyy hh-mm-ss", Some("31.12.2004")).nonEmpty)
+  }
+
+}


### PR DESCRIPTION
* DateTimeValidators changes to use the same conversion class as the standardization itself
* EnceladusDateParser class now has format method to convert TO string
* Unit tests for DateTimeValidators
* Enhanced unit tests for Format and EnceladusDateParser