### PR TITLE
#412: Refactor StandardizationInterpreter

### DIFF
--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationCommon.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationCommon.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.standardization
+
+import org.slf4j.{Logger, LoggerFactory}
+
+trait StandardizationCommon {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def unpath(path: String): String = path.replace('.', '_')
+
+}

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
@@ -107,7 +107,7 @@ object StandardizationInterpreter extends StandardizationCommon{
           val stdOutput = TypeParser.standardize(field, "", df.schema)
           logger.info(s"Applying standardization plan for ${field.name}")
           val (column1, column2, errField) = stdApplyLogic(stdOutput, field, nextErrorColumnIndex)
-          (column1 :: column2 :: accCols, errField::accErrorCols, nextErrorColumnIndex + 1)
+          (column1 :: column2 :: accCols, errField :: accErrorCols, nextErrorColumnIndex + 1)
         }
     }
 

--- a/standardization/src/test/resources/data/patients.json
+++ b/standardization/src/test/resources/data/patients.json
@@ -1,0 +1,59 @@
+[
+  {
+    "first name": "Jane",
+    "last name": "Goodall",
+    "body stats": {
+      "height": 164,
+      "weight": 61,
+      "miscellaneous": {
+        "eye color": "green",
+        "glasses": true
+      },
+      "temperature measurements": [
+        36.6,
+        36.7,
+        37,
+        36.6
+      ]
+    }
+  },
+  {
+    "first name": "Scott",
+    "last name": "Lang",
+    "body stats": {
+      "height": "various",
+      "weight": 83,
+      "miscellaneous": {
+        "eye color": "blue",
+        "glasses": false
+      },
+      "temperature measurements": [
+        36.6,
+        36.7,
+        37,
+        36.6
+      ]
+    }
+  },
+  {
+    "first name": "Aldrich",
+    "last name": "Killian",
+    "body stats": {
+      "height": 181,
+      "weight": 90,
+      "miscellaneous": {
+        "eye color": "brown or orange",
+        "glasses": "not any more"
+      },
+      "temperature measurements": [
+        36.7,
+        36.5,
+        38,
+        48,
+        152,
+        831,
+        "exploded"
+      ]
+    }
+  }
+]

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.standardization.interpreter
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.{ArrayType, BooleanType, DoubleType, IntegerType, MetadataBuilder, StringType, StructField, StructType}
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreterSuite._
+import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.general.JsonUtils
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+
+import scala.io.Source
+
+class StandardizationInterpreterSuite  extends FunSuite with SparkTestBase with LoggerTestBase {
+  import spark.implicits._
+
+  private implicit val udfLib: UDFLibrary = new UDFLibrary
+
+  test("sourcecolumn meta (does not yet) rename field") {
+    /* TODO once ##398 is done and solved as expected this test should start to fail
+       (which is good - see the two columns of same name on the output) */
+    val sourceColumnName = "source column"
+    val desiredSchema = StructType(Seq(
+      StructField("description", StringType, nullable = false),
+      StructField("new_column", StringType, nullable = false,
+        new MetadataBuilder().putString("sourcecolumn", sourceColumnName).build),
+      StructField("new_column_nullable", StringType, nullable = true,
+        new MetadataBuilder().putString("sourcecolumn", sourceColumnName).build)
+    ))
+
+    val seq = Seq(
+      ("01-Hello", "World"),
+      ("02-Null", null),
+      ("03-Number", Long.MaxValue.toString)
+    )
+    val src = seq.toDF("description", sourceColumnName)
+    logDataFrameContent(src)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    val actualSchema = std.schema.treeString
+    val expectedSchema = "root\n" +
+      " |-- description: string (nullable = true)\n" +
+      " |-- source column: string (nullable = true)\n" +
+      " |-- source column: string (nullable = true)\n" +
+      " |-- errCol: array (nullable = true)\n" +
+      " |    |-- element: struct (containsNull = false)\n" +
+      " |    |    |-- errType: string (nullable = true)\n" +
+      " |    |    |-- errCode: string (nullable = true)\n" +
+      " |    |    |-- errMsg: string (nullable = true)\n" +
+      " |    |    |-- errCol: string (nullable = true)\n" +
+      " |    |    |-- rawValues: array (nullable = true)\n" +
+      " |    |    |    |-- element: string (containsNull = true)\n" +
+      " |    |    |-- mappings: array (nullable = true)\n" +
+      " |    |    |    |-- element: struct (containsNull = true)\n" +
+      " |    |    |    |    |-- mappingTableColumn: string (nullable = true)\n" +
+      " |    |    |    |    |-- mappedDatasetColumn: string (nullable = true)\n"
+    assert(actualSchema == expectedSchema)
+
+    val exp = Seq(
+      RenamingRow("01-Hello", Option("World")),
+      RenamingRow("02-Null", None, Seq(
+        ErrorMessage.stdNullErr(sourceColumnName)
+      )),
+      RenamingRow("03-Number", Option(Long.MaxValue.toString))
+    )
+
+    assertResult(exp)(std.as[RenamingRow].collect().toList)
+  }
+
+  test("Errors in fields and having source columns") {
+    val desiredSchema = StructType(Seq(
+      StructField("first_name", StringType, nullable = true,
+        new MetadataBuilder().putString("sourcecolumn", "first name").build),
+      StructField("last_name", StringType, nullable = false,
+        new MetadataBuilder().putString("sourcecolumn", "last name").build),
+      StructField("body_stats",
+        StructType(Seq(
+          StructField("height", IntegerType, false),
+          StructField("weight", IntegerType, false),
+          StructField("miscellaneous", StructType(Seq(
+           StructField("eye_color", StringType, nullable = true,
+             new MetadataBuilder().putString("sourcecolumn", "eye color").build),
+           StructField("glasses", BooleanType, nullable = true)
+          ))),
+          StructField("temperature_measurements", ArrayType(DoubleType, true), true,
+            new MetadataBuilder().putString("sourcecolumn", "temperature measurements").build)
+        )),
+        nullable = false,
+        new MetadataBuilder().putString("sourcecolumn", "body stats").build
+      )
+    ))
+
+
+    val bufferedSource = Source.fromFile("src/test/resources/data/patients.json")
+    val srcString:String = bufferedSource.getLines().mkString("\n")
+    bufferedSource.close
+
+    val src = JsonUtils.getDataFrameFromJson(spark, Seq(srcString))
+
+    logDataFrameContent(src)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    val actualSchema = std.schema.treeString
+    val expectedSchema = "root\n" +
+                         " |-- first name: string (nullable = true)\n" +
+                         " |-- last name: string (nullable = true)\n" +
+                         " |-- body stats: struct (nullable = false)\n" +
+                         " |    |-- height: integer (nullable = true)\n" +
+                         " |    |-- weight: integer (nullable = true)\n" +
+                         " |    |-- miscellaneous: struct (nullable = false)\n" +
+                         " |    |    |-- eye_color: string (nullable = true)\n" +
+                          // TODO #398 notice that this field is renamed (not renamed back)
+                         " |    |    |-- glasses: boolean (nullable = true)\n" +
+                         " |    |-- temperature measurements: array (nullable = true)\n" +
+                          // TODO after #398 should be 'temperature measurements' (among other changes)
+                         " |    |    |-- element: double (containsNull = true)\n" +
+                         " |-- errCol: array (nullable = true)\n" +
+                         " |    |-- element: struct (containsNull = false)\n" +
+                         " |    |    |-- errType: string (nullable = true)\n" +
+                         " |    |    |-- errCode: string (nullable = true)\n" +
+                         " |    |    |-- errMsg: string (nullable = true)\n" +
+                         " |    |    |-- errCol: string (nullable = true)\n" +
+                         " |    |    |-- rawValues: array (nullable = true)\n" +
+                         " |    |    |    |-- element: string (containsNull = true)\n" +
+                         " |    |    |-- mappings: array (nullable = true)\n" +
+                         " |    |    |    |-- element: struct (containsNull = true)\n" +
+                         " |    |    |    |    |-- mappingTableColumn: string (nullable = true)\n" +
+                         " |    |    |    |    |-- mappedDatasetColumn: string (nullable = true)\n"
+    assert(actualSchema == expectedSchema)
+
+    val exp = Seq(
+      PatientRow("Jane", "Goodall", BodyStats(164, 61, "green", Option(true), Seq(36.6, 36.7, 37.0, 36.6))),
+      PatientRow("Scott", "Lang", BodyStats(0, 83, "blue", Option(false),Seq(36.6, 36.7, 37.0, 36.6)), Seq(
+        ErrorMessage.stdCastErr("body stats.height", "various")
+      )),
+      PatientRow("Aldrich", "Killian", BodyStats(181, 90, "brown or orange", Option(false), Seq(36.7, 36.5, 38.0, 48.0, 152.0, 831.0, 0.0)), Seq(
+        ErrorMessage.stdCastErr("body stats.miscellaneous.glasses", "not any more"),
+        ErrorMessage.stdCastErr("body stats.temperature measurements[*]", "exploded")
+      ))
+    )
+
+    assertResult(exp)(std.as[PatientRow].collect().toList)
+  }
+}
+
+object StandardizationInterpreterSuite {
+  // cannot use case class as the field names contain spaces therefore cast will happen into tuple
+  type RenamingRow = (String, String, Option[String], Seq[ErrorMessage])
+
+  type BodyStats = (Int, Int, (String, Option[Boolean]), Seq[Double])
+  type PatientRow = (String, String, BodyStats, Seq[ErrorMessage])
+
+  object RenamingRow {
+    def apply(
+               description: String,
+               sourceColumn: Option[String],
+               errCol: Seq[ErrorMessage] = Seq.empty
+             ): RenamingRow = {
+      (description, sourceColumn.getOrElse(""), sourceColumn, errCol)
+    }
+
+  }
+
+  object BodyStats {
+    def apply(
+               height: Int,
+               weight: Int,
+               eyeColor: String,
+               glasses: Option[Boolean],
+               temperatureMeasurements: Seq[Double]
+             ): BodyStats = {
+      (height, weight, (eyeColor, glasses), temperatureMeasurements)
+    }
+  }
+
+  object PatientRow {
+    def apply(
+               first_name: String,
+               lastName: String,
+               bodyStats: BodyStats,
+               errCol: Seq[ErrorMessage] = Seq.empty
+             ): PatientRow = {
+      (first_name, lastName, bodyStats, errCol)
+    }
+  }
+}

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromBooleanTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromBooleanTypeSuite.scala
@@ -13,24 +13,22 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuites
+package za.co.absa.enceladus.standardization.interpreter.stages
 
