### PR TITLE
#636 Automatically invalidate static resources on new deployment

### DIFF
--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -23,7 +23,7 @@ spring.servlet.multipart.max-request-size=16MB
 # Number of seconds to cache the static resources for
 spring.resources.cache.cachecontrol.max-age=2678000
 spring.resources.chain.strategy.fixed.enabled=true
-spring.resources.chain.strategy.fixed.paths=/webjars/**,/components/**,/css/**,/generic/**,/service/**
+spring.resources.chain.strategy.fixed.paths=/components/**,/css/**,/generic/**,/service/**
 spring.resources.chain.strategy.fixed.version=@project.version@
 
 # How will users authenticate to menas. Available options: inmemory, kerberos

--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -22,6 +22,9 @@ spring.servlet.multipart.max-request-size=16MB
 
 # Number of seconds to cache the static resources for
 spring.resources.cache.cachecontrol.max-age=2678000
+spring.resources.chain.strategy.fixed.enabled=true
+spring.resources.chain.strategy.fixed.paths=/webjars/**,/components/**,/css/**,/generic/**,/service/**
+spring.resources.chain.strategy.fixed.version=@project.version@
 
 # How will users authenticate to menas. Available options: inmemory, kerberos
 za.co.absa.enceladus.menas.auth.mechanism = inmemory

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
@@ -50,6 +50,9 @@ class WebSecurityConfig {
   @Value("${za.co.absa.enceladus.menas.auth.mechanism:}")
   val authMechanism: String = ""
 
+  @Value("${za.co.absa.enceladus.menas.version}")
+  val menasVersion: String = ""
+
   @Autowired
   val beanFactory: BeanFactory = null
 
@@ -83,7 +86,7 @@ class WebSecurityConfig {
         .authorizeRequests()
           .antMatchers("/index.html", "/resources/**", "/generic/**",
             "/service/**", "/webjars/**", "/css/**", "/components/**", 
-            "/api/oozie/isEnabled")
+            "/api/oozie/isEnabled", "/api/user/version", s"/$menasVersion/**")
           .permitAll()
         .anyRequest()
           .authenticated()

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/UserInfoController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/UserInfoController.scala
@@ -44,4 +44,8 @@ class UserInfoController extends BaseController {
     UserInfo(principal.getUsername, groups, menasVersion)
   }
 
+  @GetMapping(path = Array("/version"))
+  def getVersion(): String = {
+    menasVersion
+  }
 }

--- a/menas/ui/components/app.controller.js
+++ b/menas/ui/components/app.controller.js
@@ -33,6 +33,13 @@ sap.ui.define([
 
       this._app = this.byId("menasApp");
 
+      // register TNT icons
+      sap.ui.core.IconPool.registerFont({
+        collectionName: "SAP-icons-TNT",
+        fontFamily: "SAP-icons-TNT", 
+        fontURI: sap.ui.require.toUrl("sap/tnt/themes/base/fonts"),
+        lazy: true});
+
       this._model = sap.ui.getCore().getModel();
 
       this.getView().setModel(sap.ui.getCore().getModel());
@@ -118,10 +125,6 @@ sap.ui.define([
 
     onLogout: function () {
       this._router.navTo("root");
-    },
-
-    onAfterRendering: function () {
-      component.setBusy(false);
     }
 
   });

--- a/menas/ui/components/run/runDetail.controller.js
+++ b/menas/ui/components/run/runDetail.controller.js
@@ -55,15 +55,6 @@ sap.ui.define([
       } else {
         RunService.getRun(this._detail, this._checkpointsTable, oParams.dataset, oParams.version, oParams.id)
       }
-    },
-
-    /**
-     * Called when the View has been rendered (so its HTML is part of the document). Post-rendering manipulations of the HTML could be done here.
-     * This hook is the same one that SAPUI5 controls get after being rendered.
-     * @memberOf menas.main
-     */
-    onAfterRendering: function () {
-      component.setBusy(false)
     }
 
   });

--- a/menas/ui/index.html
+++ b/menas/ui/index.html
@@ -17,10 +17,20 @@
 
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv='Content-Type' content='text/html;charset=UTF-8'/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv='Content-Type' content='text/html;charset=UTF-8' />
 
