### PR TITLE
#707: Parsing leniency differs between EnceladusDateTimeParser and Spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
 
     <properties>
         <encoding>UTF-8</encoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--plugin versions-->
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -304,7 +305,7 @@
                         end to end test could run. This can be removed later when dynamic conformance
                         becomes more efficient
                     -->
-                    <argLine>-Xmx4000m</argLine>
+                    <argLine>-Xmx4000m -Dfile.encoding=UTF-8</argLine>
                 </configuration>
                 <executions>
                     <execution>

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromBooleanTypeSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser_FromBooleanTypeSuite.scala
@@ -23,7 +23,7 @@ class TypeParser_FromBooleanTypeSuite extends TypeParserSuiteTemplate  {
 
   private val input = Input(
     baseType = BooleanType,
-    defaultValueDate = "0",
+    defaultValueDate = "1",
     defaultValueTimestamp = "1",
     datePattern = "u",
     timestampPattern = "F",

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParser.scala
@@ -30,7 +30,10 @@ case class EnceladusDateTimeParser(pattern: DateTimePattern) {
   private val formatter: Option[SimpleDateFormat] = if (pattern.isEpoch) {
     None
   } else {
-    Some(new SimpleDateFormat(pattern.patternWithoutSecondFractions, Locale.US)) // locale here is hardcoded to the same value as Spark uses
+    // locale here is hardcoded to the same value as Spark uses, lenient set to false also per Spark usage
+    val sdf = new SimpleDateFormat(pattern.patternWithoutSecondFractions, Locale.US)
+    sdf.setLenient(false)
+    Some(sdf)
   }
 
   def parseDate(dateValue: String): Date = {

--- a/utils/src/test/scala/za/co/absa/enceladus/SchemaValidationSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/SchemaValidationSuite.scala
@@ -17,46 +17,47 @@ package za.co.absa.enceladus
 
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
 import za.co.absa.enceladus.utils.validation.SchemaValidator
 
 /**
  * A test suite for validation of scalar data types
  */
 //noinspection ZeroIndexToHead
-class SchemaValidationSuite extends FunSuite {
+class SchemaValidationSuite extends FunSuite with LoggerTestBase{
 
   test("Scalar types should be validated") {
     val schema = StructType(
       Array(
         StructField("id", LongType),
-        StructField("string_good", StringType, nullable = true, Metadata.fromJson(" { \"default\": \"Unknown\" } ")),
-        StructField("string_bad", StringType, nullable = true, Metadata.fromJson(" { \"default\": -1 } ")),
-        StructField("bool_good", BooleanType, nullable = true, Metadata.fromJson(" { \"default\": \"true\" } ")),
-        StructField("bool_bad", BooleanType, nullable = true, Metadata.fromJson(" { \"default\": \"1\" } ")),
-        StructField("tiny_good", ByteType, nullable = true, Metadata.fromJson(" { \"default\": \"127\" } ")),
-        StructField("tiny_bad", ByteType, nullable = true, Metadata.fromJson(" { \"default\": \"-127-\" } ")),
-        StructField("short_good", ShortType, nullable = false, Metadata.fromJson(" { \"default\": \"20000\" } ")),
-        StructField("short_bad", ShortType, nullable = false, Metadata.fromJson(" { \"default\": \"20000.0\" } ")),
-        StructField("integer_good", IntegerType, nullable = false, Metadata.fromJson(" { \"default\": \"1000000000\" } ")),
-        StructField("integer_bad", IntegerType, nullable = false, Metadata.fromJson(" { \"default\": \"number\" } ")),
-        StructField("long_good", LongType, nullable = false, Metadata.fromJson(" { \"default\": \"1000000000000000000\" } ")),
-        StructField("long_bad", LongType, nullable = false, Metadata.fromJson(" { \"default\": \"wrong\" } ")),
-        StructField("float_good", FloatType, nullable = false, Metadata.fromJson(" { \"default\": \"1000.222\" } ")),
-        StructField("float_bad", FloatType, nullable = false, Metadata.fromJson(" { \"default\": \"1000.2.22\" } ")),
-        StructField("double_good", DoubleType, nullable = false, Metadata.fromJson(" { \"default\": \"1000000.5544\" } ")),
-        StructField("double_bad", DoubleType, nullable = false, Metadata.fromJson(" { \"default\": \"++1000000.5544\" } ")),
-        StructField("decimal_good", DecimalType(20,10), nullable = false, Metadata.fromJson(" { \"default\": \"314159265.314159265\"}")),
-        StructField("decimal_bad", DecimalType(20,10), nullable = false, Metadata.fromJson(" { \"default\": \"314159265358882224.3141.59265\"}"))
+        StructField("string_good", StringType, nullable = true, Metadata.fromJson(""" { "default": "Unknown" } """)),
+        StructField("string_bad", StringType, nullable = true, Metadata.fromJson(""" { "default": -1 } """)),
+        StructField("bool_good", BooleanType, nullable = true, Metadata.fromJson(""" { "default": "true" } """)),
+        StructField("bool_bad", BooleanType, nullable = true, Metadata.fromJson(""" { "default": "1" } """)),
+        StructField("tiny_good", ByteType, nullable = true, Metadata.fromJson(""" { "default": "127" } """)),
+        StructField("tiny_bad", ByteType, nullable = true, Metadata.fromJson(""" { "default": "-127-" } """)),
+        StructField("short_good", ShortType, nullable = false, Metadata.fromJson(""" { "default": "20000" } """)),
+        StructField("short_bad", ShortType, nullable = false, Metadata.fromJson(""" { "default": "20000.0" } """)),
+        StructField("integer_good", IntegerType, nullable = false, Metadata.fromJson(""" { "default": "1000000000" } """)),
+        StructField("integer_bad", IntegerType, nullable = false, Metadata.fromJson(""" { "default": "number" } """)),
+        StructField("long_good", LongType, nullable = false, Metadata.fromJson(""" { "default": "1000000000000000000" } """)),
+        StructField("long_bad", LongType, nullable = false, Metadata.fromJson(""" { "default": "wrong" } """)),
+        StructField("float_good", FloatType, nullable = false, Metadata.fromJson(""" { "default": "1000.222" } """)),
+        StructField("float_bad", FloatType, nullable = false, Metadata.fromJson(""" { "default": "1000.2.22" } """)),
+        StructField("double_good", DoubleType, nullable = false, Metadata.fromJson(""" { "default": "1000000.5544" } """)),
+        StructField("double_bad", DoubleType, nullable = false, Metadata.fromJson(""" { "default": "++1000000.5544" } """)),
+        StructField("decimal_good", DecimalType(20,10), nullable = false, Metadata.fromJson(""" { "default": "314159265.314159265"}""")),
+        StructField("decimal_bad", DecimalType(20,10), nullable = false, Metadata.fromJson(""" { "default": "314159265358882224.3141.59265"}"""))
       )
     )
 
     val failures = SchemaValidator.validateSchema(schema)
     if (failures.lengthCompare(9) != 0) {
-      println("Validation errors:\n")
-      println(failures.mkString("\n"))
+      logger.error("Validation errors:")
+      logger.error(failures.mkString("\n"))
     }
 
-    assume(failures.lengthCompare(9) == 0)
+    assert(failures.lengthCompare(9) == 0)
     assert(failures(0).fieldName == "string_bad")
     assert(failures(1).fieldName == "bool_bad")
     assert(failures(2).fieldName == "tiny_bad")
@@ -72,30 +73,30 @@ class SchemaValidationSuite extends FunSuite {
     val schema = StructType(
       Array(
         StructField("id", LongType),
-        StructField("tiny_good", ByteType, nullable = true, Metadata.fromJson(" { \"default\": \"127\" } ")),
-        StructField("tiny_bad", ByteType, nullable = true, Metadata.fromJson(" { \"default\": \"128\" } ")),
-        StructField("short_good", ShortType, nullable = false, Metadata.fromJson(" { \"default\": \"20000\" } ")),
-        StructField("short_bad", ShortType, nullable = false, Metadata.fromJson(" { \"default\": \"32768\" } ")),
-        StructField("integer_good", IntegerType, nullable = false, Metadata.fromJson(" { \"default\": \"1000000000\" } ")),
-        StructField("integer_bad", IntegerType, nullable = false, Metadata.fromJson(" { \"default\": \"6000000000\" } ")),
-        StructField("long_good", LongType, nullable = false, Metadata.fromJson(" { \"default\": \"1000000000000000000\" } ")),
-        StructField("long_bad", LongType, nullable = false, Metadata.fromJson(" { \"default\": \"10000000000000000000\" } ")),
-        StructField("float_good", FloatType, nullable = false, Metadata.fromJson(" { \"default\": \"1000.222\" } ")),
-        StructField("float_bad", FloatType, nullable = false, Metadata.fromJson(" { \"default\": \"1e40\" } ")),
-        StructField("double_good", DoubleType, nullable = false, Metadata.fromJson(" { \"default\": \"1000000.5544\" } ")),
-        StructField("double_bad", DoubleType, nullable = false, Metadata.fromJson(" { \"default\": \"1e310\" } ")),
-        StructField("decimal_good", DecimalType(20,10), nullable = false, Metadata.fromJson(" { \"default\": \"314159265351.31415926\"}")),
-        StructField("decimal_bad", DecimalType(20,10), nullable = false, Metadata.fromJson(" { \"default\": \"123456789012345678901.12345678901\"}"))
+        StructField("tiny_good", ByteType, nullable = true, Metadata.fromJson(""" { "default": "127" } """)),
+        StructField("tiny_bad", ByteType, nullable = true, Metadata.fromJson(""" { "default": "128" } """)),
+        StructField("short_good", ShortType, nullable = false, Metadata.fromJson(""" { "default": "20000" } """)),
+        StructField("short_bad", ShortType, nullable = false, Metadata.fromJson(""" { "default": "32768" } """)),
+        StructField("integer_good", IntegerType, nullable = false, Metadata.fromJson(""" { "default": "1000000000" } """)),
+        StructField("integer_bad", IntegerType, nullable = false, Metadata.fromJson(""" { "default": "6000000000" } """)),
+        StructField("long_good", LongType, nullable = false, Metadata.fromJson(""" { "default": "1000000000000000000" } """)),
+        StructField("long_bad", LongType, nullable = false, Metadata.fromJson(""" { "default": "10000000000000000000" } """)),
+        StructField("float_good", FloatType, nullable = false, Metadata.fromJson(""" { "default": "1000.222" } """)),
+        StructField("float_bad", FloatType, nullable = false, Metadata.fromJson(""" { "default": "1e40" } """)),
+        StructField("double_good", DoubleType, nullable = false, Metadata.fromJson(""" { "default": "1000000.5544" } """)),
+        StructField("double_bad", DoubleType, nullable = false, Metadata.fromJson(""" { "default": "1e310" } """)),
+        StructField("decimal_good", DecimalType(20,10), nullable = false, Metadata.fromJson(""" { "default": "314159265351.31415926"}""")),
+        StructField("decimal_bad", DecimalType(20,10), nullable = false, Metadata.fromJson(""" { "default": "123456789012345678901.12345678901"}"""))
       )
     )
 
     val failures = SchemaValidator.validateSchema(schema)
     if (failures.lengthCompare(7) != 0) {
-      println("Validation errors:\n")
-      println(failures.mkString("\n"))
+      logger.error("Validation errors:")
+      logger.error(failures.mkString("\n"))
     }
 
-    assume(failures.lengthCompare(7) == 0)
+    assert(failures.lengthCompare(7) == 0)
     assert(failures(0).fieldName == "tiny_bad")
     assert(failures(1).fieldName == "short_bad")
     assert(failures(2).fieldName == "integer_bad")
@@ -110,20 +111,20 @@ class SchemaValidationSuite extends FunSuite {
       Array(
         StructField("id", LongType),
         StructField("name", StringType),
-        StructField("orderdate", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"kk-MM-yyyy\" } ")),
-        StructField("deliverydate", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"wrong\" } ")),
-        StructField("paymentmade", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"bad\" } ")),
-        StructField("paymentreceived", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyyTHH:mm:ss\" } "))
+        StructField("orderdate", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "kk-MM-yyyy" } """)),
+        StructField("deliverydate", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "wrong" } """)),
+        StructField("paymentmade", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "bad" } """)),
+        StructField("paymentreceived", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyyTHH:mm:ss" } """))
       )
     )
 
     val failures = SchemaValidator.validateSchema(schema)
     if (failures.lengthCompare(4) != 0) {
-      println("Validation errors:\n")
-      println(failures.mkString("\n"))
+      logger.error("Validation errors:")
+      logger.error(failures.mkString("\n"))
     }
 
