### PR TITLE
Bugfix/466 standardization support for second fractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ To enable processing of time entries from other systems **Standardization** offe
 string and even numeric values to timestamp or date types. It's done using Spark's ability to convert strings to 
 timestamp/date with some enhancements. The pattern placeholders and usage is described in Java's 
 [`SimpleDateFormat` class description](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) with 
-the addition of recognizing two keywords `epoch` and `milliepoch` (case insensitive) to denote the number of 
-seconds/milliseconds since epoch (1970/01/01 00:00:00.000 UTC).
+the addition of recognizing some keywords (like `epoch` and `milliepoch` (case insensitive)) to denote the number of 
+seconds/milliseconds since epoch (1970/01/01 00:00:00.000 UTC) and some additional placeholders.
 It should be noted explicitly that `epoch` and `milliepoch` are considered a pattern including time zone.
  
 Summary:
@@ -254,13 +254,21 @@ Summary:
 | z | General time zone | Pacific Standard Time; PST; GMT-08:00 |
 | Z | RFC 822 time zone | -0800 |
 | X | ISO 8601 time zone | -08; -0800; -08:00 |
-| _epoch_ | Seconds since 1970/01/01 00:00:00 | 1557136493|
-| _milliepoch_ | Milliseconds since 1970/01/01 00:00:00.0000| 15571364938124 |
+| _epoch_ | Seconds since 1970/01/01 00:00:00 | 1557136493, 1557136493.136|
+| _epochmilli_ | Milliseconds since 1970/01/01 00:00:00.0000| 15571364938124, 15571364938124.001 |
+| _epochmicro_ | Milliseconds since 1970/01/01 00:00:00.0000| 15571364938124789, 15571364938124789.999 |
+| _epochnano_ | Milliseconds since 1970/01/01 00:00:00.0000| 15571364938124789101 |
+| i | Microsecond | 111, 321001 |
+| n | Nanosecond | 999, 542113879 |
+
 
 **NB!** Spark uses US Locale and because on-the-fly conversion would be complicated, at the moment we stick to this 
 hardcoded locale as well. E.g. `am/pm` for `a` placeholder, English names of days and months etc.
 
 **NB!** The keywords are case **insensitive**. Therefore, there is no difference between `epoch` and `EpoCH`.
+
+**NB!** While _nanoseconds_ designation is supported on input, it's not supported in storage or further usage. So any
+value behind microseconds precision will be truncated.
    
 ##### Time Zone support
 As it has been mentioned, it's highly recommended to use timestamps with the time zone. But it's not unlikely that the 

--- a/README.md
+++ b/README.md
@@ -229,37 +229,37 @@ It should be noted explicitly that `epoch` and `milliepoch` are considered a pat
  
 Summary:
 
-| placeholder | Description | Example |
-| --- | --- | --- |
-| G | Era designator | AD |
-| y | Year | 1996; 96 |
-| Y | Week year | 2009; 09 |
-| M | Month in year (context sensitive) |  July; Jul; 07 |
-| L | Month in year (standalone form) | July; Jul; 07 |
-| w | Week in year | 27 |
-| W | Week in month | 2 |
-| D | Day in year | 189 |
-| d | Day in month |  10 |
-| F | Day of week in month | 2 |
-| E | Day name in week | Tuesday; Tue |
-| u | Day number of week (1 = Monday, ..., 7 = Sunday) | 1 |
-| a | Am/pm marker | PM |
-| H | Hour in day (0-23) | 0 |
-| k | Hour in day (1-24) | 24 |
-| K | Hour in am/pm (0-11) |  0 |
-| h | Hour in am/pm (1-12) | 12 |
-| m | Minute in hour | 30 |
-| s | Second in minute | 55 |
-| S | Millisecond | 978 |
-| z | General time zone | Pacific Standard Time; PST; GMT-08:00 |
-| Z | RFC 822 time zone | -0800 |
-| X | ISO 8601 time zone | -08; -0800; -08:00 |
-| _epoch_ | Seconds since 1970/01/01 00:00:00 | 1557136493, 1557136493.136|
-| _epochmilli_ | Milliseconds since 1970/01/01 00:00:00.0000| 15571364938124, 15571364938124.001 |
-| _epochmicro_ | Milliseconds since 1970/01/01 00:00:00.0000| 15571364938124789, 15571364938124789.999 |
-| _epochnano_ | Milliseconds since 1970/01/01 00:00:00.0000| 15571364938124789101 |
-| i | Microsecond | 111, 321001 |
-| n | Nanosecond | 999, 542113879 |
+| placeholder | Description | Example | Note |
+| --- | --- | --- | --- |
+| G | Era designator | AD | |
+| y | Year | 1996; 96 | |
+| Y | Week year | 2009; 09 | |
+| M | Month in year (context sensitive) |  July; Jul; 07 | |
+| L | Month in year (standalone form) | July; Jul; 07 | |
+| w | Week in year | 27 | |
+| W | Week in month | 2 | |
+| D | Day in year | 189 | |
+| d | Day in month |  10 | |
+| F | Day of week in month | 2 | |
+| E | Day name in week | Tuesday; Tue | |
+| u | Day number of week (1 = Monday, ..., 7 = Sunday) | 1 | |
+| a | Am/pm marker | PM | |
+| H | Hour in day (0-23) | 0 | |
+| k | Hour in day (1-24) | 24 | |
+| K | Hour in am/pm (0-11) |  0 | |
+| h | Hour in am/pm (1-12) | 12 | |
+| m | Minute in hour | 30 | |
+| s | Second in minute | 55 | |
+| S | Millisecond | 978 | |
+| z | General time zone | Pacific Standard Time; PST; GMT-08:00 | |
+| Z | RFC 822 time zone | -0800 | |
+| X | ISO 8601 time zone | -08; -0800; -08:00 | |
+| _epoch_ | Seconds since 1970/01/01 00:00:00 | 1557136493, 1557136493.136| |
+| _epochmilli_ | Milliseconds since 1970/01/01 00:00:00.0000| 1557136493128, 1557136493128.001 | |
+| _epochmicro_ | Microseconds since 1970/01/01 00:00:00.0000| 1557136493128789, 1557136493128789.999 | |
+| _epochnano_ | Nanoseconds since 1970/01/01 00:00:00.0000| 1557136493128789101 | Seen the remark bellow regarding the loss of precision in _nanoseconds_ |
+| i | Microsecond | 111, 321001 | |
+| n | Nanosecond | 999, 542113879 | Seen the remark bellow regarding the loss of precision in _nanoseconds_ |
 
 
 **NB!** Spark uses US Locale and because on-the-fly conversion would be complicated, at the moment we stick to this 

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -443,7 +443,7 @@ object TypeParser extends StandardizationCommon {
 
     override protected def castStringColumn(stringColumn: Column): Column = {
       if (pattern.containsSecondFractions) {
-        //this is a trick how to enforce fractions of seconds into teh timestamp
+        //this is a trick how to enforce fractions of seconds into the timestamp
         // - turn into timestamp up to seconds precision and that into unix_timestamp,
         // - the second fractions turn into numeric fractions
         // - add both together and convert to timestamp

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -1,0 +1,343 @@
+package za.co.absa.enceladus.standardization.interpreter
+
+import java.sql.Date
+import org.apache.spark.sql.types.{DateType, MetadataBuilder, StructField, StructType}
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+
+class StandardizationInterpreter_DateSuite extends FunSuite with SparkTestBase with LoggerTestBase {
+  import spark.implicits._
+
+  private implicit val udfLib: UDFLibrary = new UDFLibrary
+
+  private val fieldName = "dateField"
+
+  test("epoch") {
+    val seq  = Seq(
+      0,
+      86399,
+      86400,
+      978307199,
+      1563288103
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString("pattern", "epoch").build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-02")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  test("epochmilli") {
+    val seq  = Seq(
+      0L,
+      86400000,
+      978307199999L,
+      1563288103123L
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString("pattern", "epochmilli").build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-02")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  test("epochmicro") {
+    val seq  = Seq(
+      0.1,
+      86400000000.02,
+      978307199999999.003,
+      1563288103123456.123
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString("pattern", "epochmicro").build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-02")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  test("epochnano") {
+    val seq  = Seq(
+      0,
+      86400000000000L,
+      978307199999999999L,
+      1563288103123456789L
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString("pattern", "epochnano").build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-02")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  test("simple date pattern") {
+    val seq  = Seq(
+      "1970/01/01",
+      "1970/02/01",
+      "2000/31/12",
+      "2019/16/07",
+      "1970-02-02",
+      "crash"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString("pattern", "yyyy/dd/MM").build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-02")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16")),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  test("date + time pattern and named time zone") {
+    val seq  = Seq(
+      "01-00-00 01.01.1970 CET",
+      "00-00-00 03.01.1970 EET",
+      "21-45-39 30.12.2000 PST",
+      "14-25-11 16.07.2019 UTC",
+      "00-75-00 03.01.1970 EET",
+      "crash"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString("pattern", "HH-mm-ss dd.MM.yyyy ZZZ").build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-02")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16")),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "00-75-00 03.01.1970 EET"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  test("date + time + second fractions pattern and offset time zone") {
+    val seq  = Seq(
+      "01:00:00(000000000) 01+01+1970 +01:00",
+      "00:00:00(001002003) 03+01+1970 +02:00",
+      "21:45:39(999999999) 30+12+2000 -08:00",
+      "14:25:11(123456789) 16+07+2019 +00:00",
+      "00:75:00(001002003) 03+01+1970 +02:00",
+      "crash"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString("pattern", "HH:mm:ss(SSSnnnnnn) dd+MM+yyyy XXX").build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-02")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16")),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "00:75:00(001002003) 03+01+1970 +02:00"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  test("date with  default time zone - EST") {
+    val seq  = Seq(
+      "1970/01/01",
+      "1970/02/01",
+      "2000/31/12",
+      "2019/16/07",
+      "1970-02-02",
+      "crash"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder()
+          .putString("pattern", "yyyy/dd/MM")
+          .putString("timezone", "EST")
+          .build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-01-02")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16")),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+
+  test("date with  default time zone - SAST") {
+    val seq  = Seq(
+      "1970/01/01",
+      "1970/02/01",
+      "2000/31/12",
+      "2019/16/07",
+      "1970-02-02",
+      "crash"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder()
+          .putString("pattern", "yyyy/dd/MM")
+          .putString("timezone", "Africa/Johannesburg")
+          .build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1969-12-31")),
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("2000-12-30")),
+      DateRow(Date.valueOf("2019-07-15")),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  test("date with quoted") {
+    val seq  = Seq(
+      "January 1 of 1970",
+      "February 1 of 1970",
+      "December 31 of 2000",
+      "July 16 of 2019",
+      "02 3 of 1970",
+      "February 4 1970",
+      "crash"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString("pattern", "MMMM d 'of' yyyy").build)
+    ))
+    val exp = Seq(
+      DateRow(Date.valueOf("1970-01-01")),
+      DateRow(Date.valueOf("1970-02-01")),
+      DateRow(Date.valueOf("2000-12-31")),
+      DateRow(Date.valueOf("2019-07-16")),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "02 3 of 1970"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "February 4 1970"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
+  /* TODO this should work with #677 fixed
+  test("date with quoted and second frations") {
+  val seq  = Seq(
+    "1970/01/01 insignificant 000000",
+    "1970/02/01 insignificant 001002",
+    "2000/31/12 insignificant 999999",
+    "2019/16/07 insignificant 123456",
+    "1970/02/02 insignificant ",
+    "crash"
+  )
+  val desiredSchema = StructType(Seq(
+    StructField(fieldName, DateType, nullable = false,
+      new MetadataBuilder().putString("pattern", "yyyy/MM/dd 'insignificant' iiiiii").build)
+  ))
+  val exp = Seq(
+    DateRow(Date.valueOf("1970-01-01")),
+    DateRow(Date.valueOf("1970-02-01")),
+    DateRow(Date.valueOf("2000-12-31")),
+    DateRow(Date.valueOf("2019-07-16")),
+    DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "1970/02/02 insignificant "))),
+    DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+  )
+
+  val src = seq.toDF(fieldName)
+
+  val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+  logDataFrameContent(std)
+
+  assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+  */
+
+}

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -1,0 +1,347 @@
+package za.co.absa.enceladus.standardization.interpreter
+
+import java.sql.Timestamp
+
+import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType, TimestampType}
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+
+class StandardizationInterpreter_TimestampSuite extends FunSuite with SparkTestBase with LoggerTestBase {
+  import spark.implicits._
+
+  private implicit val udfLib: UDFLibrary = new UDFLibrary
+
+  private val fieldName = "tms"
+
+  test("epoch") {
+    val seq  = Seq(
+      0,
+      86400,
+      978307199,
+      1563288103
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "epoch").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
+  test("epochmilli") {
+    val seq  = Seq(
+      0.0,
+      86400000.5,
+      978307199999.05,
+      1563288103123.005
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "epochmilli").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.0005")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.99905")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123005"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
+  test("epochmicro") {
+    val seq  = Seq(
+      0L,
+      86400000000L,
+      978307199999999L,
+      1563288103123456L
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "epochmicro").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123456"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
+  test("epochnano") {
+    val seq  = Seq(
+      0,
+      86400000000000L,
+      978307199999999999L,
+      1563288103123456789L
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "epochnano").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999000")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123456000"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
+  test("pattern up to seconds precision") {
+    val seq  = Seq(
+      "01.01.1970 00-00-00",
+      "02.01.1970 00-00-00",
+      "31.12.2000 23-59-59",
+      "16.07.2019 14-41-43",
+      "02.02.1970_00-00-00",
+      "nope"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "dd.MM.yyyy HH-mm-ss").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43")),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "02.02.1970_00-00-00"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
+  test("pattern up to seconds precision with default time zone") {
+    val seq  = Seq(
+      "31.12.1969 19-00-00",
+      "01.01.1970 19-00-00",
+      "31.12.2000 18-59-59",
+      "29.02.2004 24-00-00",
+      "16.07.2019 09-41-43",
+      "02.02.1970_24-00-00",
+      "nope"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder()
+          .putString("pattern", "dd.MM.yyyy kk-mm-ss")
+          .putString("timezone", "EST")
+          .build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59")),
+      TimestampRow(Timestamp.valueOf("2004-02-29 05:00:00")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43")),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "02.02.1970_24-00-00"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
+  test("pattern up to milliseconds precision and with offset time zone") {
+    val seq  = Seq(
+      "1970 01 01 01 00 00 000 +01:00",
+      "1970 01 02 03 30 00 001 +03:30",
+      "2000 12 31 23 59 59 999 +00:00",
+      "2019 07 16 08 41 43 123 -06:00",
+      "1970 02 02 00 00 00 112",
+      "nope"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "yyyy MM dd HH mm ss SSS XXX").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.001")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123")),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "1970 02 02 00 00 00 112"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+
+  }
+
+  test("pattern up to microseconds precision and with default time zone") {
+    val seq  = Seq(
+      "01011970 010000.000000",
+      "02011970 010000.000001",
+      "01012001 005959.999999",
+      "16072019 164143.123456",
+      "02011970 010000 000001",
+      "nope"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder()
+          .putString("pattern", "ddMMyyyy HHmmss.iiiiii")
+          .putString("timezone", "CET")
+          .build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.000001")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123456")),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "02011970 010000 000001"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+
+  }
+
+  test("pattern up to nanoseconds precision, no time zone") {
+    val seq  = Seq(
+      "(000000) 01/01/1970 AM+00:00:00~000",
+      "(002003) 02/01/1970 am+00:00:00~001",
+      "(999999) 31/12/2000 PM+11:59:59~999",
+      "(456789) 16/07/2019 Pm+02:41:43~123",
+      "02/01/1970 00:00:00 001",
+      "nope"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "(iiinnn) dd/MM/yyyy aa+KK:mm:ss~SSS").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.001002")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123456")),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "02/01/1970 00:00:00 001"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+
+  }
+
+  test("pattern up to nanoseconds precision and named time zone") {
+    val seq  = Seq(
+      "(000000) 01/01/1970 01:00:00.000 CET",
+      "(001002) 02/01/1970 08:45:00.003 ACWST",
+      "(999999) 31/12/2000 15:59:59.999 PST",
+      "(456789) 16/07/2019 16:41:43.123 EET",
+      "(      ) 02/01/1970 01:00:00.000 CET",
+      "nope"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "(iiinnn) dd/MM/yyyy HH:mm:ss.SSS ZZ").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.003001")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123456")),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "(      ) 02/01/1970 01:00:00.000 CET"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+
+  }
+
+  /* TODO this should work with #677 fixed
+  test("pattern with literal and less common placeholders") {
+    val seq  = Seq(
+      "70001 star [000] 12:00:00(aM) @000000",
+      "70002 star [001] 01:00:00(pM) @002003",
+      "00365 star [999] 11:59:59(pM) @999999",
+      "80040 star [123] 02:41:43(PM) @456789",
+      "70002 staT [000] 12:00:00(aM) @000000",
+      "nope"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "yyDDD 'star' [iii] aa hh:mm:ss(aa)@nnnSSS").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.003001")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
+      TimestampRow(Timestamp.valueOf("1980-02-09 14:41:43.789123")),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "70002 staT [000] 12:00:00(aM) @000000"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    std.show(false)
+    std.printSchema()
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+  */
+
+}

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -42,10 +42,12 @@ class StandardizationInterpreter_TimestampSuite extends FunSuite with SparkTestB
 
   test("epochmilli") {
     val seq  = Seq(
-      0.0,
-      86400000.5,
-      978307199999.05,
-      1563288103123.005
+      "0.0",
+      "86400000.5",
+      "978307199999.05",
+      "1563288103123.005",
+      "-86400000",
+      "Fail"
     )
     val desiredSchema = StructType(Seq(
       StructField(fieldName, TimestampType, nullable = false,
@@ -55,7 +57,9 @@ class StandardizationInterpreter_TimestampSuite extends FunSuite with SparkTestB
       TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
       TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.0005")),
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.99905")),
-      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123005"))
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123005")),
+      TimestampRow(Timestamp.valueOf("1969-12-31 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "Fail")))
     )
 
     val src = seq.toDF(fieldName)

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuiteTemplate.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuiteTemplate.scala
@@ -36,8 +36,6 @@ trait TypeParserSuiteTemplate extends FunSuite with SparkTestBase {
   protected def createErrorCondition(srcField: String, target: StructField, castS: String):String
 
   private val sourceFieldName = "sourceField"
-  private val dateEpochPattern = DateTimePattern.EpochKeyword
-  private val timestampEpochPattern = DateTimePattern.EpochMilliKeyword
 
   protected val log: Logger = LogManager.getLogger(this.getClass)
 
@@ -174,17 +172,17 @@ trait TypeParserSuiteTemplate extends FunSuite with SparkTestBase {
   protected def doTestIntoDateFieldWithEpochPattern(input: Input): Unit = {
     import input._
     val dateField = StructField("dateField", DateType, nullable = false,
-      new MetadataBuilder().putString("sourcecolumn", sourceFieldName).putString("pattern", dateEpochPattern).build)
+      new MetadataBuilder().putString("sourcecolumn", sourceFieldName).putString("pattern", DateTimePattern.EpochKeyword).build)
     val schema = buildSchema(Array(sourceField(baseType), dateField), path)
-    testTemplate(dateField, schema, path, dateEpochPattern)
+    testTemplate(dateField, schema, path, DateTimePattern.EpochKeyword)
   }
 
   protected def doTestIntoTimestampFieldWithEpochPattern(input: Input): Unit = {
     import input._
     val timestampField = StructField("timestampField", TimestampType, nullable = false,
-      new MetadataBuilder().putString("sourcecolumn", sourceFieldName).putString("pattern", timestampEpochPattern).build)
+      new MetadataBuilder().putString("sourcecolumn", sourceFieldName).putString("pattern", DateTimePattern.EpochMilliKeyword).build)
     val schema = buildSchema(Array(sourceField(baseType), timestampField), path)
-    testTemplate(timestampField, schema, path, timestampEpochPattern)
+    testTemplate(timestampField, schema, path, DateTimePattern.EpochMilliKeyword)
   }
 
   private def sourceField(baseType: DataType, nullable: Boolean = true): StructField = StructField(sourceFieldName, baseType, nullable)

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromBooleanTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromBooleanTypeSuite.scala
@@ -34,8 +34,8 @@ class TypeParser_FromBooleanTypeSuite extends TypeParserSuiteTemplate  {
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)                      => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)                 => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, true, _)                      => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
+      case (TimestampType, true, _)                 => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
       case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
       case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDateTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDateTypeSuite.scala
@@ -35,8 +35,8 @@ class TypeParser_FromDateTypeSuite extends TypeParserSuiteTemplate  {
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)               => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)          => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, true, _)               => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
+      case (TimestampType, true, _)          => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))           => s"to_date(to_utc_timestamp(`%s`, '$tz'))"
       case (TimestampType, _, Some(tz))      => s"to_utc_timestamp(%s, $tz)"
       case (DateType, _, _)                  => "%s"

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDecimalTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDecimalTypeSuite.scala
@@ -35,8 +35,8 @@ class TypeParser_FromDecimalTypeSuite extends TypeParserSuiteTemplate  {
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)                      => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)                 => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, true, _)                      => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
+      case (TimestampType, true, _)                 => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
       case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
       case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDoubleTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromDoubleTypeSuite.scala
@@ -39,8 +39,8 @@ class TypeParser_FromDoubleTypeSuite extends TypeParserSuiteTemplate  {
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)             => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)        => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, true, _)             => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
+      case (TimestampType, true, _)        => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))         => s"to_date(to_utc_timestamp(to_timestamp(CAST(CAST(`%s` AS DECIMAL(${datePatternDS.precision},${datePatternDS.scale})) AS STRING), '$pattern'), '$tz'))"
       case (TimestampType, _, Some(tz))    => s"to_utc_timestamp(to_timestamp(CAST(CAST(`%s` AS DECIMAL(${timestampPatternDS.precision},${timestampPatternDS.scale})) AS STRING), '$pattern'), $tz)"
       case (DateType, _, _)                => s"to_date(CAST(CAST(`%s` AS DECIMAL(${datePatternDS.precision},${datePatternDS.scale})) AS STRING), '$pattern')"

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
@@ -35,8 +35,8 @@ class TypeParser_FromLongTypeSuite extends TypeParserSuiteTemplate {
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)                      => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)                 => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, true, _)                      => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
+      case (TimestampType, true, _)                 => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
       case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
       case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromStringTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromStringTypeSuite.scala
