### PR TITLE
Add support for the old Menas JSON schema format for schema upload

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/SchemaController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/SchemaController.scala
@@ -48,7 +48,7 @@ class SchemaController @Autowired() (
     val origFile = MenasAttachment(refCollection = RefCollection.SCHEMA.name().toLowerCase, refName = name, refVersion = version + 1, attachmentType = MenasAttachment.ORIGINAL_SCHEMA_ATTACHMENT,
       filename = file.getOriginalFilename, fileContent = file.getBytes, fileMIMEType = file.getContentType)
 
-    val struct = DataType.fromJson(new String(file.getBytes)).asInstanceOf[StructType]
+    val struct = sparkMenasConvertor.convertAnyToStructType(new String(file.getBytes))
 
     for {
       upload <- attachmentService.uploadAttachment(origFile)

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
@@ -39,7 +39,8 @@ class SparkMenasSchemaConvertor @Autowired()(val objMapper: ObjectMapper) {
         convertMenasModel0JsonToStructType(inputJson) match {
           case Left(schema) => schema
           case Right(message2) =>
-            throw new IllegalStateException(s"StructType serializer: $message1\nMenas serializer: $message2")
+            throw new IllegalStateException(
+              s"Unable to parse schema JSON\nStructType serializer: $message1\nMenas serializer: $message2")
         }
     }
   }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
@@ -59,11 +59,11 @@ class SparkMenasSchemaConvertor @Autowired()(val objMapper: ObjectMapper) {
   }
 
   /**
-    * Converts a JSON in Menas 0.9.* (Model 0) format into an instance of Spark's StructType
+    * Converts a model 0 JSON (pre-release Menas) format into an instance of Spark's StructType
     */
   def convertMenasModel0JsonToStructType(inputJson: String): Either[StructType, String] = {
     try {
-      val schema = model0.Serializer.convertFromModel0ToStructType(inputJson)
+      val schema = model0.Serializer.convertToStructType(inputJson)
       Left(schema)
     }
     catch {

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
@@ -23,8 +23,27 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import java.io.ByteArrayOutputStream
 
+import scala.util.control.NonFatal
+
 @Component
 class SparkMenasSchemaConvertor @Autowired()(val objMapper: ObjectMapper) {
+
+  def convertAnyToStructType(inputJson: String): StructType = {
+    convertStructTypeJsonToStructType(inputJson) match {
+      case Some(schema) => schema
+      case None => throw new IllegalStateException("Unable to convert uploaded schema.")
+    }
+  }
+
+  def convertStructTypeJsonToStructType(inputJson: String): Option[StructType] = {
+    try {
+      val schema = DataType.fromJson(inputJson).asInstanceOf[StructType]
+      Some(schema)
+    }
+    catch {
+      case NonFatal(_) => None
+    }
+  }
 
   /**
     * Converts a seq of menas schema fields onto the spark structfields

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/Schema.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/Schema.scala
@@ -19,10 +19,6 @@ case class Schema
 (
   name: String,
   version: Int,
-
-  /*  dateCreated: LocalDateTime = LocalDateTime.now,
-    userCreated: String = "System",*/
-
   fields: List[SchemaField]
 ) extends VersionedModel {
 

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/Schema.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/Schema.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.utils.converters.model0
+
+case class Schema
+(
+  name: String,
+  version: Int,
+
+  /*  dateCreated: LocalDateTime = LocalDateTime.now,
+    userCreated: String = "System",*/
+
+  fields: List[SchemaField]
+) extends VersionedModel {
+
+
+  override def setVersion(value: Int): Schema = this.copy(version = value)
+}

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/SchemaField.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/SchemaField.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.utils.converters.model0
+
+case class SchemaField
+(
+  name: String,
+  `type`: String,
+
+  // These fields are optional when the type of the field is "array".
+  elementType: Option[String],
+  containsNull: Option[Boolean],
+
+  nullable: Boolean,
+  metadata: Map[String, String],
+  children: List[SchemaField]
+)

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/Serializer.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/Serializer.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.utils.converters.model0
+
+import java.io.ByteArrayOutputStream
+
+import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.types._
+import org.json4s.{Formats, NoTypeHints}
+import org.json4s.jackson.Serialization
+
+/**
+  * This is the object for deserializing Model 0 version of Enceladus Schema and convert it to Spark StructType
+  */
+object Serializer {
+  private val objectMapper = new ObjectMapper()
+    .registerModule(DefaultScalaModule)
+    .registerModule(new JavaTimeModule())
+    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+
+  implicit private val formatsJson: Formats = Serialization.formats(NoTypeHints).withBigDecimal
+
+  /**
+    * Converts a JSON in Model 0 format to a Spark StructType
+    */
+  def convertFromModel0ToStructType(json: String): StructType = convertToStructType(deserialize(json))
+
+  /**
+    * Deserializes a Model 0 JSON
+    */
+  def deserialize(json: String): Schema = {
+    Serialization.read[Schema](json)
+  }
+
+  /**
+    * Converts a Model 0 shema object to Spark StructType
+    */
+  def convertToStructType(schema: Schema): StructType = {
+    StructType(schema.fields.map({ menas =>
+      convertMenasToSparkField(menas)
+    }))
+  }
+
+  /**
+    * Converts a Mode 0 struct field to a Spark's StructField
+    */
+  private def convertMenasToSparkField(menasField: SchemaField): StructField = {
+    val outStream = new ByteArrayOutputStream()
+    objectMapper.writeValue(outStream, menasField.metadata)
+
+    val metadata = Metadata.fromJson(new String(outStream.toByteArray(), "UTF-8"))
+
+    StructField(
+      name = menasField.name,
+      dataType = convertMenasToSparkDataType(menasField),
+      nullable = menasField.nullable,
+      metadata = metadata)
+   }
+
+  /**
+    * Converts a Mode 0 data type to a Spark's data type
+    */
+  private def convertMenasToSparkDataType(menasField: SchemaField): DataType = {
+    menasField.`type` match {
+      case "array"  => convertMenasToSparkArray(menasField)
+      case "struct" => StructType(convertMenasToSparkFields(menasField.children))
+      case s        => CatalystSqlParser.parseDataType(s)
+    }
+  }
+
+  /**
+    * Converts a Mode 0 array field to a Spark's ArrayType field
+    */
+  private def convertMenasToSparkArray(arrayField: SchemaField): ArrayType = {
+    if (arrayField.`type` != "array") {
+      throw new IllegalStateException(s"An array is expected.")
+    }
+    arrayField.elementType match {
+      case Some("struct") => ArrayType(StructType(convertMenasToSparkFields(arrayField.children)))
+      case Some("array") => ArrayType(convertMenasToSparkArray(arrayField.children.head))
+      case Some(primitive) => ArrayType(CatalystSqlParser.parseDataType(primitive))
+      case None =>
+        val fieldName = s"${arrayField.name}"
+        throw new IllegalStateException(s"Element type is not specified for $fieldName.")
+    }
+  }
+
+  /**
+    * Converts a seq of Menas schema fields onto the spark structFields
+    */
+  private def convertMenasToSparkFields(menasFields: Seq[SchemaField]): Seq[StructField] = {
+    menasFields.map({ menas =>
+      convertMenasToSparkField(menas)
+    })
+  }
+
+}

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/Serializer.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/Serializer.scala
@@ -39,7 +39,7 @@ object Serializer {
   /**
     * Converts a JSON in Model 0 format to a Spark StructType
     */
-  def convertFromModel0ToStructType(json: String): StructType = convertToStructType(deserialize(json))
+  def convertToStructType(json: String): StructType = convertToStructType(deserialize(json))
 
   /**
     * Deserializes a Model 0 JSON
@@ -52,13 +52,11 @@ object Serializer {
     * Converts a Model 0 shema object to Spark StructType
     */
   def convertToStructType(schema: Schema): StructType = {
-    StructType(schema.fields.map({ menas =>
-      convertMenasToSparkField(menas)
-    }))
+    StructType(convertMenasToSparkFields(schema.fields))
   }
 
   /**
-    * Converts a Mode 0 struct field to a Spark's StructField
+    * Converts a Model 0 struct field to a Spark's StructField
     */
   private def convertMenasToSparkField(menasField: SchemaField): StructField = {
     val outStream = new ByteArrayOutputStream()
@@ -74,7 +72,7 @@ object Serializer {
    }
 
   /**
-    * Converts a Mode 0 data type to a Spark's data type
+    * Converts a Model 0 data type to a Spark's data type
     */
   private def convertMenasToSparkDataType(menasField: SchemaField): DataType = {
     menasField.`type` match {
@@ -85,7 +83,7 @@ object Serializer {
   }
 
   /**
-    * Converts a Mode 0 array field to a Spark's ArrayType field
+    * Converts a Model 0 array field to a Spark's ArrayType field
     */
   private def convertMenasToSparkArray(arrayField: SchemaField): ArrayType = {
     if (arrayField.`type` != "array") {

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/VersionedModel.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/VersionedModel.scala
@@ -19,8 +19,5 @@ trait VersionedModel {
   val name: String
   val version: Int
 
-  /*  val dateCreated: LocalDateTime
-    val userCreated: String*/
-
   def setVersion(value: Int): VersionedModel
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/VersionedModel.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/model0/VersionedModel.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.utils.converters.model0
+
+trait VersionedModel {
+  val name: String
+  val version: Int
+
+  /*  val dateCreated: LocalDateTime
+    val userCreated: String*/
+
+  def setVersion(value: Int): VersionedModel
+}

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/schema/SchemaConvertersSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/schema/SchemaConvertersSuite.scala
@@ -95,4 +95,191 @@ class SchemaConvertersSuite extends FunSuite {
 
     assert(actualSchema.prettyJson == expectedSchema.prettyJson)
   }
+
+  test("Test nested StructType to StructType schema conversion") {
+    val inputJson =
+      """
+        |{
+        |	"type": "struct",
+        |	"fields": [
+        |		{
+        |			"name": "field1",
+        |			"type": "string",
+        |			"nullable": true,
+        |			"metadata": {}
+        |		},
+        |		{
+        |			"name": "field2",
+        |			"type": "integer",
+        |			"nullable": true,
+        |			"metadata": {}
+        |		},
+        |		{
+        |			"name": "field3",
+        |			"type": "date",
+        |			"nullable": true,
+        |			"metadata": {
+        |				"pattern": "yyyy-MM-dd"
+        |			}
+        |		},
+        |		{
+        |			"name": "field4",
+        |			"type": "decimal(38,18)",
+        |			"nullable": true,
+        |			"metadata": {}
+        |		},
+        |		{
+        |			"name": "field5",
+        |			"type": "boolean",
+        |			"nullable": true,
+        |			"metadata": {}
+        |		},
+        |		{
+        |			"name": "field6",
+        |			"type": "timestamp",
+        |			"nullable": true,
+        |			"metadata": {
+        |				"pattern": "yyyy-MM-dd'T'HH:mm:ss"
+        |			}
+        |		},
+        |		{
+        |			"name": "nested1",
+        |			"type": {
+        |				"type": "struct",
+        |				"fields": [
+        |					{
+        |						"name": "nested2",
+        |						"type": {
+        |							"type": "array",
+        |							"elementType": {
+        |								"type": "struct",
+        |								"fields": [
+        |									{
+        |										"name": "field7",
+        |										"type": "decimal(38,18)",
+        |										"nullable": true,
+        |										"metadata": {}
+        |									},
+        |									{
+        |										"name": "field8",
+        |										"type": "string",
+        |										"nullable": false,
+        |										"metadata": {}
+        |									},
+        |									{
+        |										"name": "field9",
+        |										"type": "date",
+        |										"nullable": true,
+        |										"metadata": {
+        |											"pattern": "yyyy-MM-dd"
+        |										}
+        |									},
+        |									{
+        |										"name": "field10",
+        |										"type": "integer",
+        |										"nullable": true,
+        |										"metadata": {}
+        |									}
+        |								]
+        |							},
+        |							"containsNull": true
+        |						},
+        |						"nullable": true,
+        |						"metadata": {}
+        |					}
+        |				]
+        |			},
+        |			"nullable": true,
+        |			"metadata": {}
+        |		},
+        |		{
+        |			"name": "nested3",
+        |			"type": {
+        |				"type": "struct",
+        |				"fields": [
+        |					{
+        |						"name": "nested4",
+        |						"type": {
+        |							"type": "array",
+        |							"elementType": {
+        |								"type": "struct",
+        |								"fields": [
+        |									{
+        |										"name": "field11",
+        |										"type": "date",
+        |										"nullable": true,
+        |										"metadata": {
+        |											"pattern": "yyyy-MM-dd"
+        |										}
+        |									},
+        |									{
+        |										"name": "field12",
+        |										"type": "timestamp",
+        |										"nullable": true,
+        |										"metadata": {
+        |											"pattern": "yyyy-MM-dd'T'HH:mm:ss"
+        |										}
+        |									},
+        |									{
+        |										"name": "field13",
+        |										"type": "integer",
+        |										"nullable": false,
+        |										"metadata": {}
+        |									},
+        |									{
+        |										"name": "field14",
+        |										"type": "string",
+        |										"nullable": true,
+        |										"metadata": {}
+        |									}
+        |								]
+        |							},
+        |							"containsNull": true
+        |						},
+        |						"nullable": true,
+        |						"metadata": {}
+        |					}
+        |				]
+        |			},
+        |			"nullable": true,
+        |			"metadata": {}
+        |		},
+        |		{
+        |			"name": "field15",
+        |			"type": "string",
+        |			"nullable": true,
+        |			"metadata": {}
+        |		}
+        |	]
+        |}
+      """.stripMargin
+
+    val expectedSchema = StructType(Seq(
+      StructField("field1",StringType,true),
+      StructField("field2",IntegerType,true),
+      StructField("field3",DateType,true,Metadata.fromJson("""{"pattern": "yyyy-MM-dd"}""")),
+      StructField("field4",DecimalType(38,18),true),
+      StructField("field5",BooleanType,true),
+      StructField("field6",TimestampType,true,Metadata.fromJson("""{"pattern": "yyyy-MM-dd'T'HH:mm:ss"}""")),
+      StructField("nested1",StructType(Seq(
+        StructField("nested2",ArrayType(StructType(Seq(
+          StructField("field7",DecimalType(38,18),true),
+          StructField("field8",StringType,false),
+          StructField("field9",DateType,true,Metadata.fromJson("""{"pattern": "yyyy-MM-dd"}""")),
+          StructField("field10",IntegerType,true))),true),true)
+      )),true),
+      StructField("nested3",StructType(Seq(
+        StructField("nested4",ArrayType(StructType(Seq(
+          StructField("field11",DateType,true,Metadata.fromJson("""{"pattern": "yyyy-MM-dd"}""")),
+          StructField("field12",TimestampType,true,Metadata.fromJson("""{"pattern": "yyyy-MM-dd'T'HH:mm:ss"}""")),
+          StructField("field13",IntegerType,false),
+          StructField("field14",StringType,true))),true),true))),true),
+      StructField("field15",StringType,true)
+    ))
+
+    val actualSchema = sparkConverter.convertAnyToStructType(inputJson)
+
+    assert(actualSchema.prettyJson == expectedSchema.prettyJson)
+  }
+
 }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/schema/SchemaConvertersSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/schema/SchemaConvertersSuite.scala
@@ -282,7 +282,7 @@ class SchemaConvertersSuite extends FunSuite {
     assert(actualSchema.prettyJson == expectedSchema.prettyJson)
   }
 
-  test("Test 0.9.* Menas to StructType schema conversion") {
+  test("Test pre-release Menas JSON format to StructType schema conversion") {
     val inputJson =
       """
         |{

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/schema/SchemaConvertersSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/schema/SchemaConvertersSuite.scala
@@ -282,4 +282,131 @@ class SchemaConvertersSuite extends FunSuite {
     assert(actualSchema.prettyJson == expectedSchema.prettyJson)
   }
 
+  test("Test 0.9.* Menas to StructType schema conversion") {
+    val inputJson =
+      """
+        |{
+        |    "name" : "TestSchema",
+        |    "version" : 18,
+        |    "fields" : [
+        |        {
+        |            "name" : "field1",
+        |            "type" : "string",
+        |            "nullable" : true,
+        |            "metadata" : {},
+        |            "children" : []
+        |        },
+        |        {
+        |            "name" : "field2",
+        |            "type" : "integer",
+        |            "nullable" : true,
+        |            "metadata" : {},
+        |            "children" : []
+        |        },
+        |        {
+        |            "name" : "field3",
+        |            "type" : "date",
+        |            "nullable" : true,
+        |            "metadata" : {
+        |                "pattern" : "yyyy-MM-dd"
+        |            },
+        |            "children" : []
+        |        },
+        |        {
+        |            "name" : "field4",
+        |            "type" : "decimal(38,18)",
+        |            "nullable" : true,
+        |            "metadata" : {},
+        |            "children" : []
+        |        },
+        |        {
+        |            "name" : "field5",
+        |            "type" : "boolean",
+        |            "nullable" : true,
+        |            "metadata" : {},
+        |            "children" : []
+        |        },
+        |        {
+        |            "name" : "field6",
+        |            "type" : "timestamp",
+        |            "nullable" : true,
+        |            "metadata" : {
+        |                "pattern" : "yyyy-MM-dd'T'HH:mm:ss"
+        |            },
+        |            "children" : []
+        |        },
+        |        {
+        |            "name" : "nested1",
+        |            "type" : "struct",
+        |            "nullable" : true,
+        |            "metadata" : {},
+        |            "children" : [
+        |                {
+        |                    "name" : "nested2",
+        |                    "type" : "array",
+        |                    "elementType" : "struct",
+        |                    "containsNull" : true,
+        |                    "nullable" : true,
+        |                    "metadata" : {},
+        |                    "children" : [
+        |                        {
+        |                            "name" : "field7",
+        |                            "type" : "decimal(38,18)",
+        |                            "nullable" : true,
+        |                            "metadata" : {},
+        |                            "children" : []
+        |                        },
+        |                        {
+        |                            "name" : "field8",
+        |                            "type" : "string",
+        |                            "nullable" : false,
+        |                            "metadata" : {},
+        |                            "children" : []
+        |                        },
+        |                        {
+        |                            "name" : "field9",
+        |                            "type" : "date",
+        |                            "nullable" : true,
+        |                            "metadata" : {
+        |                                "pattern" : "yyyy-MM-dd"
+        |                            },
+        |                            "children" : []
+        |                        }
+        |                    ]
+        |                }
+        |            ]
+        |        },
+        |        {
+        |            "name" : "field10",
+        |            "type" : "string",
+        |            "nullable" : true,
+        |            "metadata" : {},
+        |            "children" : []
+        |        }
+        |    ]
+        |}
+      """.stripMargin
+
+    val expectedSchema = StructType(Seq(
+      StructField("field1",StringType,true),
+      StructField("field2",IntegerType,true),
+      StructField("field3",DateType,true, Metadata.fromJson("""{"pattern": "yyyy-MM-dd"}""")),
+      StructField("field4",DecimalType(38,18),true),
+      StructField("field5",BooleanType,true),
+      StructField("field6",TimestampType,true, Metadata.fromJson("""{"pattern": "yyyy-MM-dd'T'HH:mm:ss"}""")),
+      StructField("nested1",StructType(Seq(
+        StructField("nested2",ArrayType(StructType(Seq(
+          StructField("field7",DecimalType(38,18),true),
+          StructField("field8",StringType,false),
+          StructField("field9",DateType,true, Metadata.fromJson("""{"pattern": "yyyy-MM-dd"}""")))
+        ),true),true))),true),
+      StructField("field10",StringType,true)
+    ))
+
+
+    val actualSchema = sparkConverter.convertAnyToStructType(inputJson)
+
+    assert(actualSchema.prettyJson == expectedSchema.prettyJson)
+  }
+
 }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/schema/SchemaConvertersSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/schema/SchemaConvertersSuite.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.schema
+
+import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.spark.sql.types._
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.menas.utils.converters.SparkMenasSchemaConvertor
+
+class SchemaConvertersSuite extends FunSuite {
+
+  val objectMapper: ObjectMapper = new ObjectMapper()
+    .registerModule(DefaultScalaModule)
+    .registerModule(new JavaTimeModule())
+    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+  val sparkConverter = new SparkMenasSchemaConvertor(objectMapper)
+
+  test("Test StructType to StructType schema conversion") {
+    val inputJson =
+      """
+        |{
+        |  "type" : "struct",
+        |  "fields" : [ {
+        |    "name" : "ID",
+        |    "type" : "integer",
+        |    "nullable" : true,
+        |    "metadata" : { }
+        |  },{
+        |  "name" : "Field1",
+        |    "type" : "long",
+        |    "nullable" : true,
+        |    "metadata" : { }
+        |  },{
+        |    "name" : "Field2",
+        |    "type" : "date",
+        |    "nullable" : true,
+        |    "metadata" : {
+        |      "pattern" : "MM/dd/yyyy"
+        |    }
+        |  },{
+        |    "name" : "Field3",
+        |    "type" : "decimal(15,2)",
+        |    "nullable" : true,
+        |    "metadata" : { }
+        |  },{
+        |    "name" : "Field4",
+        |    "type" : "decimal(11,8)",
+        |    "nullable" : true,
+        |    "metadata" : { }
+        |  },{
+        |    "name" : "Field4",
+        |    "type" : "decimal(6,4)",
+        |    "nullable" : true,
+        |    "metadata" : { }
+        |  },{
+        |    "name" : "Field5",
+        |    "type" : "decimal(9,2)",
+        |    "nullable" : true,
+        |    "metadata" : { }
+        |  },{
+        |    "name" : "Field6",
+        |    "type" : "decimal(13,2)",
+        |    "nullable" : true,
+        |    "metadata" : { }
+        |  }]
+        |}
+      """.stripMargin
+
+    val expectedSchema = StructType(Seq(
+      StructField("ID",IntegerType,true),
+      StructField("Field1",LongType,true),
+      StructField("Field2",DateType,true,Metadata.fromJson("""{"pattern": "MM/dd/yyyy"}""")),
+      StructField("Field3",DecimalType(15,2),true),
+      StructField("Field4",DecimalType(11,8),true),
+      StructField("Field4",DecimalType(6,4),true),
+      StructField("Field5",DecimalType(9,2),true),
+      StructField("Field6",DecimalType(13,2),true)))
+
+    val actualSchema = sparkConverter.convertAnyToStructType(inputJson)
+
+    assert(actualSchema.prettyJson == expectedSchema.prettyJson)
+  }
+}


### PR DESCRIPTION
So this is actually not a separate conversion tool but the support of old Menas schema JSON format support by the schema uploader.