### PR TITLE
#415 Fix checkpoint measurements serialization by updating Atum to 0.2.1

### DIFF
--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -69,7 +69,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
     val expected = EmployeeConformance.conformedEmployees.sortBy(_.employee_id).toList
 
     // perform the write
-    conformed.coalesce(1).orderBy($"employee_id" asc).write.mode("overwrite").parquet("src/test/testData/_testOutput")
+    conformed.coalesce(1).orderBy($"employee_id".asc).write.mode("overwrite").parquet("src/test/testData/_testOutput")
 
     spark.disableControlMeasuresTracking()
 
@@ -87,8 +87,8 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
     assert(checkpoints.lengthCompare(9) == 0)
 
     checkpoints.foreach({ cp =>
-      assert(cp.controls(0).controlValue === 8)
-      assert(cp.controls(1).controlValue === 6)
+      assert(cp.controls(0).controlValue === "8")
+      assert(cp.controls(1).controlValue === "6")
     })
   }
 
@@ -141,9 +141,9 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
     assert(checkpoints.lengthCompare(11) == 0)
 
     checkpoints.foreach({ cp =>
-      assert(cp.controls(0).controlValue === 7)
-      assert(cp.controls(1).controlValue === 7)
-      assert(cp.controls(2).controlValue === 28)
+      assert(cp.controls(0).controlValue === "7")
+      assert(cp.controls(1).controlValue === "7")
+      assert(cp.controls(2).controlValue === "28")
     })
   }
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/samples/TradeConformance.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/samples/TradeConformance.scala
@@ -99,19 +99,19 @@ object TradeConformance {
       |          "controlName": "totalCount",
       |          "controlType": "controlType.count",
       |          "controlCol": "*",
-      |          "controlValue": 7
+      |          "controlValue": "7"
       |        },
       |        {
       |          "controlName": "countId",
       |          "controlType": "controlType.distinctCount",
       |          "controlCol": "id",
-      |          "controlValue": 7
+      |          "controlValue": "7"
       |        },
       |        {
       |          "controlName": "sumId",
       |          "controlType": "controlType.aggregatedTotal",
       |          "controlCol": "id",
-      |          "controlValue": 28
+      |          "controlValue": "28"
       |        }
       |      ]
       |    },
@@ -126,19 +126,19 @@ object TradeConformance {
       |          "controlName": "totalCount",
       |          "controlType": "controlType.count",
       |          "controlCol": "*",
-      |          "controlValue": 7
+      |          "controlValue": "7"
       |        },
       |        {
       |          "controlName": "countId",
       |          "controlType": "controlType.distinctCount",
       |          "controlCol": "id",
-      |          "controlValue": 7
+      |          "controlValue": "7"
       |        },
       |        {
       |          "controlName": "sumId",
       |          "controlType": "controlType.aggregatedTotal",
       |          "controlCol": "id",
-      |          "controlValue": 28
+      |          "controlValue": "28"
       |        }
       |      ]
       |    }

--- a/conformance/src/test/testData/employee/2017/11/01/_INFO
+++ b/conformance/src/test/testData/employee/2017/11/01/_INFO
@@ -24,13 +24,13 @@
           "controlName": "deptTotal",
           "controlType": "controlType.aggregatedTotal",
           "controlCol": "dept",
-          "controlValue": 8
+          "controlValue": "8"
         },
         {
           "controlName": "recordCount",
           "controlType": "controlType.Count",
           "controlCol": "employee_id",
-          "controlValue": 6
+          "controlValue": "6"
         }
       ]
     },
@@ -45,13 +45,13 @@
           "controlName": "deptTotal",
           "controlType": "controlType.aggregatedTotal",
           "controlCol": "dept",
-          "controlValue": 8
+          "controlValue": "8"
         },
         {
           "controlName": "recordCount",
           "controlType": "controlType.Count",
           "controlCol": "employee_id",
-          "controlValue": 6
+          "controlValue": "6"
         }
       ]
     }

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <maven.war.version>2.2</maven.war.version>
         <maven.ant.plugin.version>1.8</maven.ant.plugin.version>
         <!--dependency versions-->
-        <atum.version>0.1.3</atum.version>
+        <atum.version>0.2.1</atum.version>
         <junit.version>4.11</junit.version>
         <specs.version>2.4.16</specs.version>
         <scalatest.version>3.0.5</scalatest.version>


### PR DESCRIPTION
Atum 0.2.1 writes all control metrics as strings avoiding tricky number parsing issues.
The model of metrics still contain Any to retain compatibility with _INFO files provided
by source systems and for backward compatibility.