### PR TITLE
#458: Column enceladus_info_date does not respect time zones (optional improvement)

### DIFF
--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -169,7 +169,7 @@ object DynamicConformanceJob {
     val spark: SparkSession = SparkSession.builder()
       .appName("Dynamic Conformance")
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
+    TimeZoneNormalizer.normalizeSessionTimeZone(spark)
     spark
   }
 

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
@@ -36,7 +36,7 @@ object CustomRuleSample1 {
 
   def main(args: Array[String]) {
     // scalastyle:off magic.number
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
+    TimeZoneNormalizer.normalizeSessionTimeZone(spark)
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: EnceladusDAO = EnceladusRestDAO // you may have to hard-code your own implementation here (if not working with menas)
     val experimentalMR = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
@@ -36,7 +36,7 @@ object CustomRuleSample2 {
 
   def main(args: Array[String]) {
     // scalastyle:off magic.number
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
+    TimeZoneNormalizer.normalizeSessionTimeZone(spark)
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: EnceladusDAO = EnceladusRestDAO // you may have to hard-code your own implementation here (if not working with menas)
     val experimentalMR = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
@@ -33,7 +33,7 @@ object CustomRuleSample3 {
   spark.sparkContext.setLogLevel("WARN")
 
   def main(args: Array[String]): Unit = {
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
+    TimeZoneNormalizer.normalizeSessionTimeZone(spark)
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: EnceladusDAO = EnceladusRestDAO // you may have to hard-code your own implementation here (if not working with menas)
     val experimentalMR = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
@@ -123,7 +123,7 @@ object CustomRuleSample4 {
       .appName("CustomRuleSample4")
       .config("spark.sql.codegen.wholeStage", value = false)
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(result))
+    TimeZoneNormalizer.normalizeSessionTimeZone(result)
     result
   }
 

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/SparkConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/SparkConfig.scala
@@ -34,7 +34,7 @@ class SparkConfig {
       .config("spark.driver.bindAddress","127.0.0.1")
       .appName("Menas Spark controller")
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(sparkSession))
+    TimeZoneNormalizer.normalizeSessionTimeZone(sparkSession)
     sparkSession
   }
 

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -100,7 +100,7 @@ object StandardizationJob {
     // init CF
     import za.co.absa.atum.AtumImplicits.SparkSessionWrapper
     spark.enableControlMeasuresTracking(s"$path/_INFO").setControlMeasuresWorkflow("Standardization")
-    
+
     // Enable control framework performance optimization for pipeline-like jobs
     Atum.setAllowUnpersistOldDatasets(true)
     // Enable Menas plugin for Control Framework
@@ -124,7 +124,7 @@ object StandardizationJob {
     val spark = SparkSession.builder()
       .appName("Standardisation")
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
+    TimeZoneNormalizer.normalizeSessionTimeZone(spark)
     spark
   }
 

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
@@ -41,7 +41,7 @@ object ComparisonJob {
       .appName(s"Dataset comparison - '${cmd.newPath}' and '${cmd.refPath}'")
       .config("spark.sql.codegen.wholeStage", enableWholeStage)
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(sparkSession))
+    TimeZoneNormalizer.normalizeSessionTimeZone(sparkSession)
 
     implicit val sc: SparkContext = sparkSession.sparkContext
 

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/rest/RestRunnerJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/rest/RestRunnerJob.scala
@@ -40,7 +40,7 @@ object RestRunnerJob {
       .appName(s"Rest call test from - '${cmd.testDataPath}")
       .config("spark.sql.codegen.wholeStage", enableWholeStage)
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(sparkSession))
+    TimeZoneNormalizer.normalizeSessionTimeZone(sparkSession)
 
     implicit val sc: SparkContext = sparkSession.sparkContext
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkTestBase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkTestBase.scala
@@ -63,7 +63,7 @@ trait SparkTestBase { self =>
       .getOrCreate()
   }
 
-  TimeZoneNormalizer.normalizeAll(Seq(spark))
+  TimeZoneNormalizer.normalizeSessionTimeZone(spark)
 
   // Do not display INFO entries for tests
   Logger.getLogger("org").setLevel(Level.WARN)

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
@@ -28,6 +28,8 @@ object TimeZoneNormalizer {
   private val log: Logger = LogManager.getLogger(this.getClass)
   private lazy val timeZone: String = getConf("timezone", "UTC")
 
+  normalizeJVMTimeZone()
+
   private def getConf(path: String, default: String): String = {
     val config: Config = ConfigFactory.load()
     if (config.hasPath(path)) {
@@ -38,6 +40,11 @@ object TimeZoneNormalizer {
     }
   }
 
+  /**
+    * This is just an empty function suitable to be called to ensure the object is created and therefore JVM time zone normalized
+    */
+  def activate(): Unit = {}
+
   def normalizeJVMTimeZone(): Unit = {
     TimeZone.setDefault(TimeZone.getTimeZone(timeZone))
     log.debug(s"JVM time zone set to $timeZone")
@@ -47,10 +54,4 @@ object TimeZoneNormalizer {
     spark.conf.set("spark.sql.session.timeZone", timeZone)
     log.debug(s"Spark session ${spark.sparkContext.applicationId} time zone of name ${spark.sparkContext.appName} set to $timeZone")
   }
-
-  def normalizeAll(spars: Seq[SparkSession]): Unit = {
-    normalizeJVMTimeZone()
-    spars.foreach(normalizeSessionTimeZone)
-  }
-
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
@@ -23,7 +23,7 @@ import java.util.TimeZone
 case class TestInputRow(id: Int, stringField: String)
 
 class EnceladusDateTimeParserSuite extends FunSuite{
-  TimeZoneNormalizer.normalizeJVMTimeZone()
+  TimeZoneNormalizer.activate()
 
   test("EnceladusDateParser class epoch") {
     val parser = EnceladusDateTimeParser("epoch")

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDateSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDateSuite.scala
@@ -21,7 +21,7 @@ import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue, ValidationWarning}
 
 class FieldValidatorDateSuite extends FunSuite  {
-  TimeZoneNormalizer.normalizeJVMTimeZone()
+  TimeZoneNormalizer.activate()
 
   private def field(pattern: String, defaultValue: Option[String] = None, defaultTimeZone: Option[String] = None): StructField = {
     val builder = new MetadataBuilder().putString("pattern",pattern)

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestampSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestampSuite.scala
@@ -21,7 +21,7 @@ import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue, ValidationWarning}
 
 class FieldValidatorTimestampSuite extends FunSuite  {
-  TimeZoneNormalizer.normalizeJVMTimeZone()
+  TimeZoneNormalizer.activate()
 
   private def field(pattern: String, defaultValue: Option[String] = None, defaultTimeZone: Option[String] = None): StructField = {
     val builder = new MetadataBuilder().putString("pattern",pattern)


### PR DESCRIPTION
* Changing TimeZoneNormalizer to normalize JVM time zone upon the object instantiation, in other words as soon as possible