### PR TITLE
#312 Increase timeout to 500ms for 'Test getAuditTrail TestSchema1'

### DIFF
--- a/menas/src/test/scala/za/co/absa/enceladus/rest/services/BaseServiceTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/rest/services/BaseServiceTest.scala
@@ -21,6 +21,6 @@ import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
 
 abstract class BaseServiceTest extends FunSuite with MockitoSugar with BeforeAndAfter {
-  val millis100 = Duration(100, TimeUnit.MILLISECONDS)
-  val millis500 = Duration(500, TimeUnit.MILLISECONDS)
+  val shortTimeout = Duration(100, TimeUnit.MILLISECONDS)
+  val longTimeout = Duration(500, TimeUnit.MILLISECONDS)
 }

--- a/menas/src/test/scala/za/co/absa/enceladus/rest/services/BaseServiceTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/rest/services/BaseServiceTest.scala
@@ -22,5 +22,5 @@ import java.util.concurrent.TimeUnit
 
 abstract class BaseServiceTest extends FunSuite with MockitoSugar with BeforeAndAfter {
   val millis100 = Duration(100, TimeUnit.MILLISECONDS)
-  val millis200 = Duration(200, TimeUnit.MILLISECONDS)
+  val millis500 = Duration(500, TimeUnit.MILLISECONDS)
 }

