### PR TITLE
#463 Add new metrics to Atum's metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <maven.rat.plugin.version>0.12</maven.rat.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
         <!--dependency versions-->
-        <atum.version>0.2.2</atum.version>
+        <atum.version>0.2.3</atum.version>
         <junit.version>4.11</junit.version>
         <specs.version>2.4.16</specs.version>
         <scalatest.version>3.0.5</scalatest.version>

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -341,7 +341,15 @@ object StandardizationJob {
     })
 
     measurement.flatMap(m =>
-      try Some(m.controlValue.toString.toLong)
+      try {
+        val rawCount = m.controlValue.toString.toLong
+        // Basic sanity check
+        if (rawCount >=0 ) {
+          Some(rawCount)
+        } else {
+          None
+        }
+      }
       catch {
         case NonFatal(_) => None
       }

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -103,7 +103,7 @@ object StandardizationJob {
     // Enable Menas plugin for Control Framework
     MenasPlugin.enableMenas(cmd.datasetName, cmd.datasetVersion, isJobStageOnly = true)
 
-    // Add report date and version (aka Enceladus info data and version) to Atum's metadata
+    // Add report date and version (aka Enceladus info date and version) to Atum's metadata
     Atum.setAdditionalInfo(s"enceladus_info_date" -> cmd.reportDate)
     Atum.setAdditionalInfo(s"enceladus_info_version" -> reportVersion.toString)
 
@@ -324,7 +324,6 @@ object StandardizationJob {
     Atum.setAdditionalInfo(s"raw_record_count" -> rawRecordCount.toString)
   }
 
-
   /**
     * Gets the number of records in raw data by traversing Atum's checkpoints.
     *
@@ -348,6 +347,5 @@ object StandardizationJob {
       }
     )
   }
-
 
 }

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -21,7 +21,6 @@ import java.text.MessageFormat
 import java.util.UUID
 
 import scala.util.control.NonFatal
-
 import org.apache.log4j.LogManager
 import org.apache.log4j.Logger
 import org.apache.spark.sql.Column
@@ -30,13 +29,11 @@ import org.apache.spark.sql.DataFrameReader
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
-
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-
 import za.co.absa.atum.AtumImplicits
 import za.co.absa.atum.AtumImplicits.DataSetWrapper
-import za.co.absa.atum.core.Atum
+import za.co.absa.atum.core.{Atum, Constants}
 import za.co.absa.enceladus.dao.EnceladusRestDAO
 import za.co.absa.enceladus.dao.menasplugin.MenasPlugin
 import za.co.absa.enceladus.model.Dataset
@@ -105,6 +102,10 @@ object StandardizationJob {
     Atum.setAllowUnpersistOldDatasets(true)
     // Enable Menas plugin for Control Framework
     MenasPlugin.enableMenas(cmd.datasetName, cmd.datasetVersion, isJobStageOnly = true)
+
+    // Add report date and version (aka Enceladus info data and version) to Atum's metadata
+    Atum.setAdditionalInfo(s"enceladus_info_date" -> cmd.reportDate)
+    Atum.setAdditionalInfo(s"enceladus_info_version" -> reportVersion.toString)
 
     // init performance measurer
     val performance = new PerformanceMeasurer(spark.sparkContext.appName)
@@ -196,6 +197,8 @@ object StandardizationJob {
       stdPath: String)(implicit spark: SparkSession, udfLib: UDFLibrary, fsUtils: FileSystemVersionUtils): Unit = {
     val rawDirSize: Long = fsUtils.getDirectorySize(path)
     performance.startMeasurement(rawDirSize)
+
+    addRawRecordCountToMetadata(dfAll)
 
     val std = try {
       StandardizationInterpreter.standardize(dfAll, schema, cmd.rawFormat)
@@ -303,4 +306,48 @@ object StandardizationJob {
       case Some(rawPathOverride) => rawPathOverride
     }
   }
+
+  /**
+    * Adds metadata about the number of records in raw data by checking Atum's checkpoints first.
+    * If raw record count is not available in checkpoints the method will calculate that count
+    * based on the provided raw dataframe.
+    *
+    * @return The number of records in a checkpoint corresponding to raw data (if available)
+    */
+  private def addRawRecordCountToMetadata(df: DataFrame): Unit = {
+    val checkpointRawRecordCount = getRawRecordCountFromCheckpoints
+
+    val rawRecordCount = checkpointRawRecordCount match {
+      case Some(num) => num
+      case None      => df.count
+    }
+    Atum.setAdditionalInfo(s"raw_record_count" -> rawRecordCount.toString)
+  }
+
+
+  /**
+    * Gets the number of records in raw data by traversing Atum's checkpoints.
+    *
+    * @return The number of records in a checkpoint corresponding to raw data (if available)
+    */
+  private def getRawRecordCountFromCheckpoints: Option[Long] = {
+    val controlMeasure = Atum.getControMeasure
+
+    val rawCheckpoint = controlMeasure
+      .checkpoints
+      .find(c => c.name.equalsIgnoreCase("raw") || c.workflowName.equalsIgnoreCase("raw"))
+
+    val measurement = rawCheckpoint.flatMap(chk => {
+      chk.controls.find(m => m.controlType.equalsIgnoreCase(Constants.controlTypeRecordCount))
+    })
+
+    measurement.flatMap(m =>
+      try Some(m.controlValue.toString.toLong)
+      catch {
+        case NonFatal(_) => None
+      }
+    )
+  }
+
+
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/performance/PerformanceMetricTools.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/performance/PerformanceMetricTools.scala
@@ -60,7 +60,7 @@ object PerformanceMetricTools {
     val inputDirSize = fsUtils.getDirectorySize(inputPath)
     val outputDirSize = fsUtils.getDirectorySize(outputPath)
 
-    val (numRecrdTotal, numRecordsFailed, numRecordsSuccessful, numOfErrors) = getNumberOfErrors(spark, outputPath)
+    val (numRecordsFailed, numRecordsSuccessful, numOfErrors) = getNumberOfErrors(spark, outputPath)
 
     if (doesSizeRatioMakesSense(inputDirSize, numRecordsFailed + numRecordsSuccessful)) {
       val percent = (outputDirSize.toDouble / inputDirSize.toDouble) * 100
@@ -74,7 +74,7 @@ object PerformanceMetricTools {
     Atum.setAdditionalInfo(s"${optionPrefix}_application_id" -> spark.sparkContext.applicationId)
     Atum.setAdditionalInfo(s"${optionPrefix}_username" -> loginUserName)
     Atum.setAdditionalInfo(s"${optionPrefix}_executors_num" -> s"$numberOfExecutrs")
-    Atum.setAdditionalInfo(s"${optionPrefix}_record_count" -> numRecrdTotal.toString)
+    Atum.setAdditionalInfo(s"${optionPrefix}_record_count" -> (numRecordsSuccessful + numRecordsFailed).toString)
     Atum.setAdditionalInfo(s"${optionPrefix}_records_succeeded" -> numRecordsSuccessful.toString)
     Atum.setAdditionalInfo(s"${optionPrefix}_records_failed" -> numRecordsFailed.toString)
     Atum.setAdditionalInfo(s"${optionPrefix}_errors_count" -> numOfErrors.toString)
@@ -95,13 +95,12 @@ object PerformanceMetricTools {
 
   /** Returns the number of records failed, the number of records succeeded and the total number of errors encountered
     * when running a Standardization or a Dynamic Conformance job. */
-  private def getNumberOfErrors(spark: SparkSession, outputPath: String): (Long, Long, Long, Long) = {
+  private def getNumberOfErrors(spark: SparkSession, outputPath: String): (Long, Long, Long) = {
     val df = spark.read.parquet(outputPath)
     val errorCountColumn = SchemaUtils.getClosestUniqueName("enceladus_error_count", df.schema)
     val errCol = col(ErrorMessage.errorColumnName)
     val numRecordsFailed = df.filter(size(errCol) > 0).count
     val numRecordsSuccessful = df.filter(size(errCol) === 0).count
-    val numTotal = df.count
 
     val numOfErrors = if (numRecordsFailed + numRecordsSuccessful > 0) {
       df.withColumn(errorCountColumn, size(errCol)).agg(sum(col(errorCountColumn)))
@@ -111,6 +110,6 @@ object PerformanceMetricTools {
       0
     }
 
-    (numTotal, numRecordsFailed, numRecordsSuccessful, numOfErrors)
+    (numRecordsFailed, numRecordsSuccessful, numOfErrors)
   }
 }


### PR DESCRIPTION
These metrics will help gethering statistics about data processed by Enceladus.
The list of new metrics: enceladus_info_date, enceladus_info_version,
raw_record_count, std_record_count, conform_record_count.