-    assume(failures.lengthCompare(4) == 0)
+    assert(failures.lengthCompare(4) == 0)
     assert(failures(0).fieldName == "orderdate")
     assert(failures(1).fieldName == "deliverydate")
     assert(failures(2).fieldName == "paymentmade")
@@ -135,20 +136,20 @@ class SchemaValidationSuite extends FunSuite {
       Array(
         StructField("id", LongType),
         StructField("name", StringType),
-        StructField("orderdate", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy\", \"default\": \"2015-01-01\" } ")),
-        StructField("deliverydate", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy\", \"default\": \"KKK\" } ")),
-        StructField("paymentmade", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy'T'HH:mm:ss\", \"default\": \"2005-01-01T18:00:12\" } ")),
-        StructField("paymentreceived", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy'T'HH:mm:ss\", \"default\": \"ZZZ\" } "))
+        StructField("orderdate", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy", "default": "2015-01-01" } """)),
+        StructField("deliverydate", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy", "default": "KKK" } """)),
+        StructField("paymentmade", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy'T'HH:mm:ss", "default": "2005-01-01T18:00:12" } """)),
+        StructField("paymentreceived", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy'T'HH:mm:ss", "default": "ZZZ" } """))
       )
     )
 
     val failures = SchemaValidator.validateSchema(schema)
     if (failures.lengthCompare(4) != 0) {
-      println("Validation errors:\n")
-      println(failures.mkString("\n"))
+      logger.error("Validation errors:")
+      logger.error(failures.mkString("\n"))
     }
 