-import org.apache.spark.sql.types.{ByteType, DataType, DateType, DoubleType, FloatType, IntegerType, LongType,
-  ShortType, StructField, TimestampType}
-import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate
+import org.apache.spark.sql.types.{BooleanType, DataType, DateType, DoubleType, FloatType, StructField, TimestampType}
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
 import za.co.absa.enceladus.utils.time.DateTimePattern
 
-class TypeParserFromLongTypeSuite extends TypeParserSuiteTemplate {
+class TypeParser_FromBooleanTypeSuite extends TypeParserSuiteTemplate  {
 
   private val input = Input(
-    baseType = LongType,
-    defaultValueDate = "20001010",
-    defaultValueTimestamp = "199912311201",
-    datePattern = "yyyyMMdd",
-    timestampPattern = "yyyyMMddHHmm",
-    fixedTimezone = "EST",
-    path = "Hey"
+    baseType = BooleanType,
+    defaultValueDate = "0",
+    defaultValueTimestamp = "1",
+    datePattern = "u",
+    timestampPattern = "F",
+    fixedTimezone = "WST",
+    path = "Boo"
   )
 
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
@@ -49,8 +47,6 @@ class TypeParserFromLongTypeSuite extends TypeParserSuiteTemplate {
   override protected def createErrorCondition(srcField: String, target: StructField, castS: String): String = {
     target.dataType match {
       case FloatType | DoubleType => s"(($castS IS NULL) OR isnan($castS)) OR ($castS IN (Infinity, -Infinity))"
-      case ByteType | ShortType | IntegerType =>
-        s"($castS IS NULL) OR (NOT (CAST(Hey.sourceField AS INT) = CAST(Hey.sourceField AS BIGINT)))"
       case _ => s"$castS IS NULL"
     }
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDateTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDateTypeSuite.scala
@@ -13,44 +13,41 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuites
+package za.co.absa.enceladus.standardization.interpreter.stages
 
-import org.apache.spark.sql.types.{ByteType, DataType, DateType, DoubleType, FloatType, IntegerType, LongType,
-  ShortType, StringType, StructField, TimestampType}
-import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate
+import org.apache.spark.sql.types.{DataType, DateType, DoubleType, FloatType, StructField, TimestampType}
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
 import za.co.absa.enceladus.utils.time.DateTimePattern
 
-class TypeParserFromStringTypeSuite extends TypeParserSuiteTemplate {
+class TypeParser_FromDateTypeSuite extends TypeParserSuiteTemplate  {
 
   private val input = Input(
-    baseType = StringType,
-    defaultValueDate = "01.01.1970",
-    defaultValueTimestamp = "01.01.1970 00:00:00",
-    datePattern = "dd.MM.yyyy",
-    timestampPattern = "dd.MM.yyyy HH:mm:ss",
-    fixedTimezone = "CET",
-    path = "",
+    baseType = DateType,
+    defaultValueDate = "2000-01-01",
+    defaultValueTimestamp = "2010-12-31 23:59:59",
+    datePattern = "yyyy-MM-dd",
+    timestampPattern = "yyyy-MM-dd HH:mm:ss",
+    fixedTimezone = "CST",
+    path = "Date",
     datetimeNeedsPattern = false
   )
 
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)          => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)     => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
-      case (DateType, _, Some(tz))      => s"to_date(to_utc_timestamp(to_timestamp(`%s`, '$pattern'), '$tz'))"
-      case (TimestampType, _, Some(tz)) => s"to_utc_timestamp(to_timestamp(`%s`, '$pattern'), $tz)"
-      case (DateType, _, _)             => s"to_date(`%s`, '$pattern')"
-      case (TimestampType, _, _)        => s"to_timestamp(`%s`, '$pattern')"
-      case _                            => s"CAST(%s AS ${toType.sql})"
+      case (DateType, true, _)               => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
+      case (TimestampType, true, _)          => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, _, Some(tz))           => s"to_date(to_utc_timestamp(`%s`, '$tz'))"
+      case (TimestampType, _, Some(tz))      => s"to_utc_timestamp(%s, $tz)"
+      case (DateType, _, _)                  => "%s"
+      case (TimestampType, _, _)             => "to_timestamp(`%s`)"
+      case _                                 => s"CAST(%s AS ${toType.sql})"
     }
   }
 
   override protected def createErrorCondition(srcField: String, target: StructField, castS: String): String = {
     target.dataType match {
       case FloatType | DoubleType => s"(($castS IS NULL) OR isnan($castS)) OR ($castS IN (Infinity, -Infinity))"
-      case ByteType | ShortType | IntegerType | LongType => s"($castS IS NULL) OR contains($srcField, .)"
       case _ => s"$castS IS NULL"
     }
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDecimalTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDecimalTypeSuite.scala
@@ -13,42 +13,43 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuites
+package za.co.absa.enceladus.standardization.interpreter.stages
 
-import org.apache.spark.sql.types.{DataType, DateType, DoubleType, FloatType, StructField, TimestampType}
-import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate
+import org.apache.spark.sql.types.{ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType,
+  LongType, ShortType, StructField, TimestampType}
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
 import za.co.absa.enceladus.utils.time.DateTimePattern
 
-class TypeParserFromDateTypeSuite extends TypeParserSuiteTemplate  {
+class TypeParser_FromDecimalTypeSuite extends TypeParserSuiteTemplate  {
 
   private val input = Input(
-    baseType = DateType,
-    defaultValueDate = "2000-01-01",
-    defaultValueTimestamp = "2010-12-31 23:59:59",
-    datePattern = "yyyy-MM-dd",
-    timestampPattern = "yyyy-MM-dd HH:mm:ss",
+    baseType = DecimalType(10, 4),
+    defaultValueDate = "700101",
+    defaultValueTimestamp = "991231.2359",
+    datePattern = "yyMMdd",
+    timestampPattern = "yyMMdd.HHmm",
     fixedTimezone = "CST",
-    path = "Date",
-    datetimeNeedsPattern = false
+    path = "hello"
   )
 
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)               => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)          => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
-      case (DateType, _, Some(tz))           => s"to_date(to_utc_timestamp(`%s`, '$tz'))"
-      case (TimestampType, _, Some(tz))      => s"to_utc_timestamp(%s, $tz)"
-      case (DateType, _, _)                  => "%s"
-      case (TimestampType, _, _)             => "to_timestamp(`%s`)"
-      case _                                 => s"CAST(%s AS ${toType.sql})"
+      case (DateType, true, _)                      => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
+      case (TimestampType, true, _)                 => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
+      case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
+      case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"
+      case (DateType, _, _)                         => s"to_date(CAST(`%s` AS STRING), '$pattern')"
+      case _                                        => s"CAST(%s AS ${toType.sql})"
     }
   }
 
   override protected def createErrorCondition(srcField: String, target: StructField, castS: String): String = {
     target.dataType match {
       case FloatType | DoubleType => s"(($castS IS NULL) OR isnan($castS)) OR ($castS IN (Infinity, -Infinity))"
+      case ByteType | ShortType | IntegerType | LongType =>
+        s"($castS IS NULL) OR (NOT ($srcField = CAST($castS AS ${input.baseType.sql})))"
       case _ => s"$castS IS NULL"
     }
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDoubleTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDoubleTypeSuite.scala
@@ -13,15 +13,14 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuites
+package za.co.absa.enceladus.standardization.interpreter.stages
 
 import org.apache.spark.sql.types.{ByteType, DataType, DateType, DoubleType, FloatType, IntegerType, LongType,
   ShortType, StructField, TimestampType}
-import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
 import za.co.absa.enceladus.utils.time.DateTimePattern
 
-class TypeParserFromDoubleTypeSuite extends TypeParserSuiteTemplate  {
+class TypeParser_FromDoubleTypeSuite extends TypeParserSuiteTemplate  {
 
   private val input = Input(
     baseType = DoubleType,

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
@@ -13,24 +13,23 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuites
+package za.co.absa.enceladus.standardization.interpreter.stages
 
-import org.apache.spark.sql.types.{ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType,
-  LongType, ShortType, StructField, TimestampType}
-import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate
+import org.apache.spark.sql.types.{ByteType, DataType, DateType, DoubleType, FloatType, IntegerType, LongType,
+  ShortType, StructField, TimestampType}
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
 import za.co.absa.enceladus.utils.time.DateTimePattern
 
-class TypeParserFromDecimalTypeSuite extends TypeParserSuiteTemplate  {
+class TypeParser_FromLongTypeSuite extends TypeParserSuiteTemplate {
 
   private val input = Input(
-    baseType = DecimalType(10, 4),
-    defaultValueDate = "700101",
-    defaultValueTimestamp = "991231.2359",
-    datePattern = "yyMMdd",
-    timestampPattern = "yyMMdd.HHmm",
-    fixedTimezone = "CST",
-    path = "hello"
+    baseType = LongType,
+    defaultValueDate = "20001010",
+    defaultValueTimestamp = "199912311201",
+    datePattern = "yyyyMMdd",
+    timestampPattern = "yyyyMMddHHmm",
+    fixedTimezone = "EST",
+    path = "Hey"
   )
 
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
@@ -49,8 +48,8 @@ class TypeParserFromDecimalTypeSuite extends TypeParserSuiteTemplate  {
   override protected def createErrorCondition(srcField: String, target: StructField, castS: String): String = {
     target.dataType match {
       case FloatType | DoubleType => s"(($castS IS NULL) OR isnan($castS)) OR ($castS IN (Infinity, -Infinity))"
-      case ByteType | ShortType | IntegerType | LongType =>
-        s"($castS IS NULL) OR (NOT ($srcField = CAST($castS AS ${input.baseType.sql})))"
+      case ByteType | ShortType | IntegerType =>
+        s"($castS IS NULL) OR (NOT (CAST(Hey.sourceField AS INT) = CAST(Hey.sourceField AS BIGINT)))"
       case _ => s"$castS IS NULL"
     }
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromTimestampTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromTimestampTypeSuite.scala
@@ -13,35 +13,35 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuites
+package za.co.absa.enceladus.standardization.interpreter.stages
 
-import org.apache.spark.sql.types.{BooleanType, DataType, DateType, DoubleType, FloatType, StructField, TimestampType}
-import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate
+import org.apache.spark.sql.types.{DataType, DateType, DoubleType, FloatType, StructField, TimestampType}
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
 import za.co.absa.enceladus.utils.time.DateTimePattern
 
-class TypeParserFromBooleanTypeSuite extends TypeParserSuiteTemplate  {
+class TypeParser_FromTimestampTypeSuite extends TypeParserSuiteTemplate  {
 
   private val input = Input(
-    baseType = BooleanType,
-    defaultValueDate = "0",
-    defaultValueTimestamp = "1",
-    datePattern = "u",
-    timestampPattern = "F",
-    fixedTimezone = "WST",
-    path = "Boo"
+    baseType = TimestampType,
+    defaultValueDate = "2000-01-01",
+    defaultValueTimestamp = "2010-12-31 23:59:59",
+    datePattern = "yyyy-MM-dd",
+    timestampPattern = "yyyy-MM-dd HH:mm:ss",
+    fixedTimezone = "CST",
+    path = "timestamp",
+    datetimeNeedsPattern = false
   )
 
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)                      => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)                 => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
-      case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
-      case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
-      case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"
-      case (DateType, _, _)                         => s"to_date(CAST(`%s` AS STRING), '$pattern')"
-      case _                                        => s"CAST(%s AS ${toType.sql})"
+      case (DateType, true, _)          => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
+      case (TimestampType, true, _)     => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (TimestampType, _, Some(tz)) => s"to_utc_timestamp(%s, $tz)"
+      case (DateType, _, Some(tz))      => s"to_date(to_utc_timestamp(`%s`, '$tz'))"
+      case (TimestampType, _, _)        => "%s"
+      case (DateType, _, _)             => "to_date(`%s`)"
+      case _                            => s"CAST(%s AS ${toType.sql})"
     }
   }
 


### PR DESCRIPTION
* Splitting up too long `StandardizationInterpreter.standardize` method
* Removed usage of `Random` for temporary error column names to decrease chance of name clash
* Removed var property within `StandardizationInterpreter` object
* Two unit tests to cover the refactoring doesn't change the logic
* `unpath` function to own trait
* `TypeParser` suits renamed per agreement from CQC