### PR TITLE
#178 Remove unused button from add/edit dialogs

### DIFF
--- a/menas/ui/components/mappingTable/addMappingTable.fragment.xml
+++ b/menas/ui/components/mappingTable/addMappingTable.fragment.xml
@@ -45,8 +45,6 @@
                                 <core:ListItem key="{version}" text="{version}"
                                                additionalText="updated: {path: 'lastUpdated', formatter: 'Formatters.stringDateShortFormatter'}"/>
                             </Select>
-                            <Button icon="sap-icon://action">
-                            </Button>
                         </FlexBox>
                         <Label text="HDFS Path"/>
                         <hdfs:HDFSBrowser id="addMtHDFSBrowser" height="300px" width="100%"

--- a/menas/ui/components/mappingTableSelector.fragment.xml
+++ b/menas/ui/components/mappingTableSelector.fragment.xml
@@ -26,7 +26,5 @@
             <core:ListItem key="{version}" text="{version}"
                            additionalText="updated: {path: 'lastUpdated', formatter: 'Formatters.stringDateShortFormatter'}"/>
         </Select>
-        <Button icon="sap-icon://action">
-        </Button>
     </FlexBox>
 </core:FragmentDefinition>

--- a/menas/ui/components/schemaSelector.fragment.xml
+++ b/menas/ui/components/schemaSelector.fragment.xml
@@ -28,7 +28,5 @@
             <core:ListItem key="{version}" text="{version}"
                            additionalText="updated: {path: 'lastUpdated', formatter: 'Formatters.stringDateShortFormatter'}"/>
         </Select>
-        <Button icon="sap-icon://action">
-        </Button>
     </FlexBox>
 </core:FragmentDefinition>


### PR DESCRIPTION
This was probably intended to provide a popup view of the selected schema, but was never implemented. It doesn't make sense to have a functionless button until we do implement this feature (if we do, we should have create a task for it).