-    <script>
+<script src="webjars/openui5/sap-ui-core.js" id="sap-ui-bootstrap"
+  data-sap-ui-compatVersion="edge"
+  data-sap-ui-libs="sap.m,sap.ui.table,sap.ui.layout"
+  data-sap-ui-bindingSyntax="complex"
+  data-sap-ui-theme='sap_belize'></script>
+  
+<script src="webjars/momentjs/min/moment.min.js"></script>
+<script src="webjars/lodash/lodash.js"></script>
+<script src="webjars/cronstrue-webjar/cronstrue-webjar.js"></script>
+
+<script>
       function _menasLoadElem(sElemType, sSrc, aAttrs, fnOnLoad) {
         const el = document.createElement(sElemType);
         const srcAttr = sElemType === "link" ? "href" : "src";
@@ -44,68 +54,58 @@
             {k: "type", v: "text/css"},
             {k: "rel", v: "stylesheet"}
           ]);
-          _menasLoadElem("script", "webjars/momentjs/2.22.2/min/moment.min.js", []);
-          _menasLoadElem("script", "webjars/lodash/4.17.10/lodash.js", []);
-          _menasLoadElem("script", "webjars/cronstrue-webjar/1.79.0/cronstrue-webjar.js", []);
-          _menasLoadElem("script", "webjars/openui5/1.65.1/sap-ui-core.js", [
-            {k: "id", v: "sap-ui-bootstrap"},
-            {k: "data-sap-ui-compatVersion", v: "edge"},
-            {k: "data-sap-ui-libs", v: "sap.m,sap.ui.table,sap.ui.layout"},
-            {k: "data-sap-ui-bindingSyntax", v: "complex"},
-            {k: "data-sap-ui-theme", v: "sap_belize"}
-          ], function(){
-            //Load deps which require sap on load
-            sap.ui.getCore().attachInit(function() {
-              _menasLoadElem("script", "generic/model.js", []);
-              _menasLoadElem("script", "generic/prop.js", []);
-              _menasLoadElem("script", "generic/functions.js", []);
-              _menasLoadElem("script", "generic/formatters.js", []);
-              _menasLoadElem("script", "service/ValidationResult.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRule.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/SchemaManager.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/MappingConformanceRule/JoinConditionDialog.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/MappingConformanceRule/JoinConditionDialogFactory.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/ConcatenationConformanceRule/ConcatenationColumnDialog.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/ConcatenationConformanceRule/ConcatenationColumnDialogFactory.js", []);
-              _menasLoadElem("script", "components/SchemaTable.js", []);
-              _menasLoadElem("script", "service/MessageProvider.js", []);
-              _menasLoadElem("script", "service/RestDAO.js", []);
-              _menasLoadElem("script", "service/RunRestDAO.js", []);
-              _menasLoadElem("script", "service/EntityService.js", []);
-              _menasLoadElem("script", "service/GenericService.js", []);
-              _menasLoadElem("script", "service/MonitoringService.js", []);
-              _menasLoadElem("script", "service/RuleService.js", []);
-              _menasLoadElem("script", "service/OozieService.js", []);
-              _menasLoadElem("script", "service/RunService.js", []);
-              _menasLoadElem("script", "service/EntityDialog.js", []);
-              _menasLoadElem("script", "service/DialogFactory.js", []);
-              _menasLoadElem("script", "service/EntityValidationService.js", []);
-              _menasLoadElem("script", "service/SchemaFieldSelector.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleDialog.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleForm.js", []);
-              _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleFormFactory.js", [], function() {
 
-                sap.ui.loader.config({
-                  async: true,
-                  paths: {
-                    'components': `${window.menasVersion}/components/`
-                  }
-                });
+          //Load deps which require sap on load
+          sap.ui.getCore().attachInit(function() {
+            _menasLoadElem("script", "generic/model.js", []);
+            _menasLoadElem("script", "generic/prop.js", []);
+            _menasLoadElem("script", "generic/functions.js", []);
+            _menasLoadElem("script", "generic/formatters.js", []);
+            _menasLoadElem("script", "service/ValidationResult.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRule.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/SchemaManager.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/MappingConformanceRule/JoinConditionDialog.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/MappingConformanceRule/JoinConditionDialogFactory.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/ConcatenationConformanceRule/ConcatenationColumnDialog.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/ConcatenationConformanceRule/ConcatenationColumnDialogFactory.js", []);
+            _menasLoadElem("script", "components/SchemaTable.js", []);
+            _menasLoadElem("script", "service/MessageProvider.js", []);
+            _menasLoadElem("script", "service/RestDAO.js", []);
+            _menasLoadElem("script", "service/RunRestDAO.js", []);
+            _menasLoadElem("script", "service/EntityService.js", []);
+            _menasLoadElem("script", "service/GenericService.js", []);
+            _menasLoadElem("script", "service/MonitoringService.js", []);
+            _menasLoadElem("script", "service/RuleService.js", []);
+            _menasLoadElem("script", "service/OozieService.js", []);
+            _menasLoadElem("script", "service/RunService.js", []);
+            _menasLoadElem("script", "service/EntityDialog.js", []);
+            _menasLoadElem("script", "service/DialogFactory.js", []);
+            _menasLoadElem("script", "service/EntityValidationService.js", []);
+            _menasLoadElem("script", "service/SchemaFieldSelector.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleDialog.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleForm.js", []);
+            _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleFormFactory.js", [], function() {
 
-                var component = new sap.ui.core.ComponentContainer("MenasComponent", {
-                    name: "components",
-                });
-
-                component.placeAt("content");
+              sap.ui.loader.config({
+                async: true,
+                paths: {
+                  'components': `${window.menasVersion}/components/`
+                }
               });
-            })
-          });
+
+              var component = new sap.ui.core.ComponentContainer("MenasComponent", {
+                  name: "components",
+              });
+
+              component.placeAt("content");
+              });
+            });
         })
       })
     </script>
 
 </head>
 <body class="sapUiBody" role="application">
