### PR TITLE
#458: Column enceladus_info_date does not respect timezones

### DIFF
--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -88,7 +88,7 @@ object DynamicConformanceJob {
     // load data for input and mapping tables
     val inputData = DataSource.getData(stdPath, dateTokens(0), dateTokens(1), dateTokens(2), "")
 
-    val result = performTheConformance(conformance, inputData, enableCF)
+    val result = conform(conformance, inputData, enableCF)
 
     processResult(result, performance, publishPath, stdPath, reportVersion)
   }
@@ -172,8 +172,8 @@ object DynamicConformanceJob {
     performance
   }
 
-  private def performTheConformance(conformance: Dataset, inputData: sql.Dataset[Row], enableCF: Boolean)
-                                   (implicit spark: SparkSession, cmd: CmdConfig, fsUtils: FileSystemVersionUtils, dao: EnceladusDAO): DataFrame = {
+  private def conform(conformance: Dataset, inputData: sql.Dataset[Row], enableCF: Boolean)
+                     (implicit spark: SparkSession, cmd: CmdConfig, fsUtils: FileSystemVersionUtils, dao: EnceladusDAO): DataFrame = {
     try {
       DynamicInterpreter.interpret(conformance, inputData, isExperimentalRuleEnabled(), isCatalystWorkaroundEnabled(), enableCF)
     } catch {

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
@@ -24,7 +24,8 @@ import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
-import za.co.absa.enceladus.utils.testUtils.LogLevel
+import org.slf4j.event.Level._
+
 
 trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase {
 
@@ -53,9 +54,9 @@ trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase
       logger.error("ACTUAL:")
       logger.error(conformedJSON)
       logger.error("DETAILS (Input):")
-      logDataFrameContent(inputDf, LogLevel.Error)
+      logDataFrameContent(inputDf, ERROR)
       println("DETAILS (Conformed):")
-      logDataFrameContent(conformed, LogLevel.Error)
+      logDataFrameContent(conformed, ERROR)
       fail("Actual conformed dataset JSON does not match the expected JSON (see log).")
     }
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
@@ -24,7 +24,7 @@ import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase.LogLevel._
+import za.co.absa.enceladus.utils.testUtils.LogLevel
 
 trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase {
 
@@ -53,9 +53,9 @@ trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase
       logger.error("ACTUAL:")
       logger.error(conformedJSON)
       logger.error("DETAILS (Input):")
-      logDataFrameContent(inputDf, ERROR)
+      logDataFrameContent(inputDf, LogLevel.Error)
       println("DETAILS (Conformed):")
-      logDataFrameContent(conformed, ERROR)
+      logDataFrameContent(conformed, LogLevel.Error)
       fail("Actual conformed dataset JSON does not match the expected JSON (see log).")
     }
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
@@ -23,8 +23,10 @@ import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.LoggerTestBase.LogLevel._
 
-trait TestRuleBehaviors  extends FunSuite with SparkTestBase {
+trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase {
 
   def conformanceRuleShouldMatchExpected(inputDf: DataFrame, inputDataset: Dataset, expectedJSON: String) {
     implicit val dao: EnceladusDAO = mock(classOf[EnceladusDAO])
@@ -46,19 +48,15 @@ trait TestRuleBehaviors  extends FunSuite with SparkTestBase {
     val conformedJSON = conformed.orderBy($"id").toJSON.collect().mkString("\n")
 
     if (conformedJSON != expectedJSON) {
-      conformed.printSchema()
-      conformed.show
-      println("EXPECTED:")
-      println(expectedJSON)
-      println("ACTUAL:")
-      println(conformedJSON)
-      println("DETAILS (Input):")
-      inputDf.printSchema()
-      inputDf.show
+      logger.error("EXPECTED:")
+      logger.error(expectedJSON)
+      logger.error("ACTUAL:")
+      logger.error(conformedJSON)
+      logger.error("DETAILS (Input):")
+      logDataFrameContent(inputDf, ERROR)
       println("DETAILS (Conformed):")
-      conformed.printSchema()
-      conformed.show
-      fail("Actual conformed dataset JSON does not match the expected JSON (see above).")
+      logDataFrameContent(conformed, ERROR)
+      fail("Actual conformed dataset JSON does not match the expected JSON (see log).")
     }
 
   }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/OozieRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/OozieRepository.scala
@@ -23,9 +23,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Properties
 import java.util.TimeZone
-
 import scala.concurrent.Future
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.Path
@@ -38,12 +36,13 @@ import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
-
 import za.co.absa.enceladus.menas.exceptions.OozieConfigurationException
 import za.co.absa.enceladus.menas.models.OozieCoordinatorStatus
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.menas.scheduler.RuntimeConfig
 import za.co.absa.enceladus.menas.exceptions.EntityAlreadyExistsException
+import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
+import OozieRepository._
 
 @Repository
 class OozieRepository @Autowired() (oozieClientRes: Either[OozieConfigurationException, OozieClient],
@@ -83,12 +82,11 @@ class OozieRepository @Autowired() (oozieClientRes: Either[OozieConfigurationExc
   @Value("${za.co.absa.enceladus.menas.oozie.sparkConf.surroundingQuoteChar:}")
   val sparkConfQuotes: String = ""
 
-  private val classLoader = Thread.currentThread().getContextClassLoader()
+  private val classLoader = Thread.currentThread().getContextClassLoader
   private val workflowTemplate = getTemplateFile("scheduling/oozie/workflow_template.xml")
   private val coordinatorTemplate = getTemplateFile("scheduling/oozie/coordinator_template.xml")
   private val namenode = hadoopConf.get("fs.defaultFS")
   private val resourceManager = hadoopConf.get("yarn.resourcemanager.address")
-  private val dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'")
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   override def afterPropertiesSet() {
@@ -132,7 +130,7 @@ class OozieRepository @Autowired() (oozieClientRes: Either[OozieConfigurationExc
         case _ => logger.info(s"Standardization jar loaded to $hdfsStdPath")
       }
       resFutureStd.onFailure {
-        case (err: Throwable) =>
+        case err: Throwable =>
           hadoopFS.delete(hdfsStdPath, true)
       }
 
@@ -141,7 +139,7 @@ class OozieRepository @Autowired() (oozieClientRes: Either[OozieConfigurationExc
         case _ => logger.info(s"Conformance jar loaded to $hdfsConfPath")
       }
       resFutureConf.onFailure {
-        case (err: Throwable) =>
+        case err: Throwable =>
           hadoopFS.delete(hdfsConfPath, true)
       }
 
@@ -188,14 +186,14 @@ class OozieRepository @Autowired() (oozieClientRes: Either[OozieConfigurationExc
     this.validateProperties(logWarnings) && oozieClientRes.isRight
   }
 
-  private def getOozieClient[T](fn: (OozieClient => Future[T])): Future[T] = {
+  private def getOozieClient[T](fn: OozieClient => Future[T]): Future[T] = {
     oozieClientRes match {
       case Right(client) => fn(client)
       case Left(ex)      => Future.failed(ex)
     }
   }
 
-  private def getOozieClientWrap[T](fn: (OozieClient => T)): Future[T] = {
+  private def getOozieClientWrap[T](fn: OozieClient => T): Future[T] = {
     getOozieClient({ cl: OozieClient =>
       Future(fn(cl))
     })
@@ -361,5 +359,12 @@ class OozieRepository @Autowired() (oozieClientRes: Either[OozieConfigurationExc
     val coordPath = s"$namenode$oozieScheduleHDFSPath/menas-oozie-schedule-coord-${dataset.name}-${dataset.version + 1}/coordinator.xml"
     val content = getCoordinatorFromTemplate(dataset, wfPath)
     this.writeScheduleData(coordPath, content)
+  }
+}
+
+object OozieRepository {
+  private lazy val dateFormat = {
+    TimeZoneNormalizer.normalizeJVMTimeZone() //ensure time zone normalization before SimpleDateFormat creation
+    new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'")
   }
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/OozieRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/OozieRepository.scala
@@ -44,6 +44,14 @@ import za.co.absa.enceladus.menas.exceptions.EntityAlreadyExistsException
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 import OozieRepository._
 
+
+object OozieRepository {
+  private lazy val dateFormat = {
+    TimeZoneNormalizer.normalizeJVMTimeZone() //ensure time zone normalization before SimpleDateFormat creation
+    new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'")
+  }
+}
+
 @Repository
 class OozieRepository @Autowired() (oozieClientRes: Either[OozieConfigurationException, OozieClient],
     datasetMongoRepository: DatasetMongoRepository,
@@ -359,12 +367,5 @@ class OozieRepository @Autowired() (oozieClientRes: Either[OozieConfigurationExc
     val coordPath = s"$namenode$oozieScheduleHDFSPath/menas-oozie-schedule-coord-${dataset.name}-${dataset.version + 1}/coordinator.xml"
     val content = getCoordinatorFromTemplate(dataset, wfPath)
     this.writeScheduleData(coordPath, content)
-  }
-}
-
-object OozieRepository {
-  private lazy val dateFormat = {
-    TimeZoneNormalizer.normalizeJVMTimeZone() //ensure time zone normalization before SimpleDateFormat creation
-    new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'")
   }
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/DatasetService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/DatasetService.scala
@@ -31,7 +31,7 @@ class DatasetService @Autowired() (datasetMongoRepository: DatasetMongoRepositor
   import scala.concurrent.ExecutionContext.Implicits.global
 
   override def update(username: String, dataset: Dataset): Future[Option[Dataset]] = {
-      super.updateFuture(username, dataset.name, dataset.version) { latest =>
+    super.updateFuture(username, dataset.name, dataset.version) { latest =>
       updateSchedule(dataset, latest).map({ withSchedule =>
         withSchedule
           .setSchemaName(dataset.schemaName)
@@ -40,8 +40,9 @@ class DatasetService @Autowired() (datasetMongoRepository: DatasetMongoRepositor
           .setHDFSPublishPath(dataset.hdfsPublishPath)
           .setConformance(dataset.conformance)
           .setDescription(dataset.description).asInstanceOf[Dataset]
-        })
-      }
+        }
+      )
+    }
   }
 
   private def updateSchedule(newDataset: Dataset, latest: Dataset): Future[Dataset] = {

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/DatasetService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/DatasetService.scala
@@ -21,31 +21,28 @@ import za.co.absa.enceladus.model.conformanceRule.ConformanceRule
 import za.co.absa.enceladus.model.{Dataset, UsedIn}
 import za.co.absa.enceladus.menas.repositories.DatasetMongoRepository
 import scala.concurrent.Future
-import za.co.absa.enceladus.model.menas.MenasReference
 import za.co.absa.enceladus.menas.repositories.OozieRepository
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 import za.co.absa.enceladus.model.menas.scheduler.oozie.OozieScheduleInstance
 
 @Service
 class DatasetService @Autowired() (datasetMongoRepository: DatasetMongoRepository, oozieRepository: OozieRepository)
   extends VersionedModelService(datasetMongoRepository) {
 
-	import scala.concurrent.ExecutionContext.Implicits.global
+  import scala.concurrent.ExecutionContext.Implicits.global
 
-	override def update(username: String, dataset: Dataset): Future[Option[Dataset]] = {
-			super.updateFuture(username, dataset.name, dataset.version) { latest =>
-			this.updateSchedule(dataset, latest).map({ withSchedule =>
-			withSchedule
-			.setSchemaName(dataset.schemaName)
-			.setSchemaVersion(dataset.schemaVersion)
-			.setHDFSPath(dataset.hdfsPath)
-			.setHDFSPublishPath(dataset.hdfsPublishPath)
-			.setConformance(dataset.conformance)
-			.setDescription(dataset.description).asInstanceOf[Dataset]
-			})
-			}
-	}
+  override def update(username: String, dataset: Dataset): Future[Option[Dataset]] = {
+      super.updateFuture(username, dataset.name, dataset.version) { latest =>
+      updateSchedule(dataset, latest).map({ withSchedule =>
+        withSchedule
+          .setSchemaName(dataset.schemaName)
+          .setSchemaVersion(dataset.schemaVersion)
+          .setHDFSPath(dataset.hdfsPath)
+          .setHDFSPublishPath(dataset.hdfsPublishPath)
+          .setConformance(dataset.conformance)
+          .setDescription(dataset.description).asInstanceOf[Dataset]
+        })
+      }
+  }
 
   private def updateSchedule(newDataset: Dataset, latest: Dataset): Future[Dataset] = {
     if (newDataset.schedule == latest.schedule) {

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -70,14 +70,13 @@ object StandardizationJob {
 
     val reportVersion = cmd.reportVersion match {
       case Some(version) => version
-      case None => {
+      case None =>
         val newVersion = fsUtils.getLatestVersion(dataset.hdfsPublishPath, cmd.reportDate) + 1
         log.warn(s"Report version not provided, inferred report version: $newVersion")
         log.warn("This is an EXPERIMENTAL feature.")
         log.warn(" -> It can lead to issues when running multiple jobs on a dataset concurrently.")
         log.warn(" -> It may not work as desired when there are gaps in the versions of the data being landed.")
         newVersion
-      }
     }
 
     val path: String = buildRawPath(cmd, dataset, dateTokens, reportVersion)
@@ -100,7 +99,7 @@ object StandardizationJob {
     // init CF
     import za.co.absa.atum.AtumImplicits.SparkSessionWrapper
     spark.enableControlMeasuresTracking(s"$path/_INFO").setControlMeasuresWorkflow("Standardization")
-    
+
     // Enable control framework performance optimization for pipeline-like jobs
     Atum.setAllowUnpersistOldDatasets(true)
     // Enable Menas plugin for Control Framework
@@ -152,7 +151,7 @@ object StandardizationJob {
   private def applyCobolOptions(dfReader: DataFrameReader,
                                 cmd: CmdConfig,
                                 dataset: Dataset): DataFrameReader = {
-    val isXcom = cmd.cobolOptions.map(_.isXcom).getOrElse(false)
+    val isXcom = cmd.cobolOptions.exists(_.isXcom)
     val copybook = cmd.cobolOptions.map(_.copybook).getOrElse("")
 
     val reader = dfReader

--- a/testutils/src/test/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJobTest.scala
+++ b/testutils/src/test/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJobTest.scala
@@ -176,8 +176,8 @@ class ComparisonJobTest extends FunSuite with SparkTestBase with BeforeAndAfterE
     }
     val df = spark.read.format("parquet").load(outPath)
 
-    Console.withOut(outCapture) { df.show(false) }
-    val result = new String(outCapture.toByteArray).trim.split("\n").toList
+    import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
+    val result = df.dataAsString(false).split("\n").toList
 
     assert(lines == result)
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.implicits
+
+import java.io.ByteArrayOutputStream
+import org.apache.spark.sql.DataFrame
+
+object DataFrameImplicits {
+  implicit class DataFrameEnhancements(val df: DataFrame) {
+
+    private def gatherData(showFnc: () => Unit): String = {
+      val outCapture = new ByteArrayOutputStream
+      Console.withOut(outCapture) {
+        showFnc()
+      }
+      val dfData = new String(outCapture.toByteArray).replace("\r\n", "\n")
+      dfData
+    }
+
+    def dataAsString(): String = {
+      val showFnc: () => Unit = df.show
+      gatherData(showFnc)
+    }
+
+    def dataAsString(truncate: Boolean): String = {
+      val showFnc:  () => Unit = ()=>{df.show(truncate)}
+      gatherData(showFnc)
+    }
+
+    def dataAsString(numRows: Int, truncate: Boolean): String = {
+      val showFnc: ()=>Unit = () => df.show(numRows, truncate)
+      gatherData(showFnc)
+    }
+
+    def dataAsString(numRows: Int, truncate: Int): String = {
+      val showFnc: ()=>Unit = () => df.show(numRows, truncate)
+      gatherData(showFnc)
+    }
+
+    def dataAsString(numRows: Int, truncate: Int, vertical: Boolean): String = {
+      val showFnc: ()=>Unit = () => df.show(numRows, truncate, vertical)
+      gatherData(showFnc)
+    }
+
+  }
+
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/LoggerTestBase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/LoggerTestBase.scala
@@ -19,23 +19,23 @@ import java.io.ByteArrayOutputStream
 
 import org.apache.spark.sql.DataFrame
 import org.slf4j.{Logger, LoggerFactory}
+import LogLevel._
 
 trait LoggerTestBase {
-  import LoggerTestBase.LogLevel._
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def logLevelToLogFunction(logLevel: LogLevel): String => Unit = {
     logLevel match {
-      case TRACE => logger.trace
-      case DEBUG => logger.debug
-      case INFO  => logger.info
-      case WARN  => logger.warn
-      case _     => logger.error
+      case Trace => logger.trace
+      case Debug => logger.debug
+      case Info  => logger.info
+      case Warn  => logger.warn
+      case Error => logger.error
     }
   }
 
-  protected def logDataFrameContent(df: DataFrame, logLevel: LogLevel = DEBUG): Unit = {
+  protected def logDataFrameContent(df: DataFrame, logLevel: LogLevel = Debug): Unit = {
     val logFnc = logLevelToLogFunction(logLevel)
     logFnc(df.schema.treeString)
 
@@ -48,9 +48,12 @@ trait LoggerTestBase {
   }
 }
 
-object LoggerTestBase {
-  object LogLevel extends Enumeration {
-    type LogLevel = Value
-    val TRACE, DEBUG, INFO, WARN, ERROR = Value
-  }
+sealed trait LogLevel
+
+object LogLevel {
+  case object Trace extends LogLevel
+  case object Debug extends LogLevel
+  case object Info extends LogLevel
+  case object Warn extends LogLevel
+  case object Error extends LogLevel
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/LoggerTestBase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/LoggerTestBase.scala
@@ -19,41 +19,30 @@ import java.io.ByteArrayOutputStream
 
 import org.apache.spark.sql.DataFrame
 import org.slf4j.{Logger, LoggerFactory}
-import LogLevel._
+import org.slf4j.event.Level
+import org.slf4j.event.Level._
 
 trait LoggerTestBase {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  def logLevelToLogFunction(logLevel: LogLevel): String => Unit = {
+  def logLevelToLogFunction(logLevel: Level): String => Unit = {
     logLevel match {
-      case Trace => logger.trace
-      case Debug => logger.debug
-      case Info  => logger.info
-      case Warn  => logger.warn
-      case Error => logger.error
+      case TRACE => logger.trace
+      case DEBUG => logger.debug
+      case INFO  => logger.info
+      case WARN  => logger.warn
+      case ERROR => logger.error
     }
   }
 
-  protected def logDataFrameContent(df: DataFrame, logLevel: LogLevel = Debug): Unit = {
+  protected def logDataFrameContent(df: DataFrame, logLevel: Level = DEBUG): Unit = {
+    import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
+
     val logFnc = logLevelToLogFunction(logLevel)
     logFnc(df.schema.treeString)
 
-    val outCapture = new ByteArrayOutputStream
-    Console.withOut(outCapture) {
-      df.show(truncate = false)
-    }
-    val dfData = new String(outCapture.toByteArray).replace("\r\n", "\n")
+    val dfData = df.dataAsString(false)
     logFnc(dfData)
   }
-}
-
-sealed trait LogLevel
-
-object LogLevel {
-  case object Trace extends LogLevel
-  case object Debug extends LogLevel
-  case object Info extends LogLevel
-  case object Warn extends LogLevel
-  case object Error extends LogLevel
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.implicits
+
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
+import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+
+class DataFrameImplicitsSuite extends FunSuite with SparkTestBase  {
+  import spark.implicits._
+
+  private val columnName = "data"
+  private val inputDataSeq = Seq(
+    "0123456789012345678901234",
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z"
+  )
+  private val inputData = inputDataSeq.toDF(columnName)
+
+  private def cellText(text: String, width: Int, leftAlign: Boolean): String = {
+    val pad = " " * (width - text.length)
+    if (leftAlign) {
+      text + pad
+    } else {
+      pad + text
+    }
+  }
+
+  private def line(width: Int): String = {
+    "+" + "-" * width + "+"
+  }
+
+  private def header(width: Int, leftAlign: Boolean): String = {
+    val lineStr = line(width)
+    val title = cellText(columnName, width, leftAlign)
+    s"$lineStr\n|$title|\n$lineStr"
+  }
+
+  private def cell(text: String, width: Int, leftAlign: Boolean): String = {
+    val inner = if (text.length > width) {
+      text.substring(0, width - 3) + "..."
+    } else {
+      cellText(text, width, leftAlign)
+    }
+    s"|$inner|"
+  }
+
+  private def inputDataToString(width: Int, leftAlign: Boolean, limit: Option[Int] = Option(20)): String = {
+    val (extraLine, seq) = limit match {
+      case Some(n) =>
+        val line =  if (inputDataSeq.length > n) {
+          s"only showing top $n rows\n"
+        } else {
+          ""
+        }
+        (line, inputDataSeq.take(n))
+      case None    =>
+        ("", inputDataSeq)
+    }
+    seq.foldLeft(header(width, leftAlign)) { (acc, item) =>
+      acc + "\n" + cell(item, width, leftAlign)
+    } + "\n" + line(width) + s"\n$extraLine\n"
+  }
+
+  test("Like show()") {
+    val result = inputData.dataAsString()
+    val leftAlign = false
+    val cellWidth = 20
+    val expected = inputDataToString(cellWidth, leftAlign)
+
+    assert(result == expected)
+  }
+
+  test("Like show(false)") {
+    val result = inputData.dataAsString(false)
+    val leftAlign = true
+    val cellWidth = 25
+    val expected = inputDataToString(cellWidth, leftAlign)
+
+    assert(result == expected)
+  }
+
+  test("Like show(3, true)") {
+    val result = inputData.dataAsString(3, true)
+    val leftAlign = false
+    val cellWidth = 20
+    val expected = inputDataToString(cellWidth, leftAlign, Option(3))
+
+    assert(result == expected)
+  }
+
+  test("Like show(30, false)") {
+    val result = inputData.dataAsString(30, false)
+    val leftAlign = true
+    val cellWidth = 25
+    val expected = inputDataToString(cellWidth, leftAlign, Option(30))
+
+    assert(result == expected)
+  }
+
+
+  test("Like show(10, 10)") {
+    val result = inputData.dataAsString(10, 10)
+    val leftAlign = false
+    val cellWidth = 10
+    val expected = inputDataToString(cellWidth, leftAlign, Option(10))
+
+    assert(result == expected)
+  }
+
+  test("Like show(50, 50, false)") {
+    val result = inputData.dataAsString(50, 50, false)
+    val leftAlign = false
+    val cellWidth = 25
+    val expected = inputDataToString(cellWidth, leftAlign, Option(50))
+
+    assert(result == expected)
+  }
+}


### PR DESCRIPTION
* simplifying the expression for enceladus_info_date, avoiding the source of problems (DynamicConformanceJob.processResult)
* Ensuring simpleDateFormat is created only after TimeZoneNormalizer logic is executed
* LoggerTestBase enhancement
* DynamicConformanceJob.main broke up into subroutines to make it shorter (hopefully clearer too)
* conformanceRuleShouldMatchExpected uses logger instead of println (not related to bug, spotted on bug investigation)
* Some stylistic adjustments

(Source of the bug - SimpleDateFormat was created before TimeZoneNormalizer logic, which bound that instance to the system time zone.