@@ -36,8 +36,8 @@ class TypeParser_FromStringTypeSuite extends TypeParserSuiteTemplate {
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)          => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)     => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, true, _)          => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
+      case (TimestampType, true, _)     => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))      => s"to_date(to_utc_timestamp(to_timestamp(`%s`, '$pattern'), '$tz'))"
       case (TimestampType, _, Some(tz)) => s"to_utc_timestamp(to_timestamp(`%s`, '$pattern'), $tz)"
       case (DateType, _, _)             => s"to_date(`%s`, '$pattern')"

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromTimestampTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromTimestampTypeSuite.scala
@@ -35,8 +35,8 @@ class TypeParser_FromTimestampTypeSuite extends TypeParserSuiteTemplate  {
   override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (toType, isEpoch, timezone) match {
-      case (DateType, true, _)          => s"to_date(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd'), 'yyyy-MM-dd')"
-      case (TimestampType, true, _)     => s"to_timestamp(from_unixtime((CAST(`%s` AS BIGINT) / ${DateTimePattern.epochFactor(pattern)}L), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')"
+      case (DateType, true, _)          => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
+      case (TimestampType, true, _)     => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (TimestampType, _, Some(tz)) => s"to_utc_timestamp(%s, $tz)"
       case (DateType, _, Some(tz))      => s"to_date(to_utc_timestamp(`%s`, '$tz'))"
       case (TimestampType, _, _)        => "%s"

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/standardizationInterpreter_RowTypes.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/standardizationInterpreter_RowTypes.scala
@@ -15,6 +15,8 @@
 
 package za.co.absa.enceladus.standardization.interpreter
 
+import java.sql.{Date, Timestamp}
+
 import za.co.absa.enceladus.utils.error.ErrorMessage
 
 //Decimal Suite
@@ -108,3 +110,15 @@ case class InputRowBigDecimalsForIntegral(
     this(description, Option(value), Option(value), Option(value), Option(value))
   }
 }
+
+//Timestamp Suite
+case class TimestampRow(
+                         tms: Timestamp,
+                         errCol: Seq[ErrorMessage] = Seq.empty
+                       )
+
+//Date Suite
+case class DateRow(
+                    dateField: Date,
+                    errCol: Seq[ErrorMessage] = Seq.empty
+                  )

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/general/Section.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/general/Section.scala
@@ -55,9 +55,9 @@ case class Section(start: Int, length: Int) extends Ordered[Section] {
   }
 
   /**
-    * Converts the Section to actual indexes representing the section on the given string if used in the substring function
-    * for example, e.g. first item of the tuple inclusive, second exclusive
-    * The result respects the boundaries of the string, the indexes not to cause OutOfBound exception
+    * Converts the Section to actual indexes representing the section on the given string, if used in the substring
+    * function. The result respects the boundaries of the string, the indexes in the result not to cause OutOfBound exception
+    * For example Section(2,3) for string "Hello!" gives (2,5), for "abc" (2,3)
     * @param forString  the string which the section would be applied to
     * @return           tuple representing the beginIndex and endIndex parameters for the substring function
     */
@@ -87,7 +87,7 @@ case class Section(start: Int, length: Int) extends Ordered[Section] {
   }
 
   /**
-    * Creates a string that is the remainder if the substring represented by this section is removed frm the provided string
+    * Creates a string that is the remainder if the substring represented by this section is removed from the provided string
     * Complementary to `extract`
     * @param fromString the string to apply the section to
     * @return concatenation of the string before and after the Section
@@ -105,14 +105,14 @@ case class Section(start: Int, length: Int) extends Ordered[Section] {
     */
   def inject(into: String, what: String): String = {
 
-    def invalidParameterExceptionMessage: String = {
+    def fail(): String = {
       throw new InvalidParameterException(
         s"The length of the string to inject (${what.length}) doesn't match Section($start, $length) for string of length ${into.length}."
       )
     }
 
     if (what.length > length) {
-      throw new InvalidParameterException(invalidParameterExceptionMessage)
+      fail()
     }
     if ((what == "") && ((length == 0) || (start > into.length) || (start + into.length + length < 0))) {
       // injecting empty string is easy if valid; which is either if the section length = 0, or the index to inject to
@@ -121,7 +121,7 @@ case class Section(start: Int, length: Int) extends Ordered[Section] {
     } else if (start >= 0) {
       if (start > into.length) {
         // beyond the into string
-        throw new InvalidParameterException(invalidParameterExceptionMessage)
+        fail()
       } else if (start == into.length) {
         // at the end of the into string
         into + what
@@ -130,7 +130,7 @@ case class Section(start: Int, length: Int) extends Ordered[Section] {
         into.substring(0, start) + what + into.substring(start)
       } else {
         // wrong size of injection
-        throw new InvalidParameterException(invalidParameterExceptionMessage)
+        fail()
       }
     } else {
       val index = into.length + start + what.length
@@ -146,7 +146,7 @@ case class Section(start: Int, length: Int) extends Ordered[Section] {
         case (`whatLengthDeficit`, `index`) =>
           // at the beginning of the into string, maybe appropriately shorter if to be place "before" 0 index
           what + into
-        case _ => throw new InvalidParameterException(invalidParameterExceptionMessage)
+        case _ => fail()
       }
     }
   }
@@ -257,7 +257,7 @@ object Section {
   def mergeSections(sections: Seq[Section]): Seq[Section] = {
     def fuse(into: Section, what: Section): Section = {
       if (into.start + into.length >= what.start + what.length) {
-        //what is within into
+        //as the sequence where the sections are coming from is sorter, this condition is enough to check that `what` is within `into`
         into
       } else {
         //actual fusion

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/general/Section.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/general/Section.scala
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.general
+
+import java.security.InvalidParameterException
+
+/**
+  * Represents a section of a string defined by its starting index and length of the section.
+  * It supports negative indexes for start, denoting a position counted from end
+  * _Comparison_
+  * The class implements the `Ordered` trait
+  * Sections with negative start are BIGGER then the ones with positive start
+  * The section with smaller ABSOLUTE value of start is considered smaller, if starts equal the shorter section is the
+  * smaller
+  * NB! Interesting consequence of the ordering is, that if the sections are not overlapping and removal applied on
+  *  string from greatest to smallest one by one, the result is the same as removing all sections "at once"
+  * @param start the start position of the section, if negative the position is counted from the end
+  * @param length length of the section, cannot be negative
+  */
+case class Section(start: Int, length: Int) extends Ordered[Section] {
+
+  if (length < 0) {
+    throw new InvalidParameterException(s"'length; cannot be negative, $length given")
+  }
+
+  if ((start >= 0) && (start.toLong + length.toLong > Int.MaxValue)) {
+    throw new IndexOutOfBoundsException(s"start and length combination are grater then ${Int.MaxValue}")
+  }
+
+  override def compare(that: Section): Int = {
+    if (start == that.start) {
+      length.compare(that.length) //shorter is smaller
+    } else if ((start < 0) && (that.start >= 0)) {
+      1 // negative start is bigger then the one of positive+zero
+    } else if ((start >= 0) && (that.start < 0)) {
+      -1
+    } else if (start.abs < that.start.abs) {
+      -1
+    } else {
+      1
+    }
+  }
+
+  /**
+    * Converts the Section to actual indexes representing the section on the given string if used in the substring function
+    * for example, e.g. first item of the tuple inclusive, second exclusive
+    * The result respects the boundaries of the string, the indexes not to cause OutOfBound exception
+    * @param forString  the string which the section would be applied to
+    * @return           tuple representing the beginIndex and endIndex parameters for the substring function
+    */
+  def toSubstringParameters(forString: String): (Int, Int) = {
+    val (realStart, after) = if (start >= 0) {
+        (start min forString.length, start + length)
+      } else {
+        val startIndex = forString.length + start
+        if (startIndex >= 0) { //
+          (startIndex, startIndex + length)
+        } else { // the distance from end is longer than the string itself
+          (0, length + startIndex max 0)
+        }
+      }
+    (realStart, after min forString.length)
+  }
+
+  /**
+    * The substring represented by this Section within the provided string
+    * Complementary to `remove`
+    * @param fromString the string to apply the section to
+    * @return           substring defined by this section
+    */
+  def extract(fromString: String): String = {
+    val (realStart, after) = toSubstringParameters(fromString)
+    fromString.substring(realStart, after)
+  }
+
+  /**
+    * Creates a string that is the remainder if the substring represented by this section is removed frm the provided string
+    * Complementary to `extract`
+    * @param fromString the string to apply the section to
+    * @return concatenation of the string before and after the Section
+    */
+  def remove(fromString: String): String = {
+    val (realStart, after) = toSubstringParameters(fromString)
+    fromString.substring(0, realStart) + fromString.substring(after)
+  }
+
+  /**
+    * Inverse function for `remove`, inserts the `what` string into the `into` string as defined by the `section`
+    * @param into the string to inject into
+    * @param what the string to inject
+    * @return     the newly created string
+    */
+  def inject(into: String, what: String): String = {
+
+    def invalidParameterExceptionMessage: String = {
+      throw new InvalidParameterException(
+        s"The length of the string to inject (${what.length}) doesn't match Section($start, $length) for string of length ${into.length}."
+      )
+    }
+
+    if (what.length > length) {
+      throw new InvalidParameterException(invalidParameterExceptionMessage)
+    }
+    if ((what == "") && ((length == 0) || (start > into.length) || (start + into.length + length < 0))) {
+      // injecting empty string is easy if valid; which is either if the section length = 0, or the index to inject to
+      // is beyond the limits of the final string
+      into
+    } else if (start >= 0) {
+      if (start > into.length) {
+        // beyond the into string
+        throw new InvalidParameterException(invalidParameterExceptionMessage)
+      } else if (start == into.length) {
+        // at the end of the into string
+        into + what
+      } else if (what.length == length) {
+        // injection in the middle (or beginning)
+        into.substring(0, start) + what + into.substring(start)
+      } else {
+        // wrong size of injection
+        throw new InvalidParameterException(invalidParameterExceptionMessage)
+      }
+    } else {
+      val index = into.length + start + what.length
+      val whatLengthDeficit = what.length - length
+      val intoLength = into.length
+      (index,  whatLengthDeficit) match {
+        case (`intoLength`, _) =>
+          // at the end of the into string
+          into + what
+        case (x, 0) if (x > 0) && (x < into.length) =>
+          // somewhere withing the into string
+          into.substring(0, x) + what + into.substring(x)
+        case (`whatLengthDeficit`, `index`) =>
+          // at the beginning of the into string, maybe appropriately shorter if to be place "before" 0 index
+          what + into
+        case _ => throw new InvalidParameterException(invalidParameterExceptionMessage)
+      }
+    }
+  }
+
+  /**
+    * Metrics defined on Section
+    * @param that the Section to compute the distance from/to
+    * @return     None - if one Section has a negative start and the other positive or zero
+    *             The end of the smaller section subtracted from the start of the greater one (see comparison), e.g. can be negative
+    */
+  def distance(that: Section): Option[Int] = {
+    def subtractLike(from: Section, what: Section): Int = {
+      from.start - what.start - what.length
+    }
+
+    (start >= 0, that.start >= 0) match {
+      case (false, true) | (true, false) =>
+        // two sections of differently signed starts don't have a distance defined
+        None
+      case (true, true) =>
+        if (this <= that) {
+          Option(subtractLike(that, this))
+        } else {
+          Option(subtractLike(this, that))
+        }
+      case (false, false) =>
+        if (this <= that) {
+          Option(subtractLike(this, that))
+        } else {
+          Option(subtractLike(that, this))
+        }
+    }
+  }
+
+  /**
+    * Checks if two sections overlap
+    * @param that the other Section
+    * @return     true if the greater Section starts before the smaller one ends (see comparison)
+    *             false otherwise
+    */
+  def overlaps(that: Section): Boolean = {
+    distance(that).exists(_ < 0)
+  }
+
+  /**
+    * Checks if two sections touch or overlap
+    * @param that the other Section
+    * @return     true if the greater Section starts before the smaller one ends (see comparison) or right after it
+    *             false otherwise
+    */
+  def touches(that: Section): Boolean = {
+    distance(that).exists(_ <= 0)
+  }
+}
+
+object Section {
+  def fromIndexes(start: Int, end: Int): Section = {
+    Section(start, end - start + 1)
+  }
+
+  def ofSameChars(fromString: String, fromIndex: Int): Section = {
+    val realFromIndex = if (fromIndex >= 0) {
+      fromIndex
+    } else {
+      fromString.length + fromIndex
+    }
+    if ((realFromIndex >= fromString.length) || (realFromIndex < 0)) {
+      Section(fromIndex, 0)
+    } else {
+      val char = fromString(realFromIndex)
+      var res = realFromIndex
+      while ((res < fromString.length) && (fromString(res) == char)) {
+        res += 1
+      }
+      Section(fromIndex, res - realFromIndex)
+    }
+  }
+
+  /**
+    * Removes sections of the string in a way, that string is considered intact until all removals are executed. In
+    * other words the indexes are not shifted.
+    * @param fromString the string to operate upon
+    * @param sections   sections to apply
+    * @return           the string as a result if all the sections would be removed "at once"
+    */
+  def removeMultiple(fromString: String, sections: Seq[Section]): String = {
+    if (sections.isEmpty) {
+      fromString
+    } else {
+      val charsPresent = Array.fill(fromString.length)(true)
+      sections.foreach{section =>
+        val (realStart, after) = section.toSubstringParameters(fromString)
+        for (i <- realStart until after) {
+          charsPresent(i) = false
+        }
+      }
+      val paring: Seq[(Char, Boolean)] = fromString.toSeq.zip(charsPresent)
+
+      paring.collect{case (c, true) => c}.mkString
+    }
+  }
+
+  /**
+    * Merges all touching (that includes overlaps too) sections and sort them
+    * @param sections the sections to merge
+    * @return         an ordered from greater to smaller sequence of distinct sections (their distance is at least 1 or undefined)
+    */
+  def mergeSections(sections: Seq[Section]): Seq[Section] = {
+    def fuse(into: Section, what: Section): Section = {
+      if (into.start + into.length >= what.start + what.length) {
+        //what is within into
+        into
+      } else {
+        //actual fusion
+        //the length expression is simplified: into.length + what.length - ((into.start + into.length) - what.start)
+        Section(into.start, what.length - into.start + what.start)
+      }
+    }
+
+    def doMerge(input: Seq[Section]): Seq[Section] = {
+      if (input.isEmpty) {
+        input
+      } else {
+        val sorted = input.sorted
+        sorted.tail.foldLeft(List(sorted.head)) { (resultAcc, item) =>
+          if (item touches resultAcc.head) {
+            val newHead = if (item.start >= 0) fuse(resultAcc.head, item) else fuse(item, resultAcc.head)
+            newHead :: resultAcc.tail
+          } else {
+            item :: resultAcc
+          }
+        }
+      }
+    }
+
+    val (negativeOnes, positiveOnes) = sections.partition(_.start < 0)
+    doMerge(negativeOnes) ++ doMerge(positiveOnes)
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/ColumnImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/ColumnImplicits.scala
@@ -25,6 +25,14 @@ object ColumnImplicits {
       column.isin(Double.PositiveInfinity, Double.NegativeInfinity)
     }
 
+    /**
+      * Spark strings are base on 1 unlike scala. The function shifts the substring indexation to be in accordance with
+      * Scala/ Java.
+      * Another enhancement is, that the function allows a negative index, denoting counting of the index from back
+      * This version takes the substring from the startPos until the end.
+      * @param startPos the index (zero based) where to start the substring from, if negative it;s counted from end
+      * @return         column with requested substring
+      */
     def zeroBasedSubstr(startPos: Int): Column = {
       if (startPos >= 0) {
         zeroBasedSubstr(startPos, Int.MaxValue - startPos)
@@ -33,6 +41,15 @@ object ColumnImplicits {
       }
     }
 
+    /**
+      * Spark strings are base on 1 unlike scala. The function shifts the substring indexation to be in accordance with
+      * Scala/ Java.
+      * Another enhancement is, that the function allows a negative index, denoting counting of the index from back
+      * This version takes the substring from the startPos and takes up to the given number of characters (less.
+      * @param startPos the index (zero based) where to start the substring from, if negative it;s counted from end
+      * @param len      length of the desired substring, if longer then the rest of the string, all the remaining characters are taken
+      * @return         column with requested substring
+      */
     def zeroBasedSubstr(startPos: Int, len: Int): Column = {
       if (startPos >= 0) {
         column.substr(startPos + 1, len)
@@ -43,8 +60,22 @@ object ColumnImplicits {
       }
     }
 
+    /**
+      * Spark strings are base on 1 unlike scala. The function shifts the substring indexation to be in accordance with
+      * Scala/ Java.
+      * Another enhancement is, that the function allows a negative index, denoting counting of the index from back
+      * This version takes the startPos and len from the provided Section object.
+      * @param section  the start and requested length of the substring encoded within the Section object
+      * @return         column with requested substring
+      */
     def zeroBasedSubstr(section: Section): Column = zeroBasedSubstr(section.start, section.length)
 
+    /**
+      * Removes part of a StringType column, defined by the provided section. A column containing the remaining part of
+      * the string is returned
+      * @param section  Definition of the part of the string to remove
+      * @return         Column with the remaining parts of the string (concatenated)
+      */
     def removeSection(section: Section): Column = {
       splitBySection(section) match {
         case Left(result) => result
@@ -52,6 +83,13 @@ object ColumnImplicits {
       }
     }
 
+    /**
+      * Removes multiple sections from a StringType column. The operation is done in a way, as if the sections would be
+      * removed all "at once". E.g. removing Section(3, 1) and Section(6,1) removes the 3rd and 6th character (zero based),
+      * NOT the 3rd and 7th.
+      * @param sections Sections to removed
+      * @return         Column with the remainders of the string concatenated
+      */
     def removeSections(sections: Seq[Section]): Column = {
       val mergedSections = Section.mergeSections(sections)
       mergedSections.foldLeft(column) ((columnAcc, item) => columnAcc.removeSection(item)) //TODO try more effectively #678

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/ColumnImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/ColumnImplicits.scala
@@ -91,7 +91,7 @@ object ColumnImplicits {
       * @return         Column with the remainders of the string concatenated
       */
     def removeSections(sections: Seq[Section]): Column = {
-      val mergedSections = Section.mergeSections(sections)
+      val mergedSections = Section.mergeTouchingSectionsAndSort(sections)
       mergedSections.foldLeft(column) ((columnAcc, item) => columnAcc.removeSection(item)) //TODO try more effectively #678
     }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/ColumnImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/ColumnImplicits.scala
@@ -17,11 +17,57 @@ package za.co.absa.enceladus.utils.implicits
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
+import za.co.absa.enceladus.utils.general.Section
 
 object ColumnImplicits {
   implicit class ColumnEnhancements(column: Column) {
     def isInfinite: Column = {
       column.isin(Double.PositiveInfinity, Double.NegativeInfinity)
     }
+
+    def zeroBasedSubstr(startPos: Int): Column = {
+      if (startPos >= 0) {
+        zeroBasedSubstr(startPos, Int.MaxValue - startPos)
+      } else {
+        zeroBasedSubstr(startPos, -startPos)
+      }
+    }
+
+    def zeroBasedSubstr(startPos: Int, len: Int): Column = {
+      if (startPos >= 0) {
+        column.substr(startPos + 1, len)
+      } else {
+        val startPosColumn = greatest(length(column) + startPos + 1, lit(1))
+        val lenColumn = lit(len) + when(length(column) + startPos <= 0, length(column) + startPos).otherwise(0)
+        column.substr(startPosColumn,lenColumn)
+      }
+    }
+
+    def zeroBasedSubstr(section: Section): Column = zeroBasedSubstr(section.start, section.length)
+
+    def removeSection(section: Section): Column = {
+      splitBySection(section) match {
+        case Left(result) => result
+        case Right((leftColumn, rightColumn)) => concat(leftColumn, rightColumn)
+      }
+    }
+
+    def removeSections(sections: Seq[Section]): Column = {
+      val mergedSections = Section.mergeSections(sections)
+      mergedSections.foldLeft(column) ((columnAcc, item) => columnAcc.removeSection(item)) //TODO try more effectively #678
+    }
+
+    private def splitBySection(section: Section): Either[Column, (Column, Column)] = {
+      def upToNegative(negativeIndex: Int): Column = column.substr(lit(1), greatest(length(column) + negativeIndex, lit(0)))
+
+      section match {
+        case Section(_, 0) => Left(column)
+        case Section(0, l) => Left(zeroBasedSubstr(l))
+        case Section(s, l) if (s < 0) && (s + l >= 0) => Left(upToNegative(s)) //till the end
+        case Section(s, l) if s >= 0 => Right(zeroBasedSubstr(0, s), zeroBasedSubstr(s + l, Int.MaxValue))
+        case Section(s, l) => Right(upToNegative(s), zeroBasedSubstr(s + l))
+      }
+    }
+
   }
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StringImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StringImplicits.scala
@@ -22,6 +22,21 @@ import scala.annotation.tailrec
 object StringImplicits {
   implicit class StringEnhancements(string: String) {
 
+    def injectWith(what: String, where: Int): String = {
+      val index = if (where >= 0) {
+        where
+      } else {
+        string.length + where
+      }
+      if (index <=0) {
+        what + string
+      } else if (index >= string.length) {
+        string + what
+      } else {
+        string.substring(0, index) + what + string.substring(index)
+      }
+    }
+
     /**
       * Function to find the first occurrence of any of the characters from the charsToFind in the string. The
       * occurrence is not considered if the character is part of a sequence within a pair of quote characters specified
@@ -150,6 +165,5 @@ object StringImplicits {
         case   _ => Option(None, false)
       }
     }
-
   }
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StringImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StringImplicits.scala
@@ -21,22 +21,6 @@ import scala.annotation.tailrec
 
 object StringImplicits {
   implicit class StringEnhancements(string: String) {
-
-    def injectWith(what: String, where: Int): String = {
-      val index = if (where >= 0) {
-        where
-      } else {
-        string.length + where
-      }
-      if (index <=0) {
-        what + string
-      } else if (index >= string.length) {
-        string + what
-      } else {
-        string.substring(0, index) + what + string.substring(index)
-      }
-    }
-
     /**
       * Function to find the first occurrence of any of the characters from the charsToFind in the string. The
       * occurrence is not considered if the character is part of a sequence within a pair of quote characters specified

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/DateTimePattern.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/DateTimePattern.scala
@@ -127,7 +127,7 @@ object DateTimePattern {
     override val isTimeZoned: Boolean = timeZoneInPattern || defaultTimeZone.nonEmpty
 
     val (millisecondsPosition, microsecondsPosition, nanosecondsPosition) = analyzeSecondFractionsPositions(pattern)
-    override val secondFractionsSections: Seq[Section] = Section.mergeSections(Seq(millisecondsPosition, microsecondsPosition, nanosecondsPosition).flatten)
+    override val secondFractionsSections: Seq[Section] = Section.mergeTouchingSectionsAndSort(Seq(millisecondsPosition, microsecondsPosition, nanosecondsPosition).flatten)
     override val patternWithoutSecondFractions: String = Section.removeMultipleFrom(pattern, secondFractionsSections)
 
     private def scanForPlaceholder(withinString: String, placeHolder: Char): Option[Section] = {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/DateTimePattern.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/DateTimePattern.scala
@@ -18,8 +18,8 @@ package za.co.absa.enceladus.utils.time
 import java.security.InvalidParameterException
 
 import org.apache.spark.sql.types.{DateType, StructField, TimestampType}
+import za.co.absa.enceladus.utils.general.Section
 import za.co.absa.enceladus.utils.types.TypePattern
-import DateTimePattern.Section
 
 /**
   * Class to carry enhanced information about date/time formatting pattern in conversion from/to string
@@ -31,16 +31,18 @@ abstract sealed class DateTimePattern(pattern: String, isDefault: Boolean = fals
 
   val isEpoch: Boolean
   val epochFactor: Long
-  val epochMilliFactor: Long
 
   val timeZoneInPattern: Boolean
   val defaultTimeZone: Option[String]
   val isTimeZoned: Boolean
+
   val millisecondsPosition: Option[Section]
   val microsecondsPosition: Option[Section]
   val nanosecondsPosition: Option[Section]
-  val containsSecondFraction: Boolean
+
+  val secondFractionsSections: Seq[Section]
   val patternWithoutSecondFractions: String
+  def containsSecondFractions: Boolean = secondFractionsSections.nonEmpty
 
   override def toString: String = {
     val q = "\""
@@ -53,16 +55,29 @@ object DateTimePattern {
   import za.co.absa.enceladus.utils.implicits.StringImplicits.StringEnhancements
   import za.co.absa.enceladus.utils.implicits.StructFieldImplicits.{StructFieldEnhancements, PatternInfo}
 
-  type Section = (Int, Int)
   val EpochKeyword = "epoch"
   val EpochMilliKeyword = "epochmilli"
+  val EpochMicroKeyword = "epochmicro"
+  val EpochNanoKeyword = "epochnano"
 
   private val epochUnitFactor = 1
-  private val epochThousandFactor = 1000
+  private val epoch1kFactor = 1000
+  private val epoch1MFactor = 1000000
+  private val epoch1GFactor = 1000000000
+
   private val patternTimeZoneChars = Set('X','z','Z')
+
   private val patternMilliSecondChar = 'S'
   private val patternMicroSecondChar = 'i'
   private val patternNanoSecondChat = 'n'
+
+  // scalastyle:off magic.number
+  private val last3Chars = Section(-3, 3)
+  private val last6Chars = Section(-6, 6)
+  private val last9Chars = Section(-9, 9)
+  private val trio6Back  = Section(-6, 3)
+  private val trio9Back  = Section(-9, 3)
+  // scalastyle:on magic.number
 
   private final case class EpochDTPattern(override val pattern: String,
                                           override val isDefault: Boolean = false)
@@ -70,12 +85,32 @@ object DateTimePattern {
 
     override val isEpoch: Boolean = true
     override val epochFactor: Long = DateTimePattern.epochFactor(pattern)
-    override val epochMilliFactor: Long = DateTimePattern.epochMilliFactor(pattern)
 
     override val timeZoneInPattern: Boolean = true
     override val defaultTimeZone: Option[String] = None
     override val isTimeZoned: Boolean = true
-    override val containsSecondFraction: Boolean = pattern != EpochKeyword //not really used here, but for consistency
+
+    override val millisecondsPosition: Option[Section] = pattern match {
+      case EpochMilliKeyword => Option(last3Chars)
+      case EpochMicroKeyword => Option(trio6Back)
+      case EpochNanoKeyword  => Option(trio9Back)
+      case _                 => None
+    }
+    override val microsecondsPosition: Option[Section] = pattern match {
+      case EpochMicroKeyword => Option(last3Chars)
+      case EpochNanoKeyword  => Option(trio6Back)
+      case _                 => None
+    }
+    override val nanosecondsPosition: Option[Section] = pattern match {
+      case EpochNanoKeyword => Option(last3Chars)
+      case _                => None
+    }
+    override val secondFractionsSections: Seq[Section] = pattern match {
+      case EpochMilliKeyword => Seq(last3Chars)
+      case EpochMicroKeyword => Seq(last6Chars)
+      case EpochNanoKeyword  => Seq(last9Chars)
+      case _                 => Seq.empty
+    }
     override val patternWithoutSecondFractions: String = EpochKeyword
   }
 
@@ -86,28 +121,29 @@ object DateTimePattern {
 
     override val isEpoch: Boolean = false
     override val epochFactor: Long = 0
-    override val epochMilliFactor: Long = 0
 
     override val timeZoneInPattern: Boolean = DateTimePattern.timeZoneInPattern(pattern)
     override val defaultTimeZone: Option[String] = assignedDefaultTimeZone.filterNot(_ => timeZoneInPattern)
     override val isTimeZoned: Boolean = timeZoneInPattern || defaultTimeZone.nonEmpty
-    override val millisecondsPosition: Option[Section] = scanForPlaceholder(pattern, patternMilliSecondChar)
-    override val microsecondsPosition: Option[Section] = scanForPlaceholder(pattern, patternMicroSecondChar)
-    override val nanosecondsPosition: Option[Section] = scanForPlaceholder(pattern, patternNanoSecondChat)
-    override val containsSecondFraction: Boolean = microsecondsPosition.nonEmpty || millisecondsPosition.nonEmpty || nanosecondsPosition.nonEmpty
-  }
 
-  private def findSectionEnd(pattern: String, placeHolder: Char, fromIndex: Int): Int = {
-    var res = fromIndex
-    while ((res < pattern.length) && (pattern(res) == placeHolder)) {
-      res += 1
+    val (millisecondsPosition, microsecondsPosition, nanosecondsPosition) = analyzeSecondFractionsPositions(pattern)
+    override val secondFractionsSections: Seq[Section] = Section.mergeSections(Seq(millisecondsPosition, microsecondsPosition, nanosecondsPosition).flatten)
+    override val patternWithoutSecondFractions: String = Section.removeMultiple(pattern, secondFractionsSections)
+
+    private def scanForPlaceholder(withinString: String, placeHolder: Char): Option[Section] = {
+      val start = withinString.findFirstUnquoted(Set(placeHolder), Set('''))
+      start.map(index => Section.ofSameChars(withinString, index))
     }
-    res - 1
-  }
 
-  private def scanForPlaceholder(pattern: String, placeHolder: Char): Option[Section] = {
-    val start = pattern.findFirstUnquoted(Set(placeHolder), Set('''))
-    start.map(index => (index, findSectionEnd(pattern, placeHolder, index)))
+    private def analyzeSecondFractionsPositions(withinString: String): (Option[Section], Option[Section], Option[Section]) = {
+      val clearedPattern = withinString
+
+      // TODO as part of #677 fix
+      val milliSP = scanForPlaceholder(clearedPattern, patternMilliSecondChar)
+      val microSP = scanForPlaceholder(clearedPattern, patternMicroSecondChar)
+      val nanoSP = scanForPlaceholder(clearedPattern, patternNanoSecondChat)
+      (milliSP, microSP, nanoSP)
+    }
   }
 
   private def create(pattern: String, assignedDefaultTimeZone: Option[String], isDefault: Boolean): DateTimePattern = {
@@ -137,7 +173,7 @@ object DateTimePattern {
 
   def isEpoch(pattern: String): Boolean = {
     pattern.toLowerCase match {
-      case EpochKeyword | EpochMilliKeyword => true
+      case EpochKeyword | EpochMilliKeyword | EpochMicroKeyword | EpochNanoKeyword => true
       case _ => false
     }
   }
@@ -145,15 +181,9 @@ object DateTimePattern {
   def epochFactor(pattern: String): Long = {
     pattern.toLowerCase match {
       case EpochKeyword      => epochUnitFactor
-      case EpochMilliKeyword => epochThousandFactor
-      case _                 => 0
-    }
-  }
-
-  def epochMilliFactor(pattern: String): Long = {
-    pattern.toLowerCase match {
-      case EpochKeyword      => epochThousandFactor
-      case EpochMilliKeyword => epochUnitFactor
+      case EpochMilliKeyword => epoch1kFactor
+      case EpochMicroKeyword => epoch1MFactor
+      case EpochNanoKeyword  => epoch1GFactor
       case _                 => 0
     }
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/DateTimePattern.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/DateTimePattern.scala
@@ -128,7 +128,7 @@ object DateTimePattern {
 
     val (millisecondsPosition, microsecondsPosition, nanosecondsPosition) = analyzeSecondFractionsPositions(pattern)
     override val secondFractionsSections: Seq[Section] = Section.mergeSections(Seq(millisecondsPosition, microsecondsPosition, nanosecondsPosition).flatten)
-    override val patternWithoutSecondFractions: String = Section.removeMultiple(pattern, secondFractionsSections)
+    override val patternWithoutSecondFractions: String = Section.removeMultipleFrom(pattern, secondFractionsSections)
 
     private def scanForPlaceholder(withinString: String, placeHolder: Char): Option[Section] = {
       val start = withinString.findFirstUnquoted(Set(placeHolder), Set('''))

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParser.scala
@@ -59,9 +59,9 @@ case class EnceladusDateTimeParser(pattern: DateTimePattern) {
       }
 
       val injections: Map[Section, String] = Seq(
-        pattern.millisecondsPosition.map(x => (x, Section(-x.length, x.length).extract(nanoString.substring(0, 3)))),
-        pattern.microsecondsPosition.map(x => (x, Section(-x.length, x.length).extract(nanoString.substring(0, 6)))),
-        pattern.nanosecondsPosition.map(x => (x, Section(-x.length, x.length).extract(nanoString)))
+        pattern.millisecondsPosition.map(x => (x, Section(-x.length, x.length).extractFrom(nanoString.substring(0, 3)))),
+        pattern.microsecondsPosition.map(x => (x, Section(-x.length, x.length).extractFrom(nanoString.substring(0, 6)))),
+        pattern.nanosecondsPosition.map(x => (x, Section(-x.length, x.length).extractFrom(nanoString)))
       ).flatten.toMap
 
       val sections: Seq[Section] = Seq(
@@ -71,7 +71,7 @@ case class EnceladusDateTimeParser(pattern: DateTimePattern) {
       ).flatten.sorted
 
       sections.foldLeft(preliminaryResult) ((result, section) =>
-        section.inject(result, injections(section))
+        section.injectInto(result, injections(section))
       )
       // scalastyle:on magic.number
     } else {
@@ -90,7 +90,7 @@ case class EnceladusDateTimeParser(pattern: DateTimePattern) {
 
   private def extractSeconds(value: String): Long = {
     val valueToParse = if (pattern.containsSecondFractions) {
-      Section.removeMultiple(value, pattern.secondFractionsSections)
+      Section.removeMultipleFrom(value, pattern.secondFractionsSections)
     } else {
       value
     }
@@ -101,9 +101,9 @@ case class EnceladusDateTimeParser(pattern: DateTimePattern) {
 
   private def extractNanoseconds(value: String): Int = {
     var result = 0
-    pattern.millisecondsPosition.foreach(result += _.extract(value).toInt * NanosecondsInMillisecond)
-    pattern.microsecondsPosition.foreach(result += _.extract(value).toInt * NanosecondsInMicrosecond)
-    pattern.nanosecondsPosition.foreach(result += _.extract(value).toInt)
+    pattern.millisecondsPosition.foreach(result += _.extractFrom(value).toInt * NanosecondsInMillisecond)
+    pattern.microsecondsPosition.foreach(result += _.extractFrom(value).toInt * NanosecondsInMicrosecond)
+    pattern.nanosecondsPosition.foreach(result += _.extractFrom(value).toInt)
     result
   }
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParser.scala
@@ -18,6 +18,8 @@ package za.co.absa.enceladus.utils.time
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
 import java.util.Locale
+import EnceladusDateTimeParser._
+import za.co.absa.enceladus.utils.general.Section
 
 /**
   * Enables to parse string to date and timestamp based on the provided format
@@ -28,30 +30,89 @@ case class EnceladusDateTimeParser(pattern: DateTimePattern) {
   private val formatter: Option[SimpleDateFormat] = if (pattern.isEpoch) {
     None
   } else {
-    Some(new SimpleDateFormat(pattern, Locale.US)) // locale here is hardcoded to the same value as Spark uses
+    Some(new SimpleDateFormat(pattern.patternWithoutSecondFractions, Locale.US)) // locale here is hardcoded to the same value as Spark uses
   }
 
-  private def convertValue(value: String): Long = {
-    formatter.map(_.parse(value).getTime).getOrElse(
-      value.toLong * pattern.epochMilliFactor
+  private def makePreciseTimestamp(seconds: Long, nanoseconds: Int): Timestamp = {
+    val result = new Timestamp(seconds * MillisecondsInSecond)
+    if (nanoseconds > 0) {
+    result.setNanos(nanoseconds)
+    }
+    result
+  }
+
+  private def extractSeconds(value: String): Long = {
+    val valueToParse = if (pattern.containsSecondFractions) {
+      Section.removeMultiple(value, pattern.secondFractionsSections)
+    } else {
+      value
+    }
+    formatter.map(_.parse(valueToParse).getTime / MillisecondsInSecond).getOrElse(
+      valueToParse.toLong
     )
+  }
+
+  private def extractNanoseconds(value: String): Int = {
+    var result = 0
+    pattern.millisecondsPosition.foreach(result += _.extract(value).toInt * NanosecondsInMillisecond)
+    pattern.microsecondsPosition.foreach(result += _.extract(value).toInt * NanosecondsInMicrosecond)
+    pattern.nanosecondsPosition.foreach(result += _.extract(value).toInt)
+    result
   }
 
   def parseDate(dateValue: String): Date = {
-    new Date(convertValue(dateValue))
+    new Date(extractSeconds(dateValue) * 1000)
   }
 
   def parseTimestamp(timestampValue: String): Timestamp = {
-    new Timestamp(convertValue(timestampValue))
+    val seconds = extractSeconds(timestampValue)
+    val nanoseconds = extractNanoseconds(timestampValue)
+    makePreciseTimestamp(seconds, nanoseconds)
   }
 
   def format(time: java.util.Date): String = {
-    formatter.map(_.format(time)).getOrElse(
-      (time.getTime / pattern.epochMilliFactor).toString
+
+
+    //up to milliseconds it's easy with the formatter
+    val preliminaryResult = formatter.map(_.format(time)).getOrElse(
+      (time.getTime / MillisecondsInSecond).toString
     )
+    if (pattern.containsSecondFractions) {
+      // fractions of second present
+      // scalastyle:off magic.number
+      // 9 has the relation that nano- is a 10^-9 prefix, micro- is 10^-6 and milli is 10^-3
+      val nanoString = time match {
+        case ts: Timestamp => "%09d".format(ts.getNanos)
+        case _ => "000000000"
+      }
+
+      val injections: Map[Section, String] = Seq(
+        pattern.millisecondsPosition.map(x => (x, Section(-x.length, x.length).extract(nanoString.substring(0, 3)))),
+        pattern.microsecondsPosition.map(x => (x, Section(-x.length, x.length).extract(nanoString.substring(0, 6)))),
+        pattern.nanosecondsPosition.map(x => (x, Section(-x.length, x.length).extract(nanoString)))
+      ).flatten.toMap
+
+      val sections: Seq[Section] = Seq(
+        pattern.millisecondsPosition,
+        pattern.microsecondsPosition,
+        pattern.nanosecondsPosition
+      ).flatten.sorted
+
+      sections.foldLeft(preliminaryResult) ((result, item) =>
+        item.inject(result, injections(item))
+      )
+      // scalastyle:on magic.number
+    } else {
+      // no fractions of second
+      preliminaryResult
+    }
   }
 }
 
 object EnceladusDateTimeParser {
+  private val MillisecondsInSecond = 1000
+  private val NanosecondsInMillisecond = 1000000
+  private val NanosecondsInMicrosecond = 1000
+
   def apply(pattern: String): EnceladusDateTimeParser = new EnceladusDateTimeParser(DateTimePattern(pattern))
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParser.scala
@@ -71,7 +71,7 @@ case class EnceladusDateTimeParser(pattern: DateTimePattern) {
       ).flatten.sorted
 
       sections.foldLeft(preliminaryResult) ((result, section) =>
-        section.injectInto(result, injections(section))
+        section.injectInto(result, injections(section)).getOrElse(result)
       )
       // scalastyle:on magic.number
     } else {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDate.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDate.scala
@@ -47,21 +47,23 @@ object FieldValidatorDate extends FieldValidatorDateTime {
     }
 
     val patternIssues: Seq[ValidationIssue] = if (!pattern.isEpoch) {
-      val placeholders = Set('y', 'M', 'd', 'H', 'm', 's', 'D', 'S', 'a', 'k', 'K', 'h')
-      val patternChars = pattern.pattern.countUnquoted(placeholders, Set('''))
-      patternChars.foldLeft(List.empty[ValidationIssue]) {(acc, item) => item match {
-        case ('y', 0) => ValidationWarning("No year placeholder 'yyyy' found.")::acc
-        case ('M', 0) => ValidationWarning("No month placeholder 'MM' found.")::acc
-        case ('d', 0) => ValidationWarning("No day placeholder 'dd' found.")::acc
-        case ('H', x) if x > 0 => ValidationWarning("Redundant hour placeholder 'H' found.")::acc
-        case ('m', x) if x > 0 => ValidationWarning("Redundant minute placeholder 'm' found.")::acc
-        case ('s', x) if x > 0 => ValidationWarning("Redundant second placeholder 's' found.")::acc
-        case ('S', x) if x > 0 => ValidationWarning("Redundant millisecond placeholder 'S' found.")::acc
-        case ('a', x) if x > 0 => ValidationWarning("Redundant am/pm placeholder 'a' found.")::acc
-        case ('k', x) if x > 0 => ValidationWarning("Redundant hour placeholder 'k' found.")::acc
-        case ('h', x) if x > 0 => ValidationWarning("Redundant hour placeholder 'h' found.")::acc
-        case ('K', x) if x > 0 => ValidationWarning("Redundant hour placeholder 'H' found.")::acc
-        case ('D', x) if x > 0 && patternChars('d') == 0  =>
+      val placeholders = Set('y', 'M', 'd', 'H', 'm', 's', 'D', 'S', 'i', 'n', 'a', 'k', 'K', 'h')
+      val patternChars: Map[Char, Int] = pattern.pattern.countUnquoted(placeholders, Set('''))
+      patternChars.foldLeft(List.empty[ValidationIssue]) {(acc, item) => (item._1, item._2 > 0) match {
+        case ('y', false) => ValidationWarning("No year placeholder 'yyyy' found.")::acc
+        case ('M', false) => ValidationWarning("No month placeholder 'MM' found.")::acc
+        case ('d', false) => ValidationWarning("No day placeholder 'dd' found.")::acc
+        case ('H', true) => ValidationWarning("Redundant hour placeholder 'H' found.")::acc
+        case ('m', true) => ValidationWarning("Redundant minute placeholder 'm' found.")::acc
+        case ('s', true) => ValidationWarning("Redundant second placeholder 's' found.")::acc
+        case ('S', true) => ValidationWarning("Redundant millisecond placeholder 'S' found.")::acc
+        case ('i', true) => ValidationWarning("Redundant microsecond placeholder 'i' found.")::acc
+        case ('n', true) => ValidationWarning("Redundant nanosecond placeholder 'n' found.")::acc
+        case ('a', true) => ValidationWarning("Redundant am/pm placeholder 'a' found.")::acc
+        case ('k', true) => ValidationWarning("Redundant hour placeholder 'k' found.")::acc
+        case ('h', true) => ValidationWarning("Redundant hour placeholder 'h' found.")::acc
+        case ('K', true) => ValidationWarning("Redundant hour placeholder 'H' found.")::acc
+        case ('D', true) if patternChars('d') == 0  =>
           ValidationWarning("Rarely used DayOfYear placeholder 'D' found. Possibly DayOfMonth 'd' intended.")::acc
         case _ => acc
       }}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDateTime.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDateTime.scala
@@ -21,8 +21,7 @@ import java.util.TimeZone
 
 import org.apache.spark.sql.types.{StringType, StructField}
 import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue}
-import za.co.absa.enceladus.utils.time.{DateTimePattern, EnceladusDateTimeParser, TimeZoneNormalizer}
-import org.apache.spark.sql.functions._
+import za.co.absa.enceladus.utils.time.{DateTimePattern, EnceladusDateTimeParser}
 
 import scala.util.control.NonFatal
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestamp.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestamp.scala
@@ -39,32 +39,40 @@ object FieldValidatorTimestamp extends FieldValidatorDateTime {
       Nil
     }
 
-    val patternIssues: Seq[ValidationIssue] = if (!pattern.isEpoch) {
-      val placeholders = Set('y', 'M', 'd', 'H', 'm', 's', 'D', 'K', 'h', 'a', 'k')
-      val patternChars = pattern.pattern.countUnquoted(placeholders, Set('''))
-      patternChars.foldLeft(List.empty[ValidationIssue]) {(acc, item) => item match {
-        case ('y', 0) => ValidationWarning("No year placeholder 'yyyy' found.")::acc
-        case ('M', 0) => ValidationWarning("No month placeholder 'MM' found.")::acc
-        case ('d', 0) => ValidationWarning("No day placeholder 'dd' found.")::acc
-        case ('H', 0) if patternChars('k') + patternChars('K') + patternChars('h') == 0 =>
-          ValidationWarning("No hour placeholder 'HH' found.")::acc
-        case ('m', 0) => ValidationWarning("No minute placeholder 'mm' found.")::acc
-        case ('s', 0) => ValidationWarning("No second placeholder 'ss' found.")::acc
-        case ('D', x) if x > 0 && patternChars('d') == 0 =>
-          ValidationWarning("Rarely used DayOfYear placeholder 'D' found. Possibly DayOfMonth 'd' intended.")::acc
-        case ('h', x) if x > 0 && patternChars('a') == 0 =>
-          ValidationWarning(
-            "Placeholder for hour 1-12 'h' found, but no am/pm 'a' placeholder. Possibly 0-23 'H' intended."
+    val patternIssues: Seq[ValidationIssue] =
+        if (pattern.pattern == DateTimePattern.EpochNanoKeyword) {
+          List(ValidationWarning(
+            "Pattern 'epochnano'. While supported it comes with possible loss of precision beyond microseconds."
+          ))
+        } else if (!pattern.isEpoch) {
+        val placeholders = Set('y', 'M', 'd', 'H', 'm', 's', 'D', 'K', 'h', 'a', 'k', 'n')
+        val patternChars = pattern.pattern.countUnquoted(placeholders, Set('''))
+        patternChars.foldLeft(List.empty[ValidationIssue]) {(acc, item) => item match {
+          case ('y', 0) => ValidationWarning("No year placeholder 'yyyy' found.")::acc
+          case ('M', 0) => ValidationWarning("No month placeholder 'MM' found.")::acc
+          case ('d', 0) => ValidationWarning("No day placeholder 'dd' found.")::acc
+          case ('H', 0) if patternChars('k') + patternChars('K') + patternChars('h') == 0 =>
+            ValidationWarning("No hour placeholder 'HH' found.")::acc
+          case ('m', 0) => ValidationWarning("No minute placeholder 'mm' found.")::acc
+          case ('s', 0) => ValidationWarning("No second placeholder 'ss' found.")::acc
+          case ('D', x) if x > 0 && patternChars('d') == 0 =>
+            ValidationWarning("Rarely used DayOfYear placeholder 'D' found. Possibly DayOfMonth 'd' intended.")::acc
+          case ('h', x) if x > 0 && patternChars('a') == 0 =>
+            ValidationWarning(
+              "Placeholder for hour 1-12 'h' found, but no am/pm 'a' placeholder. Possibly 0-23 'H' intended."
+            )::acc
+          case ('K', x) if x > 0 && patternChars('a') == 0 =>
+            ValidationWarning(
+              "Placeholder for hour 0-11 'K' found, but no am/pm 'a' placeholder. Possibly 1-24 'k' intended."
+            )::acc
+          case ('n', x) if x > 0 => ValidationWarning(
+            "Placeholder 'n' for nanoseconds recognized. While supported it brings possible loss of precision."
           )::acc
-        case ('K', x) if x > 0 && patternChars('a') == 0 =>
-          ValidationWarning(
-            "Placeholder for hour 0-11 'K' found, but no am/pm 'a' placeholder. Possibly 1-24 'k' intended."
-          )::acc
-        case _ => acc
-      }}
-    } else {
-      Nil
-    }
+          case _ => acc
+        }}
+      } else {
+        Nil
+      }
     doubleTimeZoneIssue ++ patternIssues
   }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestamp.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestamp.scala
@@ -66,7 +66,7 @@ object FieldValidatorTimestamp extends FieldValidatorDateTime {
               "Placeholder for hour 0-11 'K' found, but no am/pm 'a' placeholder. Possibly 1-24 'k' intended."
             )::acc
           case ('n', x) if x > 0 => ValidationWarning(
-            "Placeholder 'n' for nanoseconds recognized. While supported it brings possible loss of precision."
+            "Placeholder 'n' for nanoseconds recognized. While supported, it brings possible loss of precision."
           )::acc
           case _ => acc
         }}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/general/SectionSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/general/SectionSuite.scala
@@ -22,16 +22,16 @@ import org.scalatest.FunSuite
 class SectionSuite extends FunSuite {
 
   private def check(section: Section, fullString: String, remainder: String, extracted: String): Unit = {
-    assert(section.remove(fullString) == remainder)
-    assert(section.extract(fullString) == extracted)
-    assert(section.inject(remainder, extracted) == fullString)
+    assert(section.removeFrom(fullString) == remainder)
+    assert(section.extractFrom(fullString) == extracted)
+    assert(section.injectInto(remainder, extracted) == fullString)
   }
 
   def circularCheck(start: Integer, length: Int, string: String): Unit = {
     val section = Section(start, length)
-    val removeResult = section.remove(string)
-    val extractResult = section.extract(string)
-    val injectResult = section.inject(removeResult, extractResult)
+    val removeResult = section.removeFrom(string)
+    val extractResult = section.extractFrom(string)
+    val injectResult = section.injectInto(removeResult, extractResult)
     assert(injectResult == string)
   }
 
@@ -39,7 +39,7 @@ class SectionSuite extends FunSuite {
     "The length of the string to inject (%d) doesn't match Section(%d, %d) for string of length %d."
 
 
-  test("Negative length = exception") {
+  test("Negative length causes exception") {
     val value = -1
     val message = s"'length; cannot be negative, $value given"
     val caught = intercept[InvalidParameterException] {
@@ -49,7 +49,7 @@ class SectionSuite extends FunSuite {
     assert(caught.getMessage == message)
   }
 
-  test("Overflow exception") {
+  test("Section end would overflow integer causes exception") {
     val value = -1
     val message = s"start and length combination are grater then ${Int.MaxValue}"
     val caught = intercept[IndexOutOfBoundsException] {
@@ -88,7 +88,7 @@ class SectionSuite extends FunSuite {
   }
 
   //toSubstringParameters
-  test("toSubstringParameters: standard positive") {
+  test("toSubstringParameters: simple case with positive value of Start") {
     val start = 3
     val length = 5
     val after = 8
@@ -101,7 +101,7 @@ class SectionSuite extends FunSuite {
     assert(result2 == (0, 0))
   }
 
-  test("toSubstringParameters: negative within bounds") {
+  test("toSubstringParameters: with negative value of Start, within bounds of the string") {
     val start = -6
     val length = 3
 
@@ -111,7 +111,7 @@ class SectionSuite extends FunSuite {
     assert(result == (5, 8))
   }
 
-  test("toSubstringParameters: negative on short string") {
+  test("toSubstringParameters: with negative value of Start, on a too short string") {
     val start = -5
     val length = 3
 
@@ -122,7 +122,7 @@ class SectionSuite extends FunSuite {
   }
 
   //extract, remove, inject
-  test("extract, remove, inject: positive within") {
+  test("extractFrom, removeFrom, injectInto: with positive value of Start within the input string") {
     val section = Section(2,4)
     val fullString = "abcdefghi"
     val remainder = "abghi"
@@ -130,7 +130,7 @@ class SectionSuite extends FunSuite {
     check(section, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: positive till the end") {
+  test("extractFrom, removeFrom, injectInto: with positive value of Start till the end of the input string") {
     val section = Section(4,2)
     val fullString = "abcdef"
     val remainder = "abcd"
@@ -138,7 +138,7 @@ class SectionSuite extends FunSuite {
     check(section, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: positive over the end") {
+  test("extractFrom, removeFrom, injectInto: with positive value of Start, extending over the end of the input string") {
     val section = Section(4,4)
     val fullString = "abcdef"
     val remainder = "abcd"
@@ -146,7 +146,7 @@ class SectionSuite extends FunSuite {
     check(section, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: positive beyond") {
+  test("extractFrom, removeFrom, injectInto: with positive value of Start, Start beyond the end of input string") {
     val section = Section(10,7)
     val fullString = "abcdef"
     val remainder = "abcdef"
@@ -154,7 +154,7 @@ class SectionSuite extends FunSuite {
     check(section, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: negative within") {
+  test("extractFrom, removeFrom, injectInto: with negative value of Start, within the input string") {
     val section = Section (-4,2)
     val fullString = "abcdef"
     val remainder = "abef"
@@ -162,7 +162,7 @@ class SectionSuite extends FunSuite {
     check(section, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: negative before begin") {
+  test("extractFrom, removeFrom, injectInto: with negative value of Start, before beginning of the input string") {
     val section = Section (-8,5)
     val fullString = "abcdef"
     val remainder = "def"
@@ -170,7 +170,7 @@ class SectionSuite extends FunSuite {
     check(section, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: negative before begin, far") {
+  test("extractFrom, removeFrom, injectInto: with negative value of Start, far before beginning of the input string") {
     val section = Section (-10,3)
     val fullString = "abcdef"
     val remainder = "abcdef"
@@ -178,7 +178,7 @@ class SectionSuite extends FunSuite {
     check(section, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: negative over end") {
+  test("extractFrom, removeFrom, injectInto: with negative value of Start, extending over end of the input string") {
     val section = Section (-2,4)
     val fullString = "abcdef"
     val remainder = "abcd"
@@ -186,7 +186,7 @@ class SectionSuite extends FunSuite {
     check(section, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: zero length") {
+  test("extractFrom, removeFrom, injectInto: zero length sections") {
     val section1 = Section (2,0)
     val section2 = Section (0,0)
     val section3 = Section (-2,0)
@@ -202,7 +202,7 @@ class SectionSuite extends FunSuite {
     check(section5, fullString, remainder, extracted)
   }
 
-  test("extract, remove, inject: whole spectrum automated, length 0") {
+  test("extractFrom, removeFrom, injectInto (automated): whole spectrum of Start, length 0") {
     val playString = "abcdefghij"
     val length = 0
     for (i <- -15 to 15) {
@@ -210,7 +210,7 @@ class SectionSuite extends FunSuite {
     }
   }
 
-  test("extract, remove, inject: whole spectrum automated, length 3") {
+  test("extractFrom, removeFrom, injectInto (automated): whole spectrum of STart, length 3") {
     val playString = "abcdefghij"
     val length = 3
     for (i <- -15 to 15) {
@@ -218,7 +218,7 @@ class SectionSuite extends FunSuite {
     }
   }
   //inject
-  test("inject(into, what): too long") {
+  test("injectInto: injected string too long compared to Section") {
     val what = "what"
     val into = "This is long enough"
     val sec1 = Section(0, 3)
@@ -226,147 +226,147 @@ class SectionSuite extends FunSuite {
     val sec3 =  Section(-4, 3)
 
     val caught1 = intercept[InvalidParameterException] {
-      sec1.inject(into, what)
+      sec1.injectInto(into, what)
     }
     assert(caught1.getMessage == invalidParameterExceptionMessageTemplate.format(4, 0, 3, 19))
     val caught2 = intercept[InvalidParameterException] {
-      sec2.inject(into, what)
+      sec2.injectInto(into, what)
     }
     assert(caught2.getMessage == invalidParameterExceptionMessageTemplate.format(4, 2, 3, 19))
     val caught3 = intercept[InvalidParameterException] {
-      sec3.inject(into, what)
+      sec3.injectInto(into, what)
     }
     assert(caught3.getMessage == invalidParameterExceptionMessageTemplate.format(4, -4, 3, 19))
   }
 
-  test("inject(into, what): too short") {
+  test("injectInto: injected string too short compared to Section length") {
     val into = "abcdef"
 
     //within but short
     val section1 = Section(3, 3)
     val caught1 = intercept[InvalidParameterException] {
-      section1.inject(into, "xx")
+      section1.injectInto(into, "xx")
     }
     assert(caught1.getMessage == invalidParameterExceptionMessageTemplate.format(2, 3, 3, 6))
     //within from behind, but short
     val section2 = Section(-5, 3)
     val caught2 = intercept[InvalidParameterException] {
-      section2.inject(into, "xx")
+      section2.injectInto(into, "xx")
     }
     assert(caught2.getMessage == invalidParameterExceptionMessageTemplate.format(2, -5, 3, 6))
     //too far behind
     val section3 = Section(10, 3)
     val caught3 = intercept[InvalidParameterException] {
-      section3.inject(into, "xx")
+      section3.injectInto(into, "xx")
     }
     assert(caught3.getMessage == invalidParameterExceptionMessageTemplate.format(2, 10, 3, 6))
     //too far ahead
     val section4 = Section(-7, 3)
     val caught4 = intercept[InvalidParameterException] {
-      section4.inject(into, "xx")
+      section4.injectInto(into, "xx")
     }
     assert(caught4.getMessage == invalidParameterExceptionMessageTemplate.format(2, -7, 3, 6))
   }
 
-  test("inject: empty string") {
+  test("injectInto: empty string") {
     val into = "abcdef"
     val what = ""
     // ok for section length 0
-    assert(Section(3, 0).inject(into, what) == into)
+    assert(Section(3, 0).injectInto(into, what) == into)
     // ok for section behind
-    assert(Section(6, 3).inject(into, what) == into)
+    assert(Section(6, 3).injectInto(into, what) == into)
     // ok for section far enough ahead
-    assert(Section(-8, 2).inject(into, what) == into)
+    assert(Section(-8, 2).injectInto(into, what) == into)
     // fails otherwise
     val section1 = Section(2, 2)
     val caught1 = intercept[InvalidParameterException] {
-      section1.inject(into, what)
+      section1.injectInto(into, what)
     }
     assert(caught1.getMessage == invalidParameterExceptionMessageTemplate.format(0, 2, 2, 6))
   }
 
-  test("inject: Special fail on seemingly correct input, but not if considered as reverse to remove and except") {
+  test("injectInto: Special fail on seemingly correct input, but not if considered as reverse to remove and except") {
     val into = "abcdef"
     val what = "xxx"
     val section = Section(-2, 3)
     val caught = intercept[InvalidParameterException] {
-      section.inject(into, what)
+      section.injectInto(into, what)
     }
     assert(caught.getMessage == invalidParameterExceptionMessageTemplate.format(3, -2, 3, 6))
   }
 
   //distance
-  test("distance: negative and positive start") {
+  test("distance: two Sections with one negative and other positive value of Start") {
     val a = Section(-1, 12)
     val b = Section(3, 2)
     assert((a distance b) == (b distance a))
     assert((a distance b).isEmpty)
   }
 
-  test("distance: positive same") {
+  test("distance: two Sections with same positive values of Start") {
     val a = Section(5, 3)
     val b = Section(5, 3)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(-3))
   }
 
-  test("distance: positive standard") {
+  test("distance: two Sections with positive value of Start, gap between them") {
     val a = Section(3, 2)
     val b = Section(6, 2)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(1))
   }
 
-  test("distance: positive touching") {
+  test("distance: two Sections with positive value of Start, adjacent to each other") {
     val a = Section(3, 2)
     val b = Section(5, 2)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(0))
   }
 
-  test("distance: positive overlapping") {
+  test("distance: two Sections with positive value of Start, overlapping") {
     val a = Section(3, 4)
     val b = Section(5, 3)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(-2))
   }
 
-  test("distance: positive one within other") {
+  test("distance: two Sections with positive value of Start, one within other") {
     val a = Section(3, 3)
     val b = Section(4, 1)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(-2))
   }
 
-  test("distance: negative same") {
+  test("distance: two Sections with same negative values of Start") {
     val a = Section(-5, 3)
     val b = Section(-5, 3)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(-3))
   }
 
-  test("distance: negative standard") {
+  test("distance: two Sections with negative value of Start, gap between them") {
     val a = Section(-3, 2)
     val b = Section(-6, 2)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(1))
   }
 
-  test("distance: negative touching") {
+  test("distance: two Sections with negative value of Start, adjacent to each other") {
     val a = Section(-3, 2)
     val b = Section(-5, 2)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(0))
   }
 
-  test("distance: negative overlapping") {
+  test("distance: two Sections with negative value of Start, overlapping") {
     val a = Section(-3, 4)
     val b = Section(-5, 3)
     assert((a distance b) == (b distance a))
     assert((a distance b).contains(-1))
   }
 
-  test("distance: negative one within other") {
+  test("distance: two Sections with negative value of Start, one within other") {
     val a = Section(-5, 3)
     val b = Section(-4, 1)
     assert((a distance b) == (b distance a))
@@ -374,49 +374,49 @@ class SectionSuite extends FunSuite {
   }
 
   //overlaps
-  test("overlaps: no overlap - positive") {
+  test("overlaps: no overlap - with positive values of Start") {
     val a = Section(1, 2)
     val b = Section(4, 2)
     assert((a overlaps  b) == (b overlaps a))
     assert(!(a overlaps  b))
   }
 
-  test("overlaps: touching - positive") {
+  test("overlaps: touching - with positive values of Start") {
     val a = Section(1, 2)
     val b = Section(3, 2)
     assert((a overlaps  b) == (b overlaps a))
     assert(!(a overlaps  b))
   }
 
-  test("overlaps: overlap - positive") {
+  test("overlaps: overlap - with positive values of Start") {
     val a = Section(1, 3)
     val b = Section(3, 3)
     assert((a overlaps  b) == (b overlaps a))
     assert(a overlaps  b)
   }
 
-  test("overlaps: no overlap - negative") {
+  test("overlaps: no overlap - with negative values of Start") {
     val a = Section(-3, 2)
     val b = Section(-6, 2)
     assert((a overlaps  b) == (b overlaps a))
     assert(!(a overlaps  b))
   }
 
-  test("overlaps: touching - negative") {
+  test("overlaps: touching - with negative values of Start") {
     val a = Section(-3, 2)
     val b = Section(-6, 3)
     assert((a overlaps  b) == (b overlaps a))
     assert(!(a overlaps  b))
   }
 
-  test("overlaps: overlap - negative") {
+  test("overlaps: overlap - with negative values of Start") {
     val a = Section(-3, 2)
     val b = Section(-6, 4)
     assert((a overlaps  b) == (b overlaps a))
     assert(a overlaps  b)
   }
 
-  test("overlaps: overlap - negative abd positive") {
+  test("overlaps: overlap - one with negative value of Start and one with positive value of Start") {
     val a = Section(-1, 2)
     val b = Section(4, 2)
     assert((a overlaps b) == (b overlaps a))
@@ -424,49 +424,49 @@ class SectionSuite extends FunSuite {
   }
 
   //touches
-  test("touches: no overlap - positive") {
+  test("touches: no overlap - with positive values of Start") {
     val a = Section(1, 2)
     val b = Section(4, 2)
     assert((a touches  b) == (b touches a))
     assert(!(a touches  b))
   }
 
-  test("touches: touching - positive") {
+  test("touches: touching - with positive values of Start") {
     val a = Section(1, 2)
     val b = Section(3, 2)
     assert((a touches  b) == (b touches a))
     assert(a touches  b)
   }
 
-  test("touches: overlap - positive") {
+  test("touches: overlap - with positive values of Start") {
     val a = Section(1, 3)
     val b = Section(3, 3)
     assert((a touches  b) == (b touches a))
     assert(a touches  b)
   }
 
-  test("touches: no overlap - negative") {
+  test("touches: no overlap - with negative values of Start") {
     val a = Section(-3, 2)
     val b = Section(-6, 2)
     assert((a touches  b) == (b touches a))
     assert(!(a touches  b))
   }
 
-  test("touches: touching - negative") {
+  test("touches: touching - with negative values of Start") {
     val a = Section(-3, 2)
     val b = Section(-6, 3)
     assert((a touches  b) == (b touches a))
     assert(a touches  b)
   }
 
-  test("touches: overlap - negative") {
+  test("touches: overlap - with negative values of Start") {
     val a = Section(-3, 2)
     val b = Section(-6, 4)
     assert((a touches  b) == (b touches a))
     assert(a touches  b)
   }
 
-  test("touches: overlap - negative abd positive") {
+  test("touches: overlap - one with negative value of Start and one with positive value of Start") {
     val a = Section(-1, 2)
     val b = Section(4, 2)
     assert((a touches b) == (b touches a))
@@ -486,25 +486,25 @@ class SectionSuite extends FunSuite {
     assert(section == expected)
   }
 
-  test("ofSameChars: more characters, fromIndex start within") {
+  test("ofSameChars: more characters, fromIndex start within the sequence of same chars") {
     val section = Section.ofSameChars("aabbbbbccccddddd", 4)
     val expected = Section(4, 3)
     assert(section == expected)
   }
 
-  test("ofSameChars: out of range") {
+  test("ofSameChars: start  out of input string range") {
     val section = Section.ofSameChars("xxxxyyyzz", 20)
     val expected = Section(20, 0)
     assert(section == expected)
   }
 
-  test("ofSameChars: negative fromIndex") {
+  test("ofSameChars: with negative value of Start") {
     val section = Section.ofSameChars("xxxxyyyzz", -5)
     val expected = Section(-5, 3)
     assert(section == expected)
   }
 
-  test("ofSameChars: negative fromIndex far ahead") {
+  test("ofSameChars: with negative value of Start, 'in front' of input string") {
     val section = Section.ofSameChars("xxxxyyyzz", -15)
     val expected = Section(-15, 0)
     assert(section == expected)
@@ -513,142 +513,142 @@ class SectionSuite extends FunSuite {
   //removeMultiple
   test("removeMultiple: two Sections") {
     val sections = Seq(Section(2, 2), Section(6, 3))
-    val result = Section.removeMultiple("abcdefghijkl", sections)
+    val result = Section.removeMultipleFrom("abcdefghijkl", sections)
     val expected = "abefjkl"
     assert(result == expected)
   }
 
   test("removeMultiple: three Sections, unordered") {
     val sections = Seq(Section(6, 3), Section(2, 2), Section(11, 2))
-    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val result = Section.removeMultipleFrom("abcdefghijklmnop", sections)
     val expected = "abefjknop"
     assert(result == expected)
   }
 
-  test("removeMultiple: adjacent") {
+  test("removeMultiple: adjacent Sections") {
     val sections = Seq(Section(2, 2), Section(11, 2), Section(6, 5))
-    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val result = Section.removeMultipleFrom("abcdefghijklmnop", sections)
     val expected = "abefnop"
     assert(result == expected)
   }
 
-  test("removeMultiple: overlapping") {
+  test("removeMultiple: overlapping Sections") {
     val sections = Seq(Section(2, 2), Section(10, 3), Section(6, 5))
-    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val result = Section.removeMultipleFrom("abcdefghijklmnop", sections)
     val expected = "abefnop"
     assert(result == expected)
   }
 
-  test("removeMultiple: negative") {
+  test("removeMultiple: one with negative value of Start, other positive") {
     val sections = Seq(Section(1, 1), Section(-2, 1))
-    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val result = Section.removeMultipleFrom("abcdefghijklmnop", sections)
     val expected = "acdefghijklmnp"
     assert(result == expected)
   }
 
-  test("removeMultiple: negative overlapping") {
+  test("removeMultiple: two Sections with negative value of Start, overlapping") {
     val sections = Seq(Section(-3, 3), Section(-5, 3))
-    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val result = Section.removeMultipleFrom("abcdefghijklmnop", sections)
     val expected = "abcdefghijk"
     assert(result == expected)
   }
 
-  test("removeMultiple: running out of bounds ") {
+  test("removeMultiple: two Sections running out of bounds of input string") {
     val sections = Seq(Section(-6, 2), Section(4, 2))
-    val result = Section.removeMultiple("abcde", sections)
+    val result = Section.removeMultipleFrom("abcde", sections)
     val expected = "bcd"
     assert(result == expected)
   }
 
-  test("removeMultiple: totally out of bounds ") {
+  test("removeMultiple: two Sections totally out of bounds of input string") {
     val sections = Seq(Section(-10, 2), Section(10, 2))
-    val result = Section.removeMultiple("abcde", sections)
+    val result = Section.removeMultipleFrom("abcde", sections)
     val expected = "abcde"
     assert(result == expected)
   }
 
   test("removeMultiple: zero length") {
     val sections = Seq(Section(1, 0), Section(-2, 0))
-    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val result = Section.removeMultipleFrom("abcdefghijklmnop", sections)
     val expected = "abcdefghijklmnop"
     assert(result == expected)
   }
 
   //mergeSections
-  test("mergeSections: empty") {
+  test("mergeSections: empty sequence of sections") {
     val sections = Seq.empty[Section]
     val result = Section.mergeSections(sections)
     assert(result.isEmpty)
   }
 
-  test("mergeSections: one item") {
+  test("mergeSections: one item in input sequence") {
     val sections = Seq(Section(42, 7))
     val result = Section.mergeSections(sections)
     assert(result == sections)
   }
 
-  test("mergeSections: touching") {
+  test("mergeSections: two pairs of touching sections, ordering checked too") {
     val sections = Seq(
-      Section( 1, 1),
-      Section( 3, 2),
-      Section(-4, 2),
-      Section( 5, 1),
-      Section(-7, 3),
-      Section(-1, 1)
+      Section( 1, 1), //D
+      Section( 3, 2), //B1
+      Section(-4, 2), //A2
+      Section( 5, 1), //B2
+      Section(-7, 3), //A1
+      Section(-1, 1)  //B
     )
     val expected = Seq(
-      Section(-7, 5),
-      Section(-1, 1),
-      Section( 3, 3),
-      Section( 1, 1)
+      Section(-7, 5), //->A
+      Section(-1, 1), //->B
+      Section( 3, 3), //->C
+      Section( 1, 1)  //->D
     )
     val result = Section.mergeSections(sections)
     assert(result == expected)
   }
 
-  test("mergeSections: overlapping") {
-    val sections = Seq(
-      //overlapping
-      Section( 11, 4),
-      Section(-20, 6),
-      Section( 12, 5),
-      Section(-23, 6),
-      Section( -1, 1),
-      Section(  1, 1)
-    )
-
-    val expected = Seq(
-      Section(-23, 9),
-      Section( -1, 1),
-      Section( 11, 6),
-      Section(  1, 1)
-    )
-    val result = Section.mergeSections(sections)
-    assert(result == expected)
-  }
-
-  test("mergeSections: two same") {
+  test("mergeSections: two pairs of overlapping sections, ordering checked too") {
     val sections = Seq(
       //overlapping
-      Section( 7, 5),
-      Section(-7, 5),
-      Section( 7, 5),
-      Section(-7, 5),
-      Section(-1, 1),
-      Section( 1, 1)
+      Section( 11, 4), //B1
+      Section(-20, 6), //A2
+      Section( 12, 5), //B2
+      Section(-23, 6), //A1
+      Section( -1, 1), //B
+      Section(  1, 1)  //D
     )
 
     val expected = Seq(
-      Section(-7, 5),
-      Section(-1, 1),
-      Section( 7, 5),
-      Section( 1, 1)
+      Section(-23, 9), //->A
+      Section( -1, 1), //->B
+      Section( 11, 6), //->C
+      Section(  1, 1)  //->D
     )
     val result = Section.mergeSections(sections)
     assert(result == expected)
   }
 
-  test("mergeSections: one withing other") {
+  test("mergeSections: two pairs of same sections") {
+    val sections = Seq(
+      //overlapping
+      Section( 7, 5), //C
+      Section(-7, 5), //A
+      Section( 7, 5), //C
+      Section(-7, 5), //A
+      Section(-1, 1), //B
+      Section( 1, 1)  //D
+    )
+
+    val expected = Seq(
+      Section(-7, 5), //->A
+      Section(-1, 1), //->B
+      Section( 7, 5), //->C
+      Section( 1, 1)  //->D
+    )
+    val result = Section.mergeSections(sections)
+    assert(result == expected)
+  }
+
+  test("mergeSections: one section withing other") {
     val sections = Seq(
       //overlapping
       Section( 12, 1), // E
@@ -664,35 +664,35 @@ class SectionSuite extends FunSuite {
     )
 
     val expected = Seq(
-      Section(-30, 9), // A
-      Section(-20, 6), // B
-      Section( -1, 1), // C
-      Section( 20, 5), // D
-      Section( 12, 5), // E
-      Section(  1, 1)  // F
+      Section(-30, 9), // ->A
+      Section(-20, 6), // ->B
+      Section( -1, 1), // ->C
+      Section( 20, 5), // ->D
+      Section( 12, 5), // ->E
+      Section(  1, 1)  // ->F
     )
     val result = Section.mergeSections(sections)
     assert(result == expected)
   }
 
-  test("mergeSections: sequence of 3") {
+  test("mergeSections: sequence of 3 sections") {
     val sections = Seq(
       //overlapping
-      Section( 22, 10),
-      Section(-42, 10),
-      Section( 10, 10),
-      Section(-35, 10),
-      Section( 15, 10),
-      Section(-30, 10),
-      Section( -1, 1),
-      Section(  1, 1)
+      Section( 22, 10), //C3
+      Section(-42, 10), //A1
+      Section( 10, 10), //C1
+      Section(-35, 10), //A2
+      Section( 15, 10), //C2
+      Section(-30, 10), //A3
+      Section( -1, 1),  //B
+      Section(  1, 1)   //D
     )
 
     val expected = Seq(
-      Section(-42, 22),
-      Section( -1, 1),
-      Section( 10, 22),
-      Section(  1, 1)
+      Section(-42, 22), //->A
+      Section( -1, 1),  //->B
+      Section( 10, 22), //->C
+      Section(  1, 1)   //->D
     )
     val result = Section.mergeSections(sections)
     assert(result == expected)

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/general/SectionSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/general/SectionSuite.scala
@@ -1,0 +1,700 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.general
+
+import java.security.InvalidParameterException
+
+import org.scalatest.FunSuite
+
+class SectionSuite extends FunSuite {
+
+  private def check(section: Section, fullString: String, remainder: String, extracted: String): Unit = {
+    assert(section.remove(fullString) == remainder)
+    assert(section.extract(fullString) == extracted)
+    assert(section.inject(remainder, extracted) == fullString)
+  }
+
+  def circularCheck(start: Integer, length: Int, string: String): Unit = {
+    val section = Section(start, length)
+    val removeResult = section.remove(string)
+    val extractResult = section.extract(string)
+    val injectResult = section.inject(removeResult, extractResult)
+    assert(injectResult == string)
+  }
+
+  private val invalidParameterExceptionMessageTemplate =
+    "The length of the string to inject (%d) doesn't match Section(%d, %d) for string of length %d."
+
+
+  test("Negative length = exception") {
+    val value = -1
+    val message = s"'length; cannot be negative, $value given"
+    val caught = intercept[InvalidParameterException] {
+      Section(3, -1)
+    }
+
+    assert(caught.getMessage == message)
+  }
+
+  test("Overflow exception") {
+    val value = -1
+    val message = s"start and length combination are grater then ${Int.MaxValue}"
+    val caught = intercept[IndexOutOfBoundsException] {
+      Section(Int.MaxValue - 2, 3)
+    }
+
+    assert(caught.getMessage == message)
+  }
+
+  //sorting
+  test("Sorting") {
+    val inputSeq = Seq(
+      Section(-11, 3),
+      Section(-13, 5),
+      Section(-13, 1),
+      Section(-12, 2),
+      Section(6, 6),
+      Section(6, 1),
+      Section(2, 3),
+      Section(4, 1),
+      Section(0, 1)
+    )
+    val expectedSeq = Seq(
+      Section(0, 1),
+      Section(2, 3),
+      Section(4, 1),
+      Section(6, 1),
+      Section(6, 6),
+      Section(-11, 3),
+      Section(-12, 2),
+      Section(-13, 1),
+      Section(-13, 5)
+    )
+
+    assert(inputSeq.sorted == expectedSeq)
+  }
+
+  //toSubstringParameters
+  test("toSubstringParameters: standard positive") {
+    val start = 3
+    val length = 5
+    val after = 8
+
+    val section = Section(start, length)
+
+    val result1 = section.toSubstringParameters("Hello world")
+    assert(result1 == (start, after))
+    val result2 = section.toSubstringParameters("")
+    assert(result2 == (0, 0))
+  }
+
+  test("toSubstringParameters: negative within bounds") {
+    val start = -6
+    val length = 3
+
+    val section = Section(start, length)
+
+    val result = section.toSubstringParameters("Hello world")
+    assert(result == (5, 8))
+  }
+
+  test("toSubstringParameters: negative on short string") {
+    val start = -5
+    val length = 3
+
+    val section = Section(start, length)
+
+    val result = section.toSubstringParameters("foo")
+    assert(result == (0, 1))
+  }
+
+  //extract, remove, inject
+  test("extract, remove, inject: positive within") {
+    val section = Section(2,4)
+    val fullString = "abcdefghi"
+    val remainder = "abghi"
+    val extracted = "cdef"
+    check(section, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: positive till the end") {
+    val section = Section(4,2)
+    val fullString = "abcdef"
+    val remainder = "abcd"
+    val extracted = "ef"
+    check(section, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: positive over the end") {
+    val section = Section(4,4)
+    val fullString = "abcdef"
+    val remainder = "abcd"
+    val extracted = "ef"
+    check(section, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: positive beyond") {
+    val section = Section(10,7)
+    val fullString = "abcdef"
+    val remainder = "abcdef"
+    val extracted = ""
+    check(section, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: negative within") {
+    val section = Section (-4,2)
+    val fullString = "abcdef"
+    val remainder = "abef"
+    val extracted = "cd"
+    check(section, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: negative before begin") {
+    val section = Section (-8,5)
+    val fullString = "abcdef"
+    val remainder = "def"
+    val extracted = "abc"
+    check(section, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: negative before begin, far") {
+    val section = Section (-10,3)
+    val fullString = "abcdef"
+    val remainder = "abcdef"
+    val extracted = ""
+    check(section, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: negative over end") {
+    val section = Section (-2,4)
+    val fullString = "abcdef"
+    val remainder = "abcd"
+    val extracted = "ef"
+    check(section, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: zero length") {
+    val section1 = Section (2,0)
+    val section2 = Section (0,0)
+    val section3 = Section (-2,0)
+    val section4 = Section (20,0)
+    val section5 = Section (-20,0)
+    val fullString = "abcdef"
+    val remainder = "abcdef"
+    val extracted = ""
+    check(section1, fullString, remainder, extracted)
+    check(section2, fullString, remainder, extracted)
+    check(section3, fullString, remainder, extracted)
+    check(section4, fullString, remainder, extracted)
+    check(section5, fullString, remainder, extracted)
+  }
+
+  test("extract, remove, inject: whole spectrum automated, length 0") {
+    val playString = "abcdefghij"
+    val length = 0
+    for (i <- -15 to 15) {
+      circularCheck(i, length, playString)
+    }
+  }
+
+  test("extract, remove, inject: whole spectrum automated, length 3") {
+    val playString = "abcdefghij"
+    val length = 3
+    for (i <- -15 to 15) {
+      circularCheck(i, length, playString)
+    }
+  }
+  //inject
+  test("inject(into, what): too long") {
+    val what = "what"
+    val into = "This is long enough"
+    val sec1 = Section(0, 3)
+    val sec2 = Section(2,3)
+    val sec3 =  Section(-4, 3)
+
+    val caught1 = intercept[InvalidParameterException] {
+      sec1.inject(into, what)
+    }
+    assert(caught1.getMessage == invalidParameterExceptionMessageTemplate.format(4, 0, 3, 19))
+    val caught2 = intercept[InvalidParameterException] {
+      sec2.inject(into, what)
+    }
+    assert(caught2.getMessage == invalidParameterExceptionMessageTemplate.format(4, 2, 3, 19))
+    val caught3 = intercept[InvalidParameterException] {
+      sec3.inject(into, what)
+    }
+    assert(caught3.getMessage == invalidParameterExceptionMessageTemplate.format(4, -4, 3, 19))
+  }
+
+  test("inject(into, what): too short") {
+    val into = "abcdef"
+
+    //within but short
+    val section1 = Section(3, 3)
+    val caught1 = intercept[InvalidParameterException] {
+      section1.inject(into, "xx")
+    }
+    assert(caught1.getMessage == invalidParameterExceptionMessageTemplate.format(2, 3, 3, 6))
+    //within from behind, but short
+    val section2 = Section(-5, 3)
+    val caught2 = intercept[InvalidParameterException] {
+      section2.inject(into, "xx")
+    }
+    assert(caught2.getMessage == invalidParameterExceptionMessageTemplate.format(2, -5, 3, 6))
+    //too far behind
+    val section3 = Section(10, 3)
+    val caught3 = intercept[InvalidParameterException] {
+      section3.inject(into, "xx")
+    }
+    assert(caught3.getMessage == invalidParameterExceptionMessageTemplate.format(2, 10, 3, 6))
+    //too far ahead
+    val section4 = Section(-7, 3)
+    val caught4 = intercept[InvalidParameterException] {
+      section4.inject(into, "xx")
+    }
+    assert(caught4.getMessage == invalidParameterExceptionMessageTemplate.format(2, -7, 3, 6))
+  }
+
+  test("inject: empty string") {
+    val into = "abcdef"
+    val what = ""
+    // ok for section length 0
+    assert(Section(3, 0).inject(into, what) == into)
+    // ok for section behind
+    assert(Section(6, 3).inject(into, what) == into)
+    // ok for section far enough ahead
+    assert(Section(-8, 2).inject(into, what) == into)
+    // fails otherwise
+    val section1 = Section(2, 2)
+    val caught1 = intercept[InvalidParameterException] {
+      section1.inject(into, what)
+    }
+    assert(caught1.getMessage == invalidParameterExceptionMessageTemplate.format(0, 2, 2, 6))
+  }
+
+  test("inject: Special fail on seemingly correct input, but not if considered as reverse to remove and except") {
+    val into = "abcdef"
+    val what = "xxx"
+    val section = Section(-2, 3)
+    val caught = intercept[InvalidParameterException] {
+      section.inject(into, what)
+    }
+    assert(caught.getMessage == invalidParameterExceptionMessageTemplate.format(3, -2, 3, 6))
+  }
+
+  //distance
+  test("distance: negative and positive start") {
+    val a = Section(-1, 12)
+    val b = Section(3, 2)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).isEmpty)
+  }
+
+  test("distance: positive same") {
+    val a = Section(5, 3)
+    val b = Section(5, 3)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(-3))
+  }
+
+  test("distance: positive standard") {
+    val a = Section(3, 2)
+    val b = Section(6, 2)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(1))
+  }
+
+  test("distance: positive touching") {
+    val a = Section(3, 2)
+    val b = Section(5, 2)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(0))
+  }
+
+  test("distance: positive overlapping") {
+    val a = Section(3, 4)
+    val b = Section(5, 3)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(-2))
+  }
+
+  test("distance: positive one within other") {
+    val a = Section(3, 3)
+    val b = Section(4, 1)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(-2))
+  }
+
+  test("distance: negative same") {
+    val a = Section(-5, 3)
+    val b = Section(-5, 3)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(-3))
+  }
+
+  test("distance: negative standard") {
+    val a = Section(-3, 2)
+    val b = Section(-6, 2)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(1))
+  }
+
+  test("distance: negative touching") {
+    val a = Section(-3, 2)
+    val b = Section(-5, 2)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(0))
+  }
+
+  test("distance: negative overlapping") {
+    val a = Section(-3, 4)
+    val b = Section(-5, 3)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(-1))
+  }
+
+  test("distance: negative one within other") {
+    val a = Section(-5, 3)
+    val b = Section(-4, 1)
+    assert((a distance b) == (b distance a))
+    assert((a distance b).contains(-2))
+  }
+
+  //overlaps
+  test("overlaps: no overlap - positive") {
+    val a = Section(1, 2)
+    val b = Section(4, 2)
+    assert((a overlaps  b) == (b overlaps a))
+    assert(!(a overlaps  b))
+  }
+
+  test("overlaps: touching - positive") {
+    val a = Section(1, 2)
+    val b = Section(3, 2)
+    assert((a overlaps  b) == (b overlaps a))
+    assert(!(a overlaps  b))
+  }
+
+  test("overlaps: overlap - positive") {
+    val a = Section(1, 3)
+    val b = Section(3, 3)
+    assert((a overlaps  b) == (b overlaps a))
+    assert(a overlaps  b)
+  }
+
+  test("overlaps: no overlap - negative") {
+    val a = Section(-3, 2)
+    val b = Section(-6, 2)
+    assert((a overlaps  b) == (b overlaps a))
+    assert(!(a overlaps  b))
+  }
+
+  test("overlaps: touching - negative") {
+    val a = Section(-3, 2)
+    val b = Section(-6, 3)
+    assert((a overlaps  b) == (b overlaps a))
+    assert(!(a overlaps  b))
+  }
+
+  test("overlaps: overlap - negative") {
+    val a = Section(-3, 2)
+    val b = Section(-6, 4)
+    assert((a overlaps  b) == (b overlaps a))
+    assert(a overlaps  b)
+  }
+
+  test("overlaps: overlap - negative abd positive") {
+    val a = Section(-1, 2)
+    val b = Section(4, 2)
+    assert((a overlaps b) == (b overlaps a))
+    assert(!(a overlaps b))
+  }
+
+  //touches
+  test("touches: no overlap - positive") {
+    val a = Section(1, 2)
+    val b = Section(4, 2)
+    assert((a touches  b) == (b touches a))
+    assert(!(a touches  b))
+  }
+
+  test("touches: touching - positive") {
+    val a = Section(1, 2)
+    val b = Section(3, 2)
+    assert((a touches  b) == (b touches a))
+    assert(a touches  b)
+  }
+
+  test("touches: overlap - positive") {
+    val a = Section(1, 3)
+    val b = Section(3, 3)
+    assert((a touches  b) == (b touches a))
+    assert(a touches  b)
+  }
+
+  test("touches: no overlap - negative") {
+    val a = Section(-3, 2)
+    val b = Section(-6, 2)
+    assert((a touches  b) == (b touches a))
+    assert(!(a touches  b))
+  }
+
+  test("touches: touching - negative") {
+    val a = Section(-3, 2)
+    val b = Section(-6, 3)
+    assert((a touches  b) == (b touches a))
+    assert(a touches  b)
+  }
+
+  test("touches: overlap - negative") {
+    val a = Section(-3, 2)
+    val b = Section(-6, 4)
+    assert((a touches  b) == (b touches a))
+    assert(a touches  b)
+  }
+
+  test("touches: overlap - negative abd positive") {
+    val a = Section(-1, 2)
+    val b = Section(4, 2)
+    assert((a touches b) == (b touches a))
+    assert(!(a touches b))
+  }
+
+  //ofSameChars
+  test("ofSameChars: single character") {
+    val section = Section.ofSameChars("abcdefghijkl", 4)
+    val expected = Section(4, 1)
+    assert(section == expected)
+  }
+
+  test("ofSameChars: more characters") {
+    val section = Section.ofSameChars("aabbbccccddddd", 5)
+    val expected = Section(5, 4)
+    assert(section == expected)
+  }
+
+  test("ofSameChars: more characters, fromIndex start within") {
+    val section = Section.ofSameChars("aabbbbbccccddddd", 4)
+    val expected = Section(4, 3)
+    assert(section == expected)
+  }
+
+  test("ofSameChars: out of range") {
+    val section = Section.ofSameChars("xxxxyyyzz", 20)
+    val expected = Section(20, 0)
+    assert(section == expected)
+  }
+
+  test("ofSameChars: negative fromIndex") {
+    val section = Section.ofSameChars("xxxxyyyzz", -5)
+    val expected = Section(-5, 3)
+    assert(section == expected)
+  }
+
+  test("ofSameChars: negative fromIndex far ahead") {
+    val section = Section.ofSameChars("xxxxyyyzz", -15)
+    val expected = Section(-15, 0)
+    assert(section == expected)
+  }
+
+  //removeMultiple
+  test("removeMultiple: two Sections") {
+    val sections = Seq(Section(2, 2), Section(6, 3))
+    val result = Section.removeMultiple("abcdefghijkl", sections)
+    val expected = "abefjkl"
+    assert(result == expected)
+  }
+
+  test("removeMultiple: three Sections, unordered") {
+    val sections = Seq(Section(6, 3), Section(2, 2), Section(11, 2))
+    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val expected = "abefjknop"
+    assert(result == expected)
+  }
+
+  test("removeMultiple: adjacent") {
+    val sections = Seq(Section(2, 2), Section(11, 2), Section(6, 5))
+    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val expected = "abefnop"
+    assert(result == expected)
+  }
+
+  test("removeMultiple: overlapping") {
+    val sections = Seq(Section(2, 2), Section(10, 3), Section(6, 5))
+    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val expected = "abefnop"
+    assert(result == expected)
+  }
+
+  test("removeMultiple: negative") {
+    val sections = Seq(Section(1, 1), Section(-2, 1))
+    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val expected = "acdefghijklmnp"
+    assert(result == expected)
+  }
+
+  test("removeMultiple: negative overlapping") {
+    val sections = Seq(Section(-3, 3), Section(-5, 3))
+    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val expected = "abcdefghijk"
+    assert(result == expected)
+  }
+
+  test("removeMultiple: running out of bounds ") {
+    val sections = Seq(Section(-6, 2), Section(4, 2))
+    val result = Section.removeMultiple("abcde", sections)
+    val expected = "bcd"
+    assert(result == expected)
+  }
+
+  test("removeMultiple: totally out of bounds ") {
+    val sections = Seq(Section(-10, 2), Section(10, 2))
+    val result = Section.removeMultiple("abcde", sections)
+    val expected = "abcde"
+    assert(result == expected)
+  }
+
+  test("removeMultiple: zero length") {
+    val sections = Seq(Section(1, 0), Section(-2, 0))
+    val result = Section.removeMultiple("abcdefghijklmnop", sections)
+    val expected = "abcdefghijklmnop"
+    assert(result == expected)
+  }
+
+  //mergeSections
+  test("mergeSections: empty") {
+    val sections = Seq.empty[Section]
+    val result = Section.mergeSections(sections)
+    assert(result.isEmpty)
+  }
+
+  test("mergeSections: one item") {
+    val sections = Seq(Section(42, 7))
+    val result = Section.mergeSections(sections)
+    assert(result == sections)
+  }
+
+  test("mergeSections: touching") {
+    val sections = Seq(
+      Section( 1, 1),
+      Section( 3, 2),
+      Section(-4, 2),
+      Section( 5, 1),
+      Section(-7, 3),
+      Section(-1, 1)
+    )
+    val expected = Seq(
+      Section(-7, 5),
+      Section(-1, 1),
+      Section( 3, 3),
+      Section( 1, 1)
+    )
+    val result = Section.mergeSections(sections)
+    assert(result == expected)
+  }
+
+  test("mergeSections: overlapping") {
+    val sections = Seq(
+      //overlapping
+      Section( 11, 4),
+      Section(-20, 6),
+      Section( 12, 5),
+      Section(-23, 6),
+      Section( -1, 1),
+      Section(  1, 1)
+    )
+
+    val expected = Seq(
+      Section(-23, 9),
+      Section( -1, 1),
+      Section( 11, 6),
+      Section(  1, 1)
+    )
+    val result = Section.mergeSections(sections)
+    assert(result == expected)
+  }
+
+  test("mergeSections: two same") {
+    val sections = Seq(
+      //overlapping
+      Section( 7, 5),
+      Section(-7, 5),
+      Section( 7, 5),
+      Section(-7, 5),
+      Section(-1, 1),
+      Section( 1, 1)
+    )
+
+    val expected = Seq(
+      Section(-7, 5),
+      Section(-1, 1),
+      Section( 7, 5),
+      Section( 1, 1)
+    )
+    val result = Section.mergeSections(sections)
+    assert(result == expected)
+  }
+
+  test("mergeSections: one withing other") {
+    val sections = Seq(
+      //overlapping
+      Section( 12, 1), // E
+      Section(-20, 6), // B!
+      Section( 12, 5), // E!
+      Section(-20, 3), // B
+      Section( -1, 1), // C!
+      Section(  1, 1), // F!
+      Section( 23, 2), // D
+      Section( 20, 5), // D!
+      Section(-30, 9), // A!
+      Section(-27, 6)  // A
+    )
+
+    val expected = Seq(
+      Section(-30, 9), // A
+      Section(-20, 6), // B
+      Section( -1, 1), // C
+      Section( 20, 5), // D
+      Section( 12, 5), // E
+      Section(  1, 1)  // F
+    )
+    val result = Section.mergeSections(sections)
+    assert(result == expected)
+  }
+
+  test("mergeSections: sequence of 3") {
+    val sections = Seq(
+      //overlapping
+      Section( 22, 10),
+      Section(-42, 10),
+      Section( 10, 10),
+      Section(-35, 10),
+      Section( 15, 10),
+      Section(-30, 10),
+      Section( -1, 1),
+      Section(  1, 1)
+    )
+
+    val expected = Seq(
+      Section(-42, 22),
+      Section( -1, 1),
+      Section( 10, 22),
+      Section(  1, 1)
+    )
+    val result = Section.mergeSections(sections)
+    assert(result == expected)
+  }
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/StringImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/StringImplicitsSuite.scala
@@ -21,39 +21,6 @@ import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.implicits.StringImplicits.StringEnhancements
 
 class StringImplicitsSuite extends FunSuite {
-  test("StringImprovements.injectInto - positive where") {
-    val r0 = "abc".injectWith("xxx", 0)
-    val r1 = "abc".injectWith("xxx", 1)
-    val r2 = "abc".injectWith("xxx", 2)
-    val r3 = "abc".injectWith("xxx", 3)
-    val r4 = "abc".injectWith("xxx", 4)
-    assert(r0 == "xxxabc")
-    assert(r1 == "axxxbc")
-    assert(r2 == "abxxxc")
-    assert(r3 == "abcxxx")
-    assert(r4 == "abcxxx")
-  }
-
-  test("StringImprovements.injectInto - negative where") {
-    val r1 = "abc".injectWith("xxx", -1)
-    val r2 = "abc".injectWith("xxx", -2)
-    val r3 = "abc".injectWith("xxx", -3)
-    val r4 = "abc".injectWith("xxx", -4)
-    assert(r1 == "abxxxc")
-    assert(r2 == "axxxbc")
-    assert(r3 == "xxxabc")
-    assert(r4 == "xxxabc")
-  }
-
-  test("StringImprovements.injectInto - empty string") {
-    val r1 = "".injectWith("+", -1)
-    val r2 = "".injectWith("+", 0)
-    val r3 = "".injectWith("+", 1)
-    assert(r1 == "+")
-    assert(r2 == "+")
-    assert(r3 == "+")
-  }
-
   test("StringImprovements.findFirstUnquoted - empty string") {
     var result = "".findFirstUnquoted(Set.empty, Set.empty)
     assert(result.isEmpty)

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/StringImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/StringImplicitsSuite.scala
@@ -20,7 +20,40 @@ import java.security.InvalidParameterException
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.implicits.StringImplicits.StringEnhancements
 
-class StringImplicitsSuite  extends FunSuite {
+class StringImplicitsSuite extends FunSuite {
+  test("StringImprovements.injectInto - positive where") {
+    val r0 = "abc".injectWith("xxx", 0)
+    val r1 = "abc".injectWith("xxx", 1)
+    val r2 = "abc".injectWith("xxx", 2)
+    val r3 = "abc".injectWith("xxx", 3)
+    val r4 = "abc".injectWith("xxx", 4)
+    assert(r0 == "xxxabc")
+    assert(r1 == "axxxbc")
+    assert(r2 == "abxxxc")
+    assert(r3 == "abcxxx")
+    assert(r4 == "abcxxx")
+  }
+
+  test("StringImprovements.injectInto - negative where") {
+    val r1 = "abc".injectWith("xxx", -1)
+    val r2 = "abc".injectWith("xxx", -2)
+    val r3 = "abc".injectWith("xxx", -3)
+    val r4 = "abc".injectWith("xxx", -4)
+    assert(r1 == "abxxxc")
+    assert(r2 == "axxxbc")
+    assert(r3 == "xxxabc")
+    assert(r4 == "xxxabc")
+  }
+
+  test("StringImprovements.injectInto - empty string") {
+    val r1 = "".injectWith("+", -1)
+    val r2 = "".injectWith("+", 0)
+    val r3 = "".injectWith("+", 1)
+    assert(r1 == "+")
+    assert(r2 == "+")
+    assert(r3 == "+")
+  }
+
   test("StringImprovements.findFirstUnquoted - empty string") {
     var result = "".findFirstUnquoted(Set.empty, Set.empty)
     assert(result.isEmpty)

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/time/DateTimePatternSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/time/DateTimePatternSuite.scala
@@ -41,7 +41,7 @@ class DateTimePatternSuite extends FunSuite {
     assert(dateTimePattern.epochFactor == 0)
   }
 
-  test("DateTimePattern.isEpoch returns expected values.") {
+  test("DateTimePattern.isEpoch should return true for known keywords, regardless of case") {
     val result1 = DateTimePattern.isEpoch("epoch")
     assert(result1)
     val result2 = DateTimePattern.isEpoch("epochmilli")
@@ -58,7 +58,7 @@ class DateTimePatternSuite extends FunSuite {
     assert(result7)
   }
 
-  test("DateTimePattern.epochFactor/epochMilliFactor returns expected values.") {
+  test("DateTimePattern.epochFactor returns appropriate power of ten corresponding the keyword") {
     var result = DateTimePattern.epochFactor("Epoch")
     assert(result == 1L)
     result = DateTimePattern.epochFactor("EpOcHmIlLi")

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/time/DateTimePatternSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/time/DateTimePatternSuite.scala
@@ -19,6 +19,7 @@ import java.security.InvalidParameterException
 
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.general.Section
 
 class DateTimePatternSuite extends FunSuite {
 
@@ -29,7 +30,6 @@ class DateTimePatternSuite extends FunSuite {
     assert(dateTimePattern.pattern == pattern)
     assert(!dateTimePattern.isEpoch)
     assert(0 == dateTimePattern.epochFactor)
-    assert(0 == dateTimePattern.epochMilliFactor)
   }
 
   test("Pattern for date") {
@@ -39,7 +39,6 @@ class DateTimePatternSuite extends FunSuite {
     assert(dateTimePattern.pattern == pattern)
     assert(!dateTimePattern.isEpoch)
     assert(dateTimePattern.epochFactor == 0)
-    assert(dateTimePattern.epochMilliFactor  == 0)
   }
 
   test("DateTimePattern.isEpoch returns expected values.") {
@@ -53,6 +52,10 @@ class DateTimePatternSuite extends FunSuite {
     assert(!result4)
     val result5 = DateTimePattern.isEpoch("")
     assert(!result5)
+    val result6 = DateTimePattern.isEpoch("epochMicro")
+    assert(result6)
+    val result7 = DateTimePattern.isEpoch("EPOCHNANO")
+    assert(result7)
   }
 
   test("DateTimePattern.epochFactor/epochMilliFactor returns expected values.") {
@@ -60,21 +63,23 @@ class DateTimePatternSuite extends FunSuite {
     assert(result == 1L)
     result = DateTimePattern.epochFactor("EpOcHmIlLi")
     assert(result == 1000L)
+    result = DateTimePattern.epochFactor("EpochMICRO")
+    assert(result == 1000000L)
+    result = DateTimePattern.epochFactor("epochnano")
+    assert(result == 1000000000L)
     result = DateTimePattern.epochFactor("zoom")
-    assert(result == 0L)
-    result = DateTimePattern.epochMilliFactor("Epoch")
-    assert(result == 1000L)
-    result = DateTimePattern.epochMilliFactor("EpOcHmIlLi")
-    assert(result == 1L)
-    result = DateTimePattern.epochMilliFactor("xxxx")
     assert(result == 0L)
   }
 
-  test("Epoch in pattern") {
+  test("Time zone in epoch pattern") {
     val dateTimePattern1 = DateTimePattern("epoch")
     assert(dateTimePattern1.timeZoneInPattern)
     val dateTimePattern2 = DateTimePattern("epochmilli")
     assert(dateTimePattern2.timeZoneInPattern)
+    val dateTimePattern3 = DateTimePattern("epochmicro")
+    assert(dateTimePattern3.timeZoneInPattern)
+    val dateTimePattern4 = DateTimePattern("epochnano")
+    assert(dateTimePattern4.timeZoneInPattern)
   }
 
   test("Time zone NOT in pattern") {
@@ -137,6 +142,10 @@ class DateTimePatternSuite extends FunSuite {
     assert(dateTimePattern1.defaultTimeZone.isEmpty)
     val dateTimePattern2 = DateTimePattern("epoch", Some("CET"))
     assert(dateTimePattern2.defaultTimeZone.isEmpty)
+    val dateTimePattern3 = DateTimePattern("epochmicro", Some("WST"))
+    assert(dateTimePattern3.defaultTimeZone.isEmpty)
+    val dateTimePattern4 = DateTimePattern("epochnano", Some("CET"))
+    assert(dateTimePattern4.defaultTimeZone.isEmpty)
   }
 
   test("Is NOT time-zoned ") {
@@ -177,7 +186,6 @@ class DateTimePatternSuite extends FunSuite {
       assert(dtp.isDefault == isDefault)
       assert(!dtp.isEpoch)
       assert(dtp.epochFactor == 0)
-      assert(dtp.epochMilliFactor == 0)
       assert(dtp.timeZoneInPattern == timeZoneInPattern)
       assert(dtp.defaultTimeZone == defaultTimeZone)
     }
@@ -235,4 +243,99 @@ class DateTimePatternSuite extends FunSuite {
     check(dtp6, pattern6, isDefault = false, timeZoneInPattern = false, Some(timeZone6))
   }
 
+  test("Second fractions detection in epoch") {
+    val dtp = DateTimePattern("epoch")
+    assert(dtp.millisecondsPosition.isEmpty)
+    assert(dtp.microsecondsPosition.isEmpty)
+    assert(dtp.nanosecondsPosition.isEmpty)
+    assert(dtp.secondFractionsSections.isEmpty)
+    assert(dtp.patternWithoutSecondFractions == "epoch")
+    assert(!dtp.containsSecondFractions)
+  }
+
+  test("Second fractions detection in epochmilli") {
+    val dtp = DateTimePattern("epochmilli")
+    assert(dtp.millisecondsPosition.contains(Section(-3,3)))
+    assert(dtp.microsecondsPosition.isEmpty)
+    assert(dtp.nanosecondsPosition.isEmpty)
+    assert(dtp.secondFractionsSections == Seq(Section(-3,3)))
+    assert(dtp.patternWithoutSecondFractions == "epoch")
+    assert(dtp.containsSecondFractions)
+  }
+
+  test("Second fractions detection in epochmicro") {
+    val dtp = DateTimePattern("epochmicro")
+    assert(dtp.millisecondsPosition.contains(Section(-6,3)))
+    assert(dtp.microsecondsPosition.contains(Section(-3,3)))
+    assert(dtp.nanosecondsPosition.isEmpty)
+    assert(dtp.secondFractionsSections == Seq(Section(-6,6)))
+    assert(dtp.patternWithoutSecondFractions == "epoch")
+    assert(dtp.containsSecondFractions)
+  }
+
+  test("Second fractions detection in epochnano") {
+    val dtp = DateTimePattern("epochnano")
+    assert(dtp.millisecondsPosition.contains(Section(-9,3)))
+    assert(dtp.microsecondsPosition.contains(Section(-6,3)))
+    assert(dtp.nanosecondsPosition.contains(Section(-3,3)))
+    assert(dtp.secondFractionsSections == Seq(Section(-9,9)))
+    assert(dtp.patternWithoutSecondFractions == "epoch")
+    assert(dtp.containsSecondFractions)
+  }
+
+  test("Second fractions detection in regular pattern - milliseconds") {
+    val pattern = "yyyy-MM-dd HH:mm:ss.SSS"
+    val dtp = DateTimePattern(pattern)
+    assert(dtp.millisecondsPosition.contains(Section(20,3)))
+    assert(dtp.microsecondsPosition.isEmpty)
+    assert(dtp.nanosecondsPosition.isEmpty)
+    assert(dtp.secondFractionsSections == Seq(Section(20,3)))
+    assert(dtp.patternWithoutSecondFractions == "yyyy-MM-dd HH:mm:ss.")
+    assert(dtp.containsSecondFractions)
+  }
+
+  test("Second fractions detection in regular pattern - microseconds") {
+    val pattern = "yyyy-MM-dd HH:mm:ss.iiiiii"
+    val dtp = DateTimePattern(pattern)
+    assert(dtp.millisecondsPosition.isEmpty)
+    assert(dtp.microsecondsPosition.contains(Section(20,6)))
+    assert(dtp.nanosecondsPosition.isEmpty)
+    assert(dtp.secondFractionsSections == Seq(Section(20,6)))
+    assert(dtp.patternWithoutSecondFractions == "yyyy-MM-dd HH:mm:ss.")
+    assert(dtp.containsSecondFractions)
+  }
+
+  test("Second fractions detection in regular pattern - nanoseconds") {
+    val pattern = "yyyy-MM-dd HH:mm:ss.nnnnnnnnn"
+    val dtp = DateTimePattern(pattern)
+    assert(dtp.millisecondsPosition.isEmpty)
+    assert(dtp.microsecondsPosition.isEmpty)
+    assert(dtp.nanosecondsPosition.contains(Section(20,9)))
+    assert(dtp.secondFractionsSections == Seq(Section(20,9)))
+    assert(dtp.patternWithoutSecondFractions == "yyyy-MM-dd HH:mm:ss.")
+    assert(dtp.containsSecondFractions)
+  }
+
+  test("Second fractions detection in regular pattern - milli-, micro-, nanosecond combined") {
+    val pattern = "nnniii|yyyy-MM-dd SSS HH:mm:ss"
+    val dtp = DateTimePattern(pattern)
+    assert(dtp.millisecondsPosition.contains(Section(18,3)))
+    assert(dtp.microsecondsPosition.contains(Section(3,3)))
+    assert(dtp.nanosecondsPosition.contains(Section(0,3)))
+    assert(dtp.secondFractionsSections == Seq(Section(18,3), Section(0, 6)))
+    assert(dtp.patternWithoutSecondFractions == "|yyyy-MM-dd  HH:mm:ss")
+    assert(dtp.containsSecondFractions)
+  }
+
+
+  test("Second fractions detection in regular pattern - not present") {
+    val pattern = "yyyy-MM-dd HH:mm:ss"
+    val dtp = DateTimePattern(pattern)
+    assert(dtp.millisecondsPosition.isEmpty)
+    assert(dtp.microsecondsPosition.isEmpty)
+    assert(dtp.nanosecondsPosition.isEmpty)
+    assert(dtp.secondFractionsSections.isEmpty)
+    assert(dtp.patternWithoutSecondFractions == "yyyy-MM-dd HH:mm:ss")
+    assert(!dtp.containsSecondFractions)
+  }
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
@@ -30,11 +30,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "1547553153"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2019-01-15")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class epochmilli") {
@@ -43,11 +43,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "1547553153198"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2019-01-15")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.198")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class epochmicro") {
@@ -56,11 +56,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "1547553153198765"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2019-01-15")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.198765")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class epochnano") {
@@ -69,11 +69,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "1547553153198765432"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2019-01-15")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.198765432")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class actual pattern without time zone") {
@@ -82,11 +82,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "2019_01_15:11.52.33"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2019-01-15")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class actual pattern with standard time zone") {
@@ -95,11 +95,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "2011-01-31-22-52-33-EST"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2011-02-01")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2011-02-01 03:52:33")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class actual pattern with offset time zone") {
@@ -108,11 +108,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "1990/01/31 22:52:33+01:00"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("1990-01-31")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("1990-01-31 21:52:33")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class actual pattern without time zone with milliseconds") {
@@ -121,11 +121,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "123|2019_01_15:11.52.33"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2019-01-15")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.123")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class actual pattern without time zone and microseconds") {
@@ -134,11 +134,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "2019_01_15:11.52.33.123456"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2019-01-15")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.123456")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class actual pattern with standard time zone and nanoseconds") {
@@ -147,11 +147,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "2011-01-31-22-52-33.123456789-EST"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("2011-02-01")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("2011-02-01 03:52:33.123456789")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("EnceladusDateParser class actual pattern with offset time zone and all second fractions") {
@@ -160,11 +160,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     val value: String = "1234561990/01/31 789 22:52:33+01:00"
     val resultDate: Date = parser.parseDate(value)
     val expectedDate: Date = Date.valueOf("1990-01-31")
-    assert(resultDate.toString == expectedDate.toString)
+    assert(resultDate == expectedDate)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
     val expectedTimestamp: Timestamp = Timestamp.valueOf("1990-01-31 21:52:33.456789123")
-    assert(resultTimestamp.toString == expectedTimestamp.toString)
+    assert(resultTimestamp == expectedTimestamp)
   }
 
   test("format") {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
@@ -18,7 +18,6 @@ package za.co.absa.enceladus.utils.time
 import org.scalatest.FunSuite
 import java.sql.Date
 import java.sql.Timestamp
-import java.util.TimeZone
 
 case class TestInputRow(id: Int, stringField: String)
 
@@ -30,11 +29,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
 
     val value: String = "1547553153"
     val resultDate: Date = parser.parseDate(value)
-    val expectedDate: Date = new Date(119, 0, 15) //2019-01-15
+    val expectedDate: Date = Date.valueOf("2019-01-15")
     assert(resultDate.toString == expectedDate.toString)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
-    val expectedTimestamp: Timestamp = new Timestamp(119, 0, 15, 11,52 , 33, 0 ) //2019-01-15 11:52:33
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33")
     assert(resultTimestamp.toString == expectedTimestamp.toString)
   }
 
@@ -43,11 +42,37 @@ class EnceladusDateTimeParserSuite extends FunSuite{
 
     val value: String = "1547553153198"
     val resultDate: Date = parser.parseDate(value)
-    val expectedDate: Date = new Date(119, 0, 15) //2019-01-15
+    val expectedDate: Date = Date.valueOf("2019-01-15")
     assert(resultDate.toString == expectedDate.toString)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
-    val expectedTimestamp: Timestamp = new Timestamp(119, 0, 15, 11,52 , 33, 198000000 ) //2019-01-15 11:52:33
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.198")
+    assert(resultTimestamp.toString == expectedTimestamp.toString)
+  }
+
+  test("EnceladusDateParser class epochmicro") {
+    val parser = EnceladusDateTimeParser("epochmicro")
+
+    val value: String = "1547553153198765"
+    val resultDate: Date = parser.parseDate(value)
+    val expectedDate: Date = Date.valueOf("2019-01-15")
+    assert(resultDate.toString == expectedDate.toString)
+
+    val resultTimestamp: Timestamp = parser.parseTimestamp(value)
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.198765")
+    assert(resultTimestamp.toString == expectedTimestamp.toString)
+  }
+
+  test("EnceladusDateParser class epochnano") {
+    val parser = EnceladusDateTimeParser("epochnano")
+
+    val value: String = "1547553153198765432"
+    val resultDate: Date = parser.parseDate(value)
+    val expectedDate: Date = Date.valueOf("2019-01-15")
+    assert(resultDate.toString == expectedDate.toString)
+
+    val resultTimestamp: Timestamp = parser.parseTimestamp(value)
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.198765432")
     assert(resultTimestamp.toString == expectedTimestamp.toString)
   }
 
@@ -56,11 +81,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
 
     val value: String = "2019_01_15:11.52.33"
     val resultDate: Date = parser.parseDate(value)
-    val expectedDate: Date = new Date(119, 0, 15) //2019-01-15
+    val expectedDate: Date = Date.valueOf("2019-01-15")
     assert(resultDate.toString == expectedDate.toString)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
-    val expectedTimestamp: Timestamp = new Timestamp(119, 0, 15, 11,52 , 33, 0 ) //2019-01-15 11:52:33
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33")
     assert(resultTimestamp.toString == expectedTimestamp.toString)
   }
 
@@ -69,11 +94,11 @@ class EnceladusDateTimeParserSuite extends FunSuite{
 
     val value: String = "2011-01-31-22-52-33-EST"
     val resultDate: Date = parser.parseDate(value)
-    val expectedDate: Date = new Date(111, 1, 1) //2011-02-01
+    val expectedDate: Date = Date.valueOf("2011-02-01")
     assert(resultDate.toString == expectedDate.toString)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
-    val expectedTimestamp: Timestamp = new Timestamp(111, 1, 1, 3,52 , 33, 0 ) //2011-02-01 11:52:33
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2011-02-01 03:52:33")
     assert(resultTimestamp.toString == expectedTimestamp.toString)
   }
 
@@ -82,22 +107,82 @@ class EnceladusDateTimeParserSuite extends FunSuite{
 
     val value: String = "1990/01/31 22:52:33+01:00"
     val resultDate: Date = parser.parseDate(value)
-    val expectedDate: Date = new Date(90, 0, 31) //1990-01-31
+    val expectedDate: Date = Date.valueOf("1990-01-31")
     assert(resultDate.toString == expectedDate.toString)
 
     val resultTimestamp: Timestamp = parser.parseTimestamp(value)
-    val expectedTimestamp: Timestamp = new Timestamp(90, 0, 31, 21,52 , 33, 0 ) //1990-01-31 21:52:33
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("1990-01-31 21:52:33")
+    assert(resultTimestamp.toString == expectedTimestamp.toString)
+  }
+
+  test("EnceladusDateParser class actual pattern without time zone with milliseconds") {
+    val parser = EnceladusDateTimeParser("SSS|yyyy_MM_dd:HH.mm.ss")
+
+    val value: String = "123|2019_01_15:11.52.33"
+    val resultDate: Date = parser.parseDate(value)
+    val expectedDate: Date = Date.valueOf("2019-01-15")
+    assert(resultDate.toString == expectedDate.toString)
+
+    val resultTimestamp: Timestamp = parser.parseTimestamp(value)
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.123")
+    assert(resultTimestamp.toString == expectedTimestamp.toString)
+  }
+
+  test("EnceladusDateParser class actual pattern without time zone and microseconds") {
+    val parser = EnceladusDateTimeParser("yyyy_MM_dd:HH.mm.ss.iiiiii")
+
+    val value: String = "2019_01_15:11.52.33.123456"
+    val resultDate: Date = parser.parseDate(value)
+    val expectedDate: Date = Date.valueOf("2019-01-15")
+    assert(resultDate.toString == expectedDate.toString)
+
+    val resultTimestamp: Timestamp = parser.parseTimestamp(value)
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2019-01-15 11:52:33.123456")
+    assert(resultTimestamp.toString == expectedTimestamp.toString)
+  }
+
+  test("EnceladusDateParser class actual pattern with standard time zone and nanoseconds") {
+    val parser = EnceladusDateTimeParser("yyyy-MM-dd-HH-mm-ss.nnnnnnnnn-zz")
+
+    val value: String = "2011-01-31-22-52-33.123456789-EST"
+    val resultDate: Date = parser.parseDate(value)
+    val expectedDate: Date = Date.valueOf("2011-02-01")
+    assert(resultDate.toString == expectedDate.toString)
+
+    val resultTimestamp: Timestamp = parser.parseTimestamp(value)
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2011-02-01 03:52:33.123456789")
+    assert(resultTimestamp.toString == expectedTimestamp.toString)
+  }
+
+  test("EnceladusDateParser class actual pattern with offset time zone and all second fractions") {
+    val parser = EnceladusDateTimeParser("nnnSSSyyyy/MM/dd iii HH:mm:ssXXX")
+
+    val value: String = "1234561990/01/31 789 22:52:33+01:00"
+    val resultDate: Date = parser.parseDate(value)
+    val expectedDate: Date = Date.valueOf("1990-01-31")
+    assert(resultDate.toString == expectedDate.toString)
+
+    val resultTimestamp: Timestamp = parser.parseTimestamp(value)
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("1990-01-31 21:52:33.456789123")
     assert(resultTimestamp.toString == expectedTimestamp.toString)
   }
 
   test("format") {
-    val t = new Timestamp(70, 0, 2, 1, 0, 0, 0) //25 hours to epoch
+    val t: Timestamp = Timestamp.valueOf("1970-01-02 01:00:00.123456789") //25 hours to epoch with some second fractions
     val parser1 = EnceladusDateTimeParser("yyyy-MM-dd HH:mm:ss")
     assert(parser1.format(t) == "1970-01-02 01:00:00")
     val parser2 = EnceladusDateTimeParser("epoch")
     assert(parser2.format(t) == "90000")
     val parser3 = EnceladusDateTimeParser("epochmilli")
-    assert(parser3.format(t) == "90000000")
+    assert(parser3.format(t) == "90000123")
+    val parser4 = EnceladusDateTimeParser("epochmicro")
+    assert(parser4.format(t) == "90000123456")
+    val parser5 = EnceladusDateTimeParser("epochnano")
+    assert(parser5.format(t) == "90000123456789")
+    val parser6 = EnceladusDateTimeParser("yyyy-MM-dd HH:mm:ss.iiiiii")
+    assert(parser6.format(t) == "1970-01-02 01:00:00.123456")
+    val parser7 = EnceladusDateTimeParser("(nnn) yyyy-MM-dd (SSS) HH:mm:ss (iii)")
+    assert(parser7.format(t) == "(789) 1970-01-02 (123) 01:00:00 (456)")
   }
 
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDateSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDateSuite.scala
@@ -51,7 +51,7 @@ class FieldValidatorDateSuite extends FunSuite  {
   test("epochnano pattern") {
     assert(FieldValidatorDate.validateStructField(field("epochnano")).isEmpty)
     //with default
-    assert(FieldValidatorDate.validateStructField(field("epochmilli", Option("5545556000111222"))).isEmpty)
+    assert(FieldValidatorDate.validateStructField(field("epochnano", Option("5545556000111222"))).isEmpty)
   }
 
   test("date pattern") {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDateSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorDateSuite.scala
@@ -39,7 +39,19 @@ class FieldValidatorDateSuite extends FunSuite  {
   test("epochmilli pattern") {
     assert(FieldValidatorDate.validateStructField(field("epochmilli")).isEmpty)
     //with default
-    assert(FieldValidatorDate.validateStructField(field("epochmilli", Option("55455560000"))).isEmpty)
+    assert(FieldValidatorDate.validateStructField(field("epochmilli", Option("5545556000"))).isEmpty)
+  }
+
+  test("epochmicro pattern") {
+    assert(FieldValidatorDate.validateStructField(field("epochmicro")).isEmpty)
+    //with default
+    assert(FieldValidatorDate.validateStructField(field("epochmicro", Option("5545556000111"))).isEmpty)
+  }
+
+  test("epochnano pattern") {
+    assert(FieldValidatorDate.validateStructField(field("epochnano")).isEmpty)
+    //with default
+    assert(FieldValidatorDate.validateStructField(field("epochmilli", Option("5545556000111222"))).isEmpty)
   }
 
   test("date pattern") {
@@ -158,6 +170,22 @@ class FieldValidatorDateSuite extends FunSuite  {
       ValidationWarning("No day placeholder 'dd' found.")
     )
     assert(FieldValidatorDate.validateStructField(field("GG")).toSet == expected)
+  }
+
+  test("warning issues: redundant placeholders") {
+    val expected = Set(
+      ValidationWarning("Redundant hour placeholder 'H' found."),
+      ValidationWarning("Redundant minute placeholder 'm' found."),
+      ValidationWarning("Redundant second placeholder 's' found."),
+      ValidationWarning("Redundant millisecond placeholder 'S' found."),
+      ValidationWarning("Redundant microsecond placeholder 'i' found."),
+      ValidationWarning("Redundant nanosecond placeholder 'n' found."),
+      ValidationWarning("Redundant am/pm placeholder 'a' found."),
+      ValidationWarning("Redundant hour placeholder 'k' found."),
+      ValidationWarning("Redundant hour placeholder 'h' found."),
+      ValidationWarning("Redundant hour placeholder 'H' found.")
+    )
+    assert(FieldValidatorDate.validateStructField(field("yyyy-MM-dd HH:mm:ss.SSSiiinnn (aakkhhKK)", None, None)).toSet == expected)
   }
 
   test("warning issues: missing placeholders with default time zone") {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestampSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestampSuite.scala
@@ -51,7 +51,7 @@ class FieldValidatorTimestampSuite extends FunSuite  {
   test("epochnano pattern") {
     assert(FieldValidatorDate.validateStructField(field("epochnano")).isEmpty)
     //with default
-    assert(FieldValidatorDate.validateStructField(field("epochmilli", Option("5545556000111222"))).isEmpty)
+    assert(FieldValidatorDate.validateStructField(field("epochnano", Option("5545556000111222"))).isEmpty)
   }
 
   test("timestamp pattern") {
@@ -227,7 +227,7 @@ class FieldValidatorTimestampSuite extends FunSuite  {
     assert(FieldValidatorTimestamp.validateStructField(field("epochnano")).toSet == expected1)
 
     val expected2 = Set(
-      ValidationWarning("Placeholder 'n' for nanoseconds recognized. While supported it brings possible loss of precision.")
+      ValidationWarning("Placeholder 'n' for nanoseconds recognized. While supported, it brings possible loss of precision.")
     )
     assert(FieldValidatorTimestamp.validateStructField(field("yyyy-MM-dd HH:mm:ss.nnnnnnnnn")).toSet == expected2)
 

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestampSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FieldValidatorTimestampSuite.scala
@@ -39,7 +39,19 @@ class FieldValidatorTimestampSuite extends FunSuite  {
   test("epochmilli pattern") {
     assert(FieldValidatorTimestamp.validateStructField(field("epochmilli")).isEmpty)
     //with default
-    assert(FieldValidatorTimestamp.validateStructField(field("epochmilli", Option("55455560000"))).isEmpty)
+    assert(FieldValidatorTimestamp.validateStructField(field("epochmilli", Option("5545556000"))).isEmpty)
+  }
+
+  test("epochmicro pattern") {
+    assert(FieldValidatorDate.validateStructField(field("epochmicro")).isEmpty)
+    //with default
+    assert(FieldValidatorDate.validateStructField(field("epochmicro", Option("5545556000111"))).isEmpty)
+  }
+
+  test("epochnano pattern") {
+    assert(FieldValidatorDate.validateStructField(field("epochnano")).isEmpty)
+    //with default
+    assert(FieldValidatorDate.validateStructField(field("epochmilli", Option("5545556000111222"))).isEmpty)
   }
 
   test("timestamp pattern") {
@@ -206,5 +218,18 @@ class FieldValidatorTimestampSuite extends FunSuite  {
 
   test("all placeholders") {
     assert(FieldValidatorTimestamp.validateStructField(field("X GG yyyy MM ww W DDD dd F E a HH kk KK hh mm ss SSS ZZ zzz")).isEmpty)
+  }
+
+  test("nano seconds precision lost") {
+    val expected1 = Set(
+      ValidationWarning("Pattern 'epochnano'. While supported it comes with possible loss of precision beyond microseconds.")
+    )
+    assert(FieldValidatorTimestamp.validateStructField(field("epochnano")).toSet == expected1)
+
+    val expected2 = Set(
+      ValidationWarning("Placeholder 'n' for nanoseconds recognized. While supported it brings possible loss of precision.")
+    )
+    assert(FieldValidatorTimestamp.validateStructField(field("yyyy-MM-dd HH:mm:ss.nnnnnnnnn")).toSet == expected2)
+
   }
 }


### PR DESCRIPTION
* Class `Section` to define parts of the pattern string and string to convert
* Implicit classes additional logic to enable String and Columns to operate with `Section` class
* Actual implementation of the support for second fractions
* **S**, **i** and **n** placeholders in pattern
* `EnceladusDateTimeParser` support for the new placeholders
* Standardization  (`TypeParser`) support for the new placeholders
* Fixing and enhancing UTs for the new second fractions placeholders
* Validators to support the new second fractions placeholders
* `README.md` update