-    <div id="content"></div>
+  <div id="content"></div>
 </body>
 </html>

--- a/menas/ui/index.html
+++ b/menas/ui/index.html
@@ -20,65 +20,88 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv='Content-Type' content='text/html;charset=UTF-8'/>
 
-    <link type="text/css" href="css/style.css" rel="stylesheet"/>
-
-    <script src="webjars/openui5/sap-ui-core.js" id="sap-ui-bootstrap"
-            data-sap-ui-compatVersion="edge"
-            data-sap-ui-libs="sap.m,sap.ui.table,sap.ui.layout"
-            data-sap-ui-bindingSyntax="complex"
-            data-sap-ui-theme='sap_belize'>
-    </script>
-    <script src="webjars/momentjs/min/moment.min.js"></script>
-    <script src="webjars/lodash/lodash.js"></script>
-    <script src="webjars/cronstrue-webjar/cronstrue-webjar.js"></script>
-    <script src="generic/model.js"></script>
-    <script src="generic/prop.js"></script>
-    <script src="generic/functions.js"></script>
-    <script src="generic/formatters.js"></script>
-    <script src="service/ValidationResult.js"></script>
-    <script src="components/dataset/conformanceRule/ConformanceRule.js"></script>
-    <script src="components/dataset/conformanceRule/SchemaManager.js"></script>
-    <script src="components/dataset/conformanceRule/MappingConformanceRule/JoinConditionDialog.js"></script>
-    <script src="components/dataset/conformanceRule/MappingConformanceRule/JoinConditionDialogFactory.js"></script>
-    <script src="components/dataset/conformanceRule/ConcatenationConformanceRule/ConcatenationColumnDialog.js"></script>
-    <script src="components/dataset/conformanceRule/ConcatenationConformanceRule/ConcatenationColumnDialogFactory.js"></script>
-    <script src="components/SchemaTable.js"></script>
-    <script src="service/MessageProvider.js"></script>
-    <script src="service/RestDAO.js"></script>
-    <script src="service/RunRestDAO.js"></script>
-    <script src="service/EntityService.js"></script>
-    <script src="service/GenericService.js"></script>
-    <script src="service/MonitoringService.js"></script>
-    <script src="service/RuleService.js"></script>
-    <script src="service/OozieService.js"></script>
-    <script src="service/RunService.js"></script>
-    <script src="service/EntityDialog.js"></script>
-    <script src="service/DialogFactory.js"></script>
-    <script src="service/EntityValidationService.js"></script>
-    <script src="service/SchemaFieldSelector.js"></script>
-    <script src="components/dataset/conformanceRule/ConformanceRuleDialog.js"></script>
-    <script src="components/dataset/conformanceRule/ConformanceRuleForm.js"></script>
-    <script src="components/dataset/conformanceRule/ConformanceRuleFormFactory.js"></script>
-
-    <!-- only load the mobile lib "sap.m" and the "sap_bluecrystal" theme -->
-
     <script>
