### PR TITLE
293: Updated Jenkinsfile to reversion artifacts with Git commit ID before deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
             }
             steps {
                 configFileProvider([configFile(fileId: "${mavenSettingsId}", variable: 'MAVEN_SETTINGS_XML')]) {
+                    sh "mvn versions:set -DnewVersion=${env.GIT_COMMIT}"
                     sh "mvn -s $MAVEN_SETTINGS_XML -DaltDeploymentRepository=${nexusURL} ${mavenAdditionalSettingsDeploy} deploy"
                 }
             }


### PR DESCRIPTION
This is a quick update to reversion the artifacts built during deploy.

As it stands, every artifact is version 0.99-SNAPSHOT, which isn't great.
This will reversion them on deployment to Nexus/Test Servers with the Git commit ID for tracking of actual changes.