-    assume(failures.lengthCompare(4) == 0)
+    assert(failures.lengthCompare(4) == 0)
     assert(failures(0).fieldName == "orderdate")
     assert(failures(1).fieldName == "deliverydate")
     assert(failures(2).fieldName == "paymentmade")
@@ -161,29 +162,29 @@ class SchemaValidationSuite extends FunSuite {
         StructField("id", StringType),
         StructField("name", StringType),
         StructField("orders", ArrayType(StructType(Array(
-          StructField("orderdate", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"DD-MM-yyyy\" } ")),
-          StructField("deliverdate", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy'T'HH:mm:ss\" } ")),
-          StructField("ordermade", TimestampType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy'T'HH:mm:ss\" } ")),
+          StructField("orderdate", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "DD-MM-yyyy" } """)),
+          StructField("deliverdate", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy'T'HH:mm:ss" } """)),
+          StructField("ordermade", TimestampType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy'T'HH:mm:ss" } """)),
           StructField("payment", StructType(Array(
-            StructField("due", DateType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy'T'HH:mm:ss\" } ")),
-            StructField("made", TimestampType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy\" } ")),
-            StructField("expected", TimestampType, nullable = false, Metadata.fromJson(" { \"pattern\": \"foo\" } ")),
-            StructField("received", TimestampType, nullable = false, Metadata.fromJson(" { \"pattern\": \"dd-MM-yyyy'T'HH:mm:ss\" } "))))
+            StructField("due", DateType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy'T'HH:mm:ss" } """)),
+            StructField("made", TimestampType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy" } """)),
+            StructField("expected", TimestampType, nullable = false, Metadata.fromJson(""" { "pattern": "foo" } """)),
+            StructField("received", TimestampType, nullable = false, Metadata.fromJson(""" { "pattern": "dd-MM-yyyy'T'HH:mm:ss" } """))))
           ))))
         ),
         StructField("matrix", ArrayType(ArrayType(StructType(Array(
-          StructField("bar", TimestampType, nullable = true, Metadata.fromJson(" { \"pattern\": \"DD-MM-yyyy'T'HH:mm:ss\" } ")))))
+          StructField("bar", TimestampType, nullable = true, Metadata.fromJson(""" { "pattern": "DD-MM-yyyy'T'HH:mm:ss" } """)))))
         ))
       ))
     val failures = SchemaValidator.validateSchema(schema)
     if (failures.lengthCompare(6) != 0) {
-      println("Schema:\n")
-      println(schema.prettyJson)
-      println("Validation errors:\n")
-      println(failures.mkString("\n"))
+      logger.error("Schema:\n")
+      logger.error(schema.prettyJson)
+      logger.error("Validation errors:")
+      logger.error(failures.mkString("\n"))
     }
 