-        sap.ui.localResources("components");
-        
-        // register TNT icons
-        sap.ui.core.IconPool.registerFont({
-          collectionName: "SAP-icons-TNT",
-          fontFamily: "SAP-icons-TNT", 
-          fontURI: sap.ui.require.toUrl("sap/tnt/themes/base/fonts"),
-          lazy: true});
+      function _menasLoadElem(sElemType, sSrc, aAttrs, fnOnLoad) {
+        const el = document.createElement(sElemType);
+        const srcAttr = sElemType === "link" ? "href" : "src";
+        el[srcAttr] = `${window.menasVersion}/${sSrc}`;
+        aAttrs.forEach((attr) => {
+          el.setAttribute(attr.k, attr.v);
+        })
+        if(fnOnLoad) {
+          el.addEventListener("load", fnOnLoad);
+        }
+        document.getElementsByTagName("head").item(0).append(el);
+      }
+      
+      fetch("api/user/version").then((resp) => {
+        resp.body.getReader().read().then((versionEnc) => {
+          const decoder = new TextDecoder("utf-8")
+          const version = decoder.decode(versionEnc.value);
+          window.menasVersion = version;
 
-        var component = new sap.ui.core.ComponentContainer("MenasComponent", {
-            name: "components",
-        });
+          _menasLoadElem("link", "css/style.css", [
+            {k: "type", v: "text/css"},
+            {k: "rel", v: "stylesheet"}
+          ]);
+          _menasLoadElem("script", "webjars/momentjs/2.22.2/min/moment.min.js", []);
+          _menasLoadElem("script", "webjars/lodash/4.17.10/lodash.js", []);
+          _menasLoadElem("script", "webjars/cronstrue-webjar/1.79.0/cronstrue-webjar.js", []);
+          _menasLoadElem("script", "webjars/openui5/1.65.1/sap-ui-core.js", [
+            {k: "id", v: "sap-ui-bootstrap"},
+            {k: "data-sap-ui-compatVersion", v: "edge"},
+            {k: "data-sap-ui-libs", v: "sap.m,sap.ui.table,sap.ui.layout"},
+            {k: "data-sap-ui-bindingSyntax", v: "complex"},
+            {k: "data-sap-ui-theme", v: "sap_belize"}
+          ], function(){
+            //Load deps which require sap on load
+            sap.ui.getCore().attachInit(function() {
+              _menasLoadElem("script", "generic/model.js", []);
+              _menasLoadElem("script", "generic/prop.js", []);
+              _menasLoadElem("script", "generic/functions.js", []);
+              _menasLoadElem("script", "generic/formatters.js", []);
+              _menasLoadElem("script", "service/ValidationResult.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRule.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/SchemaManager.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/MappingConformanceRule/JoinConditionDialog.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/MappingConformanceRule/JoinConditionDialogFactory.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/ConcatenationConformanceRule/ConcatenationColumnDialog.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/ConcatenationConformanceRule/ConcatenationColumnDialogFactory.js", []);
+              _menasLoadElem("script", "components/SchemaTable.js", []);
+              _menasLoadElem("script", "service/MessageProvider.js", []);
+              _menasLoadElem("script", "service/RestDAO.js", []);
+              _menasLoadElem("script", "service/RunRestDAO.js", []);
+              _menasLoadElem("script", "service/EntityService.js", []);
+              _menasLoadElem("script", "service/GenericService.js", []);
+              _menasLoadElem("script", "service/MonitoringService.js", []);
+              _menasLoadElem("script", "service/RuleService.js", []);
+              _menasLoadElem("script", "service/OozieService.js", []);
+              _menasLoadElem("script", "service/RunService.js", []);
+              _menasLoadElem("script", "service/EntityDialog.js", []);
+              _menasLoadElem("script", "service/DialogFactory.js", []);
+              _menasLoadElem("script", "service/EntityValidationService.js", []);
+              _menasLoadElem("script", "service/SchemaFieldSelector.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleDialog.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleForm.js", []);
+              _menasLoadElem("script", "components/dataset/conformanceRule/ConformanceRuleFormFactory.js", [], function() {
 
-        component.placeAt("content");
+                sap.ui.loader.config({
+                  async: true,
+                  paths: {
+                    'components': `${window.menasVersion}/components/`
+                  }
+                });
 
-        component.setBusy(true);
+                var component = new sap.ui.core.ComponentContainer("MenasComponent", {
+                    name: "components",
+                });
+
+                component.placeAt("content");
+              });
+            })
+          });
+        })
+      })
     </script>
 
 </head>


### PR DESCRIPTION
- uses the fixed version resolver in Spring
- index first gets the version from the API
     - then programmatically loads all the dependencies with the
        version prefix
     - only on load of the last dependency do we initialize the
        component container (which is configured to load all
        local resources with the version prefix)

This changes requires the 3 new properties in application
properties.

@GeorgiChochov any idea if the webjar locator can be configured for the versioned resources somehow?