### PR TITLE
#440 Add a support for the simplest use case of COBOL data format

### DIFF
--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -212,6 +212,12 @@
             <artifactId>chart.js</artifactId>
             <version>2.7.3</version>
         </dependency>
+        <!-- Data formats -->
+        <dependency>
+            <groupId>za.co.absa.cobrix</groupId>
+            <artifactId>spark-cobol</artifactId>
+            <version>${cobrix.version}</version>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <spray.json.version>1.3.5</spray.json.version>
         <oozie.version>4.3.0</oozie.version>
         <htrace.version>3.1.0-incubating</htrace.version>
+        <cobrix.version>0.5.0</cobrix.version>
         <!--other properties-->
         <skip.integration.tests>true</skip.integration.tests>
         <scalastyle.configLocation>${project.basedir}/scalastyle-config.xml</scalastyle.configLocation>

--- a/standardization/pom.xml
+++ b/standardization/pom.xml
@@ -108,6 +108,11 @@
             <artifactId>enceladus-fixedWidth</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>za.co.absa.cobrix</groupId>
+            <artifactId>spark-cobol</artifactId>
+            <version>${cobrix.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/CmdConfig.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/CmdConfig.scala
@@ -163,11 +163,8 @@ object CmdConfig {
     help("help").text("prints this usage text")
 
     private def processCobolCmdOptions(): Unit = {
-      var copybookLocation: String = ""
-      var isXcom = false
       opt[String]("copybook").optional().action((value, config) => {
-        copybookLocation = value
-        config.copy(cobolOptions = Some(CobolOptions(copybookLocation, isXcom)))
+        config.copy(cobolOptions = cobolSetCopybook(config.cobolOptions, value))
       }).text("Path to a copybook for COBOL data format")
         .validate(value =>
           if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("cobol"))
@@ -177,14 +174,27 @@ object CmdConfig {
         )
 
       opt[Boolean]("is-xcom").optional().action((value, config) => {
-        isXcom = value
-        config.copy(cobolOptions = Some(CobolOptions(copybookLocation, isXcom)))
+        config.copy(cobolOptions = cobolSetIsXcom(config.cobolOptions, value))
       }).text("Does a mainframe file in COBOL format contain XCOM record headers")
         .validate(value =>
           if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("cobol"))
             success
           else
             failure("The --is-xcom option is supported only for COBOL data format"))
+    }
+
+    private def cobolSetCopybook(cobolOptions: Option[CobolOptions], newCopybook: String): Option[CobolOptions] = {
+      cobolOptions match {
+        case Some(a) => Some(a.copy(copybook = newCopybook))
+        case None => Some(CobolOptions(newCopybook))
+      }
+    }
+
+    private def cobolSetIsXcom(cobolOptions: Option[CobolOptions], newIsXCom: Boolean): Option[CobolOptions] = {
+      cobolOptions match {
+        case Some(a) => Some(a.copy(isXcom = newIsXCom))
+        case None => Some(CobolOptions(isXcom = newIsXCom))
+      }
     }
   }
 

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/CmdConfig.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/CmdConfig.scala
@@ -38,6 +38,7 @@ case class CmdConfig(datasetName: String = "",
     rowTag: Option[String] = None,
     csvDelimiter: Option[String] = None,
     csvHeader: Option[Boolean] = Some(false),
+    cobolOptions: Option[CobolOptions] = None,
     fixedWidthTrimValues: Option[Boolean] = Some(false),
     performanceMetricsFile: Option[String] = None,
     rawPathOverride: Option[String] = None,
@@ -148,6 +149,8 @@ object CmdConfig {
         else
           failure("The --trimValues option is supported only for fixed-width files "))
 
+    processCobolCmdOptions()
+
     opt[String]("performance-file").optional().action((value, config) =>
       config.copy(performanceMetricsFile = Some(value))).text("produce a performance metrics file at the given location (local filesystem)")
 
@@ -158,6 +161,31 @@ object CmdConfig {
       config.copy(folderPrefix = Some(value))).text("Adds a folder prefix before the date tokens")
 
     help("help").text("prints this usage text")
+
+    private def processCobolCmdOptions(): Unit = {
+      var copybookLocation: String = ""
+      var isXcom = false
+      opt[String]("copybook").optional().action((value, config) => {
+        copybookLocation = value
+        config.copy(cobolOptions = Some(CobolOptions(copybookLocation, isXcom)))
+      }).text("Path to a copybook for COBOL data format")
+        .validate(value =>
+          if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("cobol"))
+            success
+          else
+            failure("The --copybook option is supported only for COBOL data format")
+        )
+
+      opt[Boolean]("is-xcom").optional().action((value, config) => {
+        isXcom = value
+        config.copy(cobolOptions = Some(CobolOptions(copybookLocation, isXcom)))
+      }).text("Does a mainframe file in COBOL format contain XCOM record headers")
+        .validate(value =>
+          if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("cobol"))
+            success
+          else
+            failure("The --is-xcom option is supported only for COBOL data format"))
+    }
   }
 
 }

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/CobolOptions.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/CobolOptions.scala
@@ -18,11 +18,14 @@ package za.co.absa.enceladus.standardization
 /**
   * This is a class for COBOL format loading properties
   *
+  * Note: scopt requires all fields to have default values.
+  * Even if a field is mandatory it needs a default value.
+
   * @param copybook A location of a copybook
   * @param isXcom Does a mainframe file contain XCOM record headers
   */
 case class CobolOptions
 (
-  copybook: String,
-  isXcom: Boolean
+  copybook: String = "",
+  isXcom: Boolean = false
 )

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/CobolOptions.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/CobolOptions.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.standardization
+
+/**
+  * This is a class for COBOL format loading properties
+  *
+  * @param copybook A location of a copybook
+  * @param isXcom Does a mainframe file contain XCOM record headers
+  */
+case class CobolOptions
+(
+  copybook: String,
+  isXcom: Boolean
+)

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -125,18 +125,22 @@ object StandardizationJob {
 
   private def readerFormatSpecific(dfReader: DataFrameReader, cmd: CmdConfig): DataFrameReader = {
     // applying format specific options
-    val dfReader4 = {
-      val dfReader1 = if (cmd.rowTag.isDefined) dfReader.option("rowTag", cmd.rowTag.get) else dfReader
-      val dfReader2 = if (cmd.csvDelimiter.isDefined) dfReader1.option("delimiter", cmd.csvDelimiter.get) else dfReader1
-      val dfReader3 = if (cmd.csvHeader.isDefined) dfReader2.option("header", cmd.csvHeader.get) else dfReader2
-      val dfReader4 = if (cmd.rawFormat.equalsIgnoreCase("cobol")) applyCobolOptions(dfReader3, cmd) else dfReader3
-      dfReader4
+    val dfReaderWithOptions = {
+      val dfr1 = if (cmd.rowTag.isDefined) dfReader.option("rowTag", cmd.rowTag.get) else dfReader
+      val dfr2 = if (cmd.csvDelimiter.isDefined) dfr1.option("delimiter", cmd.csvDelimiter.get) else dfr1
+      val dfr3 = if (cmd.csvHeader.isDefined) dfr2.option("header", cmd.csvHeader.get) else dfr2
+      val dfr4 = if (cmd.rawFormat.equalsIgnoreCase("cobol")) applyCobolOptions(dfr3, cmd) else dfr3
+      dfr4
     }
     if (cmd.rawFormat.equalsIgnoreCase("fixed-width")) {
-      val dfReader5 = if (cmd.fixedWidthTrimValues.get) dfReader4.option("trimValues", "true") else dfReader4
-      dfReader5
+      val dfWithFixedWithOptions = if (cmd.fixedWidthTrimValues.get) {
+        dfReaderWithOptions.option("trimValues", "true")
+      } else {
+        dfReaderWithOptions
+      }
+      dfWithFixedWithOptions
     } else {
-      dfReader4
+      dfReaderWithOptions
     }
   }
 

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -129,13 +129,26 @@ object StandardizationJob {
       val dfReader1 = if (cmd.rowTag.isDefined) dfReader.option("rowTag", cmd.rowTag.get) else dfReader
       val dfReader2 = if (cmd.csvDelimiter.isDefined) dfReader1.option("delimiter", cmd.csvDelimiter.get) else dfReader1
       val dfReader3 = if (cmd.csvHeader.isDefined) dfReader2.option("header", cmd.csvHeader.get) else dfReader2
-      dfReader3
+      val dfReader4 = if (cmd.rawFormat.equalsIgnoreCase("cobol")) applyCobolOptions(dfReader3, cmd) else dfReader3
+      dfReader4
     }
     if (cmd.rawFormat.equalsIgnoreCase("fixed-width")) {
       val dfReader5 = if (cmd.fixedWidthTrimValues.get) dfReader4.option("trimValues", "true") else dfReader4
       dfReader5
     } else {
       dfReader4
+    }
+  }
+
+  private def applyCobolOptions(dfReader: DataFrameReader, cmd: CmdConfig): DataFrameReader = {
+    cmd.cobolOptions match {
+      case Some(opt) =>
+        dfReader
+          .option("copybook", opt.copybook)
+          .option("is_xcom", opt.isXcom)
+      case None =>
+        throw new IllegalArgumentException("A copybook location is not specified. Please use '--copybook' " +
+          "to specify a copybook location.")
     }
   }
 


### PR DESCRIPTION
This implementation is mostly for getting Cobrix dependencies.
COBOL options, like location of a copybook, etc will go to properties of dataset. 