-    assume(failures.lengthCompare(6) == 0)
+    assert(failures.lengthCompare(6) == 0)
     assert(failures(0).fieldName == "orders[].orderdate")
     assert(failures(1).fieldName == "orders[].deliverdate")
     assert(failures(2).fieldName == "orders[].payment.due")
@@ -211,13 +212,13 @@ class SchemaValidationSuite extends FunSuite {
       ))
     val failures = SchemaValidator.validateSchema(schema)
     if (failures.lengthCompare(4) != 0) {
-      println("Schema:\n")
-      println(schema.prettyJson)
-      println("Validation errors:\n")
-      println(failures.mkString("\n"))
+      logger.error("Schema:\n")
+      logger.error(schema.prettyJson)
+      logger.error("Validation errors:")
+      logger.error(failures.mkString("\n"))
     }
 
-    assume(failures.lengthCompare(4) == 0)
+    assert(failures.lengthCompare(4) == 0)
     assert(failures(0).fieldName == "my.id")
     assert(failures(1).fieldName == "orders[].order.date")
     assert(failures(2).fieldName == "orders[].payment.due.time")

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
@@ -186,7 +186,7 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     assert(parser7.format(t) == "(789) 1970-01-02 (123) 01:00:00 (456)")
   }
 
-  test("Lenient interpretation is not accepter") {
+  test("Lenient interpretation is not accepted") {
     //first lenient interpretation
     val pattern = "dd-MM-yyyy"
     val dateString = "2015-01-01"

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/time/EnceladusDateTimeParserSuite.scala
@@ -18,6 +18,7 @@ package za.co.absa.enceladus.utils.time
 import org.scalatest.FunSuite
 import java.sql.Date
 import java.sql.Timestamp
+import java.text.{ParseException, SimpleDateFormat}
 
 case class TestInputRow(id: Int, stringField: String)
 
@@ -185,4 +186,16 @@ class EnceladusDateTimeParserSuite extends FunSuite{
     assert(parser7.format(t) == "(789) 1970-01-02 (123) 01:00:00 (456)")
   }
 
+  test("Lenient interpretation is not accepter") {
+    //first lenient interpretation
+    val pattern = "dd-MM-yyyy"
+    val dateString = "2015-01-01"
+    val sdf = new SimpleDateFormat(pattern)
+    sdf.parse(dateString)
+    //non lenient within EnceladusDateTimeParser
+    val parser = EnceladusDateTimeParser(pattern)
+    intercept[ParseException] {
+      parser.parseDate(dateString)
+    }
+  }
 }


### PR DESCRIPTION
* Match EnceladusDateTimeParser lenient setting to Spark's
* Extra test on leniency
* Fixed SchemaValidationSuite tests
* Ensuring Maven runs tests in UTF-8