### PR TITLE
#685 Fix broken schema file export

### DIFF
--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -267,7 +267,7 @@
                         <resource>
                             <directory>ui</directory>
                             <targetPath>/</targetPath>
-                            <filtering>true</filtering>
+                            <filtering>false</filtering>
                         </resource>
                     </webResources>
                     <packagingExcludes>META-INF/*.SF, META-INF/*.DSA, META-INF/*.RSA</packagingExcludes>

--- a/menas/ui/generic/model.js
+++ b/menas/ui/generic/model.js
@@ -24,7 +24,7 @@ var model = new sap.ui.model.json.JSONModel({
   currentMappingTable: {},
   newMappingTable: {},
   newSchema: {},
-  menasVersion: "${project.version}",
+  menasVersion: "",
   appInfo: {
     oozie: {}
   },

--- a/menas/ui/service/GenericService.js
+++ b/menas/ui/service/GenericService.js
@@ -23,7 +23,8 @@ var GenericService = new function () {
   
   this.getUserInfo = function () {
     let fnSuccess = (oInfo) => {
-      model.setProperty("/userInfo", oInfo)
+      model.setProperty("/userInfo", oInfo);
+      model.setProperty("/menasVersion", oInfo.menasVersion);
     };
 
     $.ajax("api/user/info", {

--- a/menas/ui/service/RestDAO.js
+++ b/menas/ui/service/RestDAO.js
@@ -166,7 +166,7 @@ class SchemaRestDAO extends DependentRestDAO {
   }
 
   downloadSchema(name, version) {
-    return RestClient.get(`api/${this.entityType}/export/${name}/${version}`)
+    return RestClient.get(`api/${this.entityType}/export/${encodeURI(name)}/${encodeURI(version)}`)
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -330,36 +330,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${maven.shade.version}</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                            <resource>application.conf</resource>
-                        </transformer>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
                 <version>1.0.0</version>


### PR DESCRIPTION
This fixes the bug observed, but does not address the underlying issue. Why did `${name}` and `${version}` get replaced with `project.name` and `project.version`. To be addressed in a follow-up PR for this task...