--- a/menas/src/test/scala/za/co/absa/enceladus/rest/services/VersionedModelServiceAuditTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/rest/services/VersionedModelServiceAuditTest.scala
@@ -49,19 +49,19 @@ class VersionedModelServiceAuditTest extends BaseServiceTest {
   test("Test getParents TestSchema1") {
     //The order here is important and is it represents the trail of parents
     val exp = Seq(testSchemas(0), testSchemas(1), testSchemas(3), testSchemas(4))
-    val actual = Await.result(service.getParents("TestSchema1"), millis200)
+    val actual = Await.result(service.getParents("TestSchema1"), millis500)
     assertResult(exp)(actual)
   }
 
   test("Test getParents TestSchema") {
     //The order here is important and is it represents the trail of parents
     val exp = Seq(testSchemas(0), testSchemas(1), testSchemas(2))
-    val actual = Await.result(service.getParents("TestSchema"), millis200)
+    val actual = Await.result(service.getParents("TestSchema"), millis500)
     assertResult(exp)(actual)
   }
 
   test("Test getAuditTrail TestSchema1") {
-    val actual = Await.result(service.getAuditTrail("TestSchema1"), millis200)
+    val actual = Await.result(service.getAuditTrail("TestSchema1"), millis500)
     val expected = AuditTrail(Stream(AuditTrailEntry(MenasReference(None, "TestSchema1", 1), null, testSchemas(4).lastUpdated,
         List(AuditTrailChange("fields", None, Some("SchemaField(b,String,,None,None,true,Map(),List())"), "Schema field added."))),
       AuditTrailEntry(MenasReference(None, "TestSchema1", 0), null, testSchemas(3).lastUpdated,
@@ -75,7 +75,7 @@ class VersionedModelServiceAuditTest extends BaseServiceTest {
   }
 
   test("Test getAuditTrail TestSchema") {
-    val actual = Await.result(service.getAuditTrail("TestSchema"), millis200)
+    val actual = Await.result(service.getAuditTrail("TestSchema"), millis500)
 
     val expected = AuditTrail(Stream(AuditTrailEntry(MenasReference(None, "TestSchema", 2), null, testSchemas(2).lastUpdated,
       List(AuditTrailChange("fields", None, Some("SchemaField(a,Integer,,None,None,true,Map(),List())"), "Schema field added."))),

--- a/menas/src/test/scala/za/co/absa/enceladus/rest/services/VersionedModelServiceAuditTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/rest/services/VersionedModelServiceAuditTest.scala
@@ -49,19 +49,19 @@ class VersionedModelServiceAuditTest extends BaseServiceTest {
   test("Test getParents TestSchema1") {
     //The order here is important and is it represents the trail of parents
     val exp = Seq(testSchemas(0), testSchemas(1), testSchemas(3), testSchemas(4))
-    val actual = Await.result(service.getParents("TestSchema1"), millis500)
+    val actual = Await.result(service.getParents("TestSchema1"), longTimeout)
     assertResult(exp)(actual)
   }
 
   test("Test getParents TestSchema") {
     //The order here is important and is it represents the trail of parents
     val exp = Seq(testSchemas(0), testSchemas(1), testSchemas(2))
-    val actual = Await.result(service.getParents("TestSchema"), millis500)
+    val actual = Await.result(service.getParents("TestSchema"), longTimeout)
     assertResult(exp)(actual)
   }
 
   test("Test getAuditTrail TestSchema1") {
-    val actual = Await.result(service.getAuditTrail("TestSchema1"), millis500)
+    val actual = Await.result(service.getAuditTrail("TestSchema1"), longTimeout)
     val expected = AuditTrail(Stream(AuditTrailEntry(MenasReference(None, "TestSchema1", 1), null, testSchemas(4).lastUpdated,
         List(AuditTrailChange("fields", None, Some("SchemaField(b,String,,None,None,true,Map(),List())"), "Schema field added."))),
       AuditTrailEntry(MenasReference(None, "TestSchema1", 0), null, testSchemas(3).lastUpdated,
@@ -75,7 +75,7 @@ class VersionedModelServiceAuditTest extends BaseServiceTest {
   }
 
   test("Test getAuditTrail TestSchema") {
-    val actual = Await.result(service.getAuditTrail("TestSchema"), millis500)
+    val actual = Await.result(service.getAuditTrail("TestSchema"), longTimeout)
 
     val expected = AuditTrail(Stream(AuditTrailEntry(MenasReference(None, "TestSchema", 2), null, testSchemas(2).lastUpdated,
       List(AuditTrailChange("fields", None, Some("SchemaField(a,Integer,,None,None,true,Map(),List())"), "Schema field added."))),

--- a/menas/src/test/scala/za/co/absa/enceladus/rest/services/VersionedModelServiceTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/rest/services/VersionedModelServiceTest.scala
@@ -32,7 +32,7 @@ abstract class VersionedModelServiceTest[C <: VersionedModel with Product with A
   test("Validate dataset with valid, unique name") {
     Mockito.when(modelRepository.isUniqueName(validName)).thenReturn(Future.successful(true))
 
-    val result = Await.result(service.validateName(validName), millis100)
+    val result = Await.result(service.validateName(validName), shortTimeout)
     assert(result.isValid())
     assert(result == Validation())
   }
@@ -40,7 +40,7 @@ abstract class VersionedModelServiceTest[C <: VersionedModel with Product with A
   test("Validate dataset with valid, taken name") {
     Mockito.when(modelRepository.isUniqueName(validName)).thenReturn(Future.successful(false))
 
-    val result = Await.result(service.validateName(validName), millis100)
+    val result = Await.result(service.validateName(validName), shortTimeout)
     assert(!result.isValid())
     assert(result == Validation(Map("name" -> List(s"entity with name already exists: '$validName'"))))
   }
@@ -54,7 +54,7 @@ abstract class VersionedModelServiceTest[C <: VersionedModel with Product with A
   }
 
   private def assertHasWhitespace(name: String): Unit = {
-    val result = Await.result(service.validateName(name), millis100)
+    val result = Await.result(service.validateName(name), shortTimeout)
     assert(!result.isValid())
     assert(result == Validation(Map("name" -> List(s"name contains whitespace: '$name'"))))
   }


### PR DESCRIPTION
This is a workaround to fix AWS builds that fail from time to time.
It's just the one unit test that takes long `"Test getAuditTrail TestSchema1"`, on my machine it need a 15ms timeout to pass consistently. We might need to figure out why it's 20 times slower on AWS.  