### PR TITLE
#458: Early Timezone normalization

### DIFF
--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -44,6 +44,7 @@ import za.co.absa.enceladus.utils.performance.PerformanceMetricTools
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 
 object DynamicConformanceJob {
+  TimeZoneNormalizer.normalizeJVMTimeZone()
 
   private val infoDateColumn = "enceladus_info_date"
   private val infoDateColumnString = s"${infoDateColumn}_string"
@@ -140,7 +141,8 @@ object DynamicConformanceJob {
     val spark: SparkSession = SparkSession.builder()
       .appName("Dynamic Conformance")
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
+
+    TimeZoneNormalizer.normalizeSessionTimeZone(spark)
     spark
   }
 

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
@@ -33,7 +33,7 @@ object CustomRuleSample1 {
     .appName("CustomRuleSample1")
     .config("spark.sql.codegen.wholeStage", value = false)
     .getOrCreate()
-  TimeZoneNormalizer.normalizeAll(Seq(spark))
+  TimeZoneNormalizer.normalizeAll(spark) //normalize the timezone of JVM and the spark session
 
   def main(args: Array[String]) {
     // scalastyle:off magic.number

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
@@ -33,10 +33,10 @@ object CustomRuleSample1 {
     .appName("CustomRuleSample1")
     .config("spark.sql.codegen.wholeStage", value = false)
     .getOrCreate()
+  TimeZoneNormalizer.normalizeAll(Seq(spark))
 
   def main(args: Array[String]) {
     // scalastyle:off magic.number
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: EnceladusDAO = EnceladusRestDAO // you may have to hard-code your own implementation here (if not working with menas)
     val experimentalMR = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
@@ -33,7 +33,7 @@ object CustomRuleSample2 {
     .appName("CustomRuleSample2")
     .config("spark.sql.codegen.wholeStage", value = false)
     .getOrCreate()
-  TimeZoneNormalizer.normalizeAll(Seq(spark))
+  TimeZoneNormalizer.normalizeAll(spark)) //normalize the timezone of JVM and the spark session
 
   def main(args: Array[String]) {
     // scalastyle:off magic.number

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
@@ -33,7 +33,7 @@ object CustomRuleSample2 {
     .appName("CustomRuleSample2")
     .config("spark.sql.codegen.wholeStage", value = false)
     .getOrCreate()
-  TimeZoneNormalizer.normalizeAll(spark)) //normalize the timezone of JVM and the spark session
+  TimeZoneNormalizer.normalizeAll(spark) //normalize the timezone of JVM and the spark session
 
   def main(args: Array[String]) {
     // scalastyle:off magic.number

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
@@ -33,10 +33,10 @@ object CustomRuleSample2 {
     .appName("CustomRuleSample2")
     .config("spark.sql.codegen.wholeStage", value = false)
     .getOrCreate()
+  TimeZoneNormalizer.normalizeAll(Seq(spark))
 
   def main(args: Array[String]) {
     // scalastyle:off magic.number
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: EnceladusDAO = EnceladusRestDAO // you may have to hard-code your own implementation here (if not working with menas)
     val experimentalMR = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
@@ -29,11 +29,9 @@ object CustomRuleSample3 {
     .appName("CustomRuleSample3")
     .config("spark.sql.codegen.wholeStage", value = false)
     .getOrCreate()
-
-  spark.sparkContext.setLogLevel("WARN")
+  TimeZoneNormalizer.normalizeAll(Seq(spark))
 
   def main(args: Array[String]): Unit = {
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: EnceladusDAO = EnceladusRestDAO // you may have to hard-code your own implementation here (if not working with menas)
     val experimentalMR = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
@@ -29,7 +29,7 @@ object CustomRuleSample3 {
     .appName("CustomRuleSample3")
     .config("spark.sql.codegen.wholeStage", value = false)
     .getOrCreate()
-  TimeZoneNormalizer.normalizeAll(Seq(spark)) //normalize the timezone of JVM and ALL the spark sessions (one in this case)
+  TimeZoneNormalizer.normalizeAll(spark) //normalize the timezone of JVM and the spark session
 
   def main(args: Array[String]): Unit = {
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
@@ -29,7 +29,7 @@ object CustomRuleSample3 {
     .appName("CustomRuleSample3")
     .config("spark.sql.codegen.wholeStage", value = false)
     .getOrCreate()
-  TimeZoneNormalizer.normalizeAll(Seq(spark))
+  TimeZoneNormalizer.normalizeAll(Seq(spark)) //normalize the timezone of JVM and ALL the spark sessions (one in this case)
 
   def main(args: Array[String]): Unit = {
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
@@ -15,7 +15,6 @@
 
 package za.co.absa.enceladus.examples
 
-import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.functions.{col, concat, concat_ws, lit}
 import org.apache.spark.sql.{DataFrame, DataFrameReader, SparkSession}
 import scopt.OptionParser
@@ -27,6 +26,8 @@ import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 
 object CustomRuleSample4 {
+  TimeZoneNormalizer.normalizeJVMTimeZone()
+
   /**
     * This is a class for configuration provided by the command line parameters
     *
@@ -123,7 +124,7 @@ object CustomRuleSample4 {
       .appName("CustomRuleSample4")
       .config("spark.sql.codegen.wholeStage", value = false)
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(result))
+    TimeZoneNormalizer.normalizeSessionTimeZone(result)
     result
   }
 

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
@@ -26,7 +26,7 @@ import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 
 object CustomRuleSample4 {
-  TimeZoneNormalizer.normalizeJVMTimeZone()
+  TimeZoneNormalizer.normalizeJVMTimeZone() //normalize JVM time zone as soon as possible
 
   /**
     * This is a class for configuration provided by the command line parameters
@@ -124,6 +124,7 @@ object CustomRuleSample4 {
       .appName("CustomRuleSample4")
       .config("spark.sql.codegen.wholeStage", value = false)
       .getOrCreate()
+    //normalize the spark session timezone, the JVM has been done on the CustomRuleSample4 object creation above
     TimeZoneNormalizer.normalizeSessionTimeZone(result)
     result
   }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/SparkConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/SparkConfig.scala
@@ -34,7 +34,7 @@ class SparkConfig {
       .config("spark.driver.bindAddress","127.0.0.1")
       .appName("Menas Spark controller")
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(sparkSession))
+    TimeZoneNormalizer.normalizeAll(sparkSession)
     sparkSession
   }
 

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -47,6 +47,7 @@ import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 import za.co.absa.enceladus.utils.validation.ValidationException
 
 object StandardizationJob {
+  TimeZoneNormalizer.normalizeJVMTimeZone()
 
   private val log: Logger = LogManager.getLogger(this.getClass)
   private val conf: Config = ConfigFactory.load()
@@ -124,7 +125,7 @@ object StandardizationJob {
     val spark = SparkSession.builder()
       .appName("Standardisation")
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(spark))
+    TimeZoneNormalizer.normalizeSessionTimeZone(spark)
     spark
   }
 

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/datasetComparison/ComparisonJob.scala
@@ -24,6 +24,8 @@ import za.co.absa.enceladus.testutils.{DataframeReader, DataframeReaderOptions, 
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 
 object ComparisonJob {
+  TimeZoneNormalizer.normalizeJVMTimeZone()
+
   private val log: Logger = LogManager.getLogger(this.getClass)
   private val errorColumnName: String = "errCol"
   private val tmpColumnName: String = "tmp"
@@ -41,7 +43,7 @@ object ComparisonJob {
       .appName(s"Dataset comparison - '${cmd.newPath}' and '${cmd.refPath}'")
       .config("spark.sql.codegen.wholeStage", enableWholeStage)
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(sparkSession))
+    TimeZoneNormalizer.normalizeSessionTimeZone(sparkSession)
 
     implicit val sc: SparkContext = sparkSession.sparkContext
 

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/e2eSparkRunner/E2ESparkRunner.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/e2eSparkRunner/E2ESparkRunner.scala
@@ -17,10 +17,13 @@ package za.co.absa.enceladus.testutils.e2eSparkRunner
 
 import org.apache.log4j.{LogManager, Logger}
 import za.co.absa.enceladus.testutils.HelperFunctions
+import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 
 import sys.process._
 
 object E2ESparkRunner {
+  TimeZoneNormalizer.normalizeJVMTimeZone()
+
   private val log: Logger = LogManager.getLogger(this.getClass)
 
   private val stdJarPath: String = "$DCE_JAR_PATH/$DCE_STD_SPT_JAR"

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/infoFileComparison/InfoFileComparisonJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/infoFileComparison/InfoFileComparisonJob.scala
@@ -27,11 +27,14 @@ import za.co.absa.atum.persistence.ControlMeasuresParser
 import za.co.absa.atum.utils.ARMImplicits
 import za.co.absa.enceladus.testutils.exceptions.InfoFilesDifferException
 import za.co.absa.enceladus.testutils.infoFileComparison.AtumModelUtils._
+import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 
 import scala.collection.JavaConverters._
 import scala.reflect.io.File
 
 object InfoFileComparisonJob {
+  TimeZoneNormalizer.normalizeJVMTimeZone()
+
   private val log: Logger = LogManager.getLogger(this.getClass)
   private lazy val hadoopConfiguration = getHadoopConfiguration
 

--- a/testutils/src/main/scala/za/co/absa/enceladus/testutils/rest/RestRunnerJob.scala
+++ b/testutils/src/main/scala/za/co/absa/enceladus/testutils/rest/RestRunnerJob.scala
@@ -27,6 +27,8 @@ import za.co.absa.enceladus.testutils.models.{TestCase, TestCaseResult, TestRun}
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 
 object RestRunnerJob {
+  TimeZoneNormalizer.normalizeJVMTimeZone()
+
   def main(args: Array[String]): Unit = {
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
     implicit val dfReaderOptions: DataframeReaderOptions = DataframeReaderOptions(cmd.rawFormat,
@@ -40,7 +42,7 @@ object RestRunnerJob {
       .appName(s"Rest call test from - '${cmd.testDataPath}")
       .config("spark.sql.codegen.wholeStage", enableWholeStage)
       .getOrCreate()
-    TimeZoneNormalizer.normalizeAll(Seq(sparkSession))
+    TimeZoneNormalizer.normalizeSessionTimeZone(sparkSession)
 
     implicit val sc: SparkContext = sparkSession.sparkContext
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkTestBase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkTestBase.scala
@@ -27,6 +27,7 @@ import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 import com.typesafe.config.Config
 
 trait SparkTestBase { self =>
+  TimeZoneNormalizer.normalizeJVMTimeZone()
 
   val config: Config = ConfigFactory.load()
   val sparkMaster: String = config.getString("enceladus.utils.testUtils.sparkTestBaseMaster")
@@ -62,8 +63,7 @@ trait SparkTestBase { self =>
       .config("spark.driver.host", "127.0.0.1")
       .getOrCreate()
   }
-
-  TimeZoneNormalizer.normalizeAll(Seq(spark))
+  TimeZoneNormalizer.normalizeSessionTimeZone(spark)
 
   // Do not display INFO entries for tests
   Logger.getLogger("org").setLevel(Level.WARN)

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.SparkSession
    */
 object TimeZoneNormalizer {
   private val log: Logger = LogManager.getLogger(this.getClass)
-  private lazy val timeZone: String = getConf("timezone", "UTC")
+  private val timeZone: String = getConf("timezone", "UTC")
 
   private def getConf(path: String, default: String): String = {
     val config: Config = ConfigFactory.load()
@@ -48,9 +48,9 @@ object TimeZoneNormalizer {
     log.debug(s"Spark session ${spark.sparkContext.applicationId} time zone of name ${spark.sparkContext.appName} set to $timeZone")
   }
 
-  def normalizeAll(spars: Seq[SparkSession]): Unit = {
+  def normalizeAll(sparks: Seq[SparkSession]): Unit = {
     normalizeJVMTimeZone()
-    spars.foreach(normalizeSessionTimeZone)
+    sparks.foreach(normalizeSessionTimeZone)
   }
 
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
@@ -48,13 +48,9 @@ object TimeZoneNormalizer {
     log.debug(s"Spark session ${spark.sparkContext.applicationId} time zone of name ${spark.sparkContext.appName} set to $timeZone")
   }
 
-  def normalizeAll(sparks: Seq[SparkSession]): Unit = {
+  def normalizeAll(spark: SparkSession): Unit = {
     normalizeJVMTimeZone()
-    sparks.foreach(normalizeSessionTimeZone)
+    normalizeSessionTimeZone(spark)
   }
-
-  def normalizeAll(spark: SparkSession): Unit = normalizeAll(Seq(spark))
-
-  def normalizeAll(): Unit = normalizeAll(Seq.empty)
 
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
@@ -53,4 +53,8 @@ object TimeZoneNormalizer {
     sparks.foreach(normalizeSessionTimeZone)
   }
 
+  def normalizeAll(spark: SparkSession): Unit = normalizeAll(Seq(spark))
+
+  def normalizeAll(): Unit = normalizeAll(Seq.empty)
+
 }


### PR DESCRIPTION
* TimeZoneNormalizer got rid of `lazy` property
* Calls to TimeZoneNormalizer, especially TimeZoneNormalizer.normalizeJVMTimeZone, moved to early stages of execution