### PR TITLE
#718: Decrease the size of the build log - module Utils

### DIFF
--- a/utils/src/main/scala/za/co/absa/enceladus/utils/error/ErrorMessage.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/error/ErrorMessage.scala
@@ -16,6 +16,7 @@
 package za.co.absa.enceladus.utils.error
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.StructType
 
 /**
  * Case class to represent an error message
@@ -33,14 +34,14 @@ case class Mapping(mappingTableColumn: String, mappedDatasetColumn: String)
 object ErrorMessage {
   val errorColumnName = "errCol"
 
-  def stdCastErr(errCol: String, rawValue: String) = ErrorMessage(errType = "stdCastError", errCode = "E00000", errMsg = "Standardization Error - Type cast", errCol = errCol, rawValues = Seq(rawValue))
-  def stdNullErr(errCol: String) = ErrorMessage(errType = "stdNullError", errCode = "E00002", errMsg = "Standardization Error - Null detected in non-nullable attribute", errCol = errCol, rawValues = Seq("null"))
-  def confMappingErr(errCol: String, rawValues: Seq[String], mappings: Seq[Mapping]) =
+  def stdCastErr(errCol: String, rawValue: String): ErrorMessage = ErrorMessage(errType = "stdCastError", errCode = "E00000", errMsg = "Standardization Error - Type cast", errCol = errCol, rawValues = Seq(rawValue))
+  def stdNullErr(errCol: String): ErrorMessage = ErrorMessage(errType = "stdNullError", errCode = "E00002", errMsg = "Standardization Error - Null detected in non-nullable attribute", errCol = errCol, rawValues = Seq("null"))
+  def confMappingErr(errCol: String, rawValues: Seq[String], mappings: Seq[Mapping]): ErrorMessage =
     ErrorMessage(errType = "confMapError", errCode = "E00001", errMsg = "Conformance Error - Null produced by mapping conformance rule", errCol = errCol, rawValues = rawValues, mappings = mappings)
-  def confCastErr(errCol: String, rawValue: String) = ErrorMessage(errType = "confCastError", errCode = "E00003", errMsg = "Conformance Error - Null returned by casting conformance rule", errCol = errCol, rawValues = Seq(rawValue))
-  def confNegErr(errCol: String, rawValue: String) = ErrorMessage(errType = "confNegError", errCode = "E00004", errMsg = "Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged", errCol = errCol, rawValues = Seq(rawValue))
+  def confCastErr(errCol: String, rawValue: String): ErrorMessage = ErrorMessage(errType = "confCastError", errCode = "E00003", errMsg = "Conformance Error - Null returned by casting conformance rule", errCol = errCol, rawValues = Seq(rawValue))
+  def confNegErr(errCol: String, rawValue: String): ErrorMessage = ErrorMessage(errType = "confNegError", errCode = "E00004", errMsg = "Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged", errCol = errCol, rawValues = Seq(rawValue))
 
-  def errorColSchema(implicit spark: SparkSession) = {
+  def errorColSchema(implicit spark: SparkSession): StructType = {
     import spark.implicits._
     spark.emptyDataset[ErrorMessage].schema
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
@@ -338,7 +338,7 @@ object ExplodeTools {
   private def addSuperTransientField(inputDf: DataFrame, arrayColPathName: String): (DataFrame, String) = {
     val colName = SchemaUtils.getUniqueName(superTransientColumnName, Some(inputDf.schema))
     val nestedColName = (arrayColPathName.split('.').dropRight(1) :+ colName).mkString(".")
-    val df = DeepArrayTransformations.nestedAddColumn(inputDf, nestedColName, () => lit(null))
+    val df = DeepArrayTransformations.nestedAddColumn(inputDf, nestedColName, c => lit(null))
     (df, nestedColName)
   }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
@@ -338,7 +338,7 @@ object ExplodeTools {
   private def addSuperTransientField(inputDf: DataFrame, arrayColPathName: String): (DataFrame, String) = {
     val colName = SchemaUtils.getUniqueName(superTransientColumnName, Some(inputDf.schema))
     val nestedColName = (arrayColPathName.split('.').dropRight(1) :+ colName).mkString(".")
-    val df = DeepArrayTransformations.nestedAddColumn(inputDf, nestedColName, _ => lit(null))
+    val df = DeepArrayTransformations.nestedAddColumn(inputDf, nestedColName, () => lit(null))
     (df, nestedColName)
   }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/fs/FileSystemVersionUtils.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/fs/FileSystemVersionUtils.scala
@@ -42,7 +42,7 @@ class FileSystemVersionUtils(conf: Configuration) {
     val uri = path.toUri
     val scheme = uri.getScheme
     val authority = uri.getAuthority
-    val prefix = if (scheme == null || authority == null) "" else scheme + "://"+authority
+    val prefix = if (scheme == null || authority == null) "" else scheme + "://" + authority
     val rawPath = uri.getRawPath
     (prefix, rawPath)
   }
@@ -61,7 +61,7 @@ class FileSystemVersionUtils(conf: Configuration) {
 
     var currPath = prefix
     tokens.foreach({ dir =>
-      currPath = currPath + "/"+dir
+      currPath = currPath + "/" + dir
       val p = new Path(currPath)
       log.info(s"Checking path: ${p.toUri.toString}")
       if (!fs.exists(p)) {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/ColumnImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/ColumnImplicits.scala
@@ -30,7 +30,7 @@ object ColumnImplicits {
       * Scala/ Java.
       * Another enhancement is, that the function allows a negative index, denoting counting of the index from back
       * This version takes the substring from the startPos until the end.
-      * @param startPos the index (zero based) where to start the substring from, if negative it;s counted from end
+      * @param startPos the index (zero based) where to start the substring from, if negative it's counted from end
       * @return         column with requested substring
       */
     def zeroBasedSubstr(startPos: Int): Column = {
@@ -46,7 +46,7 @@ object ColumnImplicits {
       * Scala/ Java.
       * Another enhancement is, that the function allows a negative index, denoting counting of the index from back
       * This version takes the substring from the startPos and takes up to the given number of characters (less.
-      * @param startPos the index (zero based) where to start the substring from, if negative it;s counted from end
+      * @param startPos the index (zero based) where to start the substring from, if negative it's counted from end
       * @param len      length of the desired substring, if longer then the rest of the string, all the remaining characters are taken
       * @return         column with requested substring
       */

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/performance/PerformanceMeasurer.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/performance/PerformanceMeasurer.scala
@@ -32,8 +32,6 @@ class PerformanceMeasurer(val jobName: String) {
     def getMetrics: String = content
   }
 
-  implicit def MetricsToString(metrics: PerfMetricsBuilder): String = metrics.getMetrics
-
   def startMeasurement(inputDatasetSize: Long): Unit = {
     startDateTime = Some(ZonedDateTime.now())
     this.inputDatasetSize = Some(inputDatasetSize)
@@ -50,7 +48,7 @@ class PerformanceMeasurer(val jobName: String) {
       case (Some(start), Some(finish)) => Duration.between(start, finish)
       case _ => throw new IllegalStateException(s"Performance metrics: either start or finish time is not set ($startDateTime .. $finishDateTime).")
     }
-    new PerfMetricsBuilder()
+    val perfMetricsBuilder = new PerfMetricsBuilder()
       .addVariable("perf_job_name", jobName)
       .addVariable("perf_start_date_time", startDateTime.get)
       .addVariable("perf_finish_date_time", finishDateTime.get)
@@ -58,6 +56,8 @@ class PerformanceMeasurer(val jobName: String) {
       .addVariable("perf_output_dataset_size", outputDatasetSize.get)
       .addVariable("perf_num_of_records", numberOfRecords.get)
       .addVariable("perf_elapsed_seconds", elapsedTime.getSeconds)
+
+    perfMetricsBuilder.getMetrics
   }
 
   def writeMetricsToFile(fileName: String): Unit = {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SchemaUtils.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SchemaUtils.scala
@@ -81,8 +81,9 @@ object SchemaUtils {
     */
   def getFieldNullability(path: String, schema: StructType): Option[Boolean] = {
     def typeHelper(pt: List[String], st: DataType, nl: Option[Boolean]): Option[Boolean] = {
-      if (pt.isEmpty) nl
-      else {
+      if (pt.isEmpty) {
+        nl
+      } else {
         st match {
           case str: StructType => Try {
             typeHelper(pt.tail, str(pt.head).dataType, Some(str.apply(pt.head).nullable))
@@ -253,13 +254,13 @@ object SchemaUtils {
     * @return The path with the new field appended or the field itself if path is empty
     */
   private[enceladus] def appendPath(path: String, fieldName: String) = {
-    if (path.isEmpty()) fieldName else s"$path.$fieldName"
+    if (path.isEmpty) fieldName else s"$path.$fieldName"
   }
 
   /**
     * Determine if a datatype is a primitive one
     */
-  def isPrimitive(dt: DataType) = dt match {
+  def isPrimitive(dt: DataType): Boolean = dt match {
     case _: BinaryType | _: BooleanType | _: ByteType | _: DateType | _: DecimalType | _: DoubleType | _: FloatType | _: IntegerType | _: LongType | _: NullType | _: ShortType | _: StringType | _: TimestampType => true
     case _ => false
   }
@@ -268,15 +269,15 @@ object SchemaUtils {
     * Determine the name of a field
     * Will override to "sourcecolumn" in the Metadata if it exists
     *
-    * @param field
-    * @return Metadata "sourcecolumn" if it exists or field.name
+    * @param field  field to work with
+    * @return       Metadata "sourcecolumn" if it exists or field.name
     */
   def getFieldNameOverriddenByMetadata(field: StructField): String = {
     if (field.metadata.contains("sourcecolumn")) {
       field.metadata.getString("sourcecolumn")
-    }
-    else
+    } else {
       field.name
+    }
   }
 
   /**

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkJobRunnerMethods.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkJobRunnerMethods.scala
@@ -27,10 +27,13 @@ trait SparkJobRunnerMethods {
     type MainClass = {def main(args: Array[String]): Unit}
 
     val jobClass = ct.runtimeClass
-    val jobClassSymbol = universe runtimeMirror jobClass.getClassLoader classSymbol jobClass
+    val jobClassSymbol = universe.runtimeMirror(jobClass.getClassLoader).classSymbol(jobClass)
     val jobInstance =
-      if (jobClassSymbol.isModuleClass) jobClass getField "MODULE$" get jobClass
-      else jobClass.newInstance
+      if (jobClassSymbol.isModuleClass) {
+        jobClass.getField("MODULE$").get(jobClass)
+      } else {
+        jobClass.newInstance
+      }
 
     jobInstance.asInstanceOf[MainClass].main(Array.empty)
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/transformations/ArrayTransformations.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/transformations/ArrayTransformations.scala
@@ -31,10 +31,13 @@ object ArrayTransformations {
 
   private val zipWithOrderUDF1 = new UDF1[Seq[Row], Seq[(Int, Row)]] {
     override def call(t1: Seq[Row]): Seq[(Int, Row)] = {
-      // scalastyle:off if.brace
-      if (t1 == null) null // scalastyle:ignore null
-      else t1.zipWithIndex.map(_.swap)
-      // scalastyle:on if.brace
+      // scalastyle:off null
+      if (t1 == null) {
+        null
+      } else {
+        t1.zipWithIndex.map(_.swap)
+      }
+      // scalastyle:on null
     }
   }
 
@@ -154,11 +157,13 @@ object ArrayTransformations {
 
     spark.udf.register(s"${groupField}_handleNullAndEmpty", new UDF2[Int, Seq[Row], Seq[Row]] {
       override def call(t1: Int, t2: Seq[Row]): Seq[Row] = {
-        // scalastyle:off if.brace
-        if (t1 == -1) null // scalastyle:ignore null
-        else if (t1 == 0) Seq()
-        else t2
-        // scalastyle:on if.brace
+        if (t1 == -1) {
+          null // scalastyle:ignore null
+        } else if (t1 == 0) {
+          Seq()
+        } else {
+          t2
+        }
       }
 
     }, arraySchema)

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformations.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformations.scala
@@ -27,7 +27,7 @@ import scala.util.control.NonFatal
 object DeepArrayTransformations {
 
   type TransformFunction = Column => Column
-  
+
   /**
     * Map transformation for columns that can be inside nested structs, arrays and its combinations.
     *
@@ -124,7 +124,7 @@ object DeepArrayTransformations {
     */
   def nestedAddColumn(df: DataFrame,
                       newColumnName: String,
-                      expression: Unit => Column): DataFrame = {
+                      expression: () => Column): DataFrame = {
     try {
       nestedWithColumnMapHelper(df, newColumnName, "", Some(_ => expression()), None)._1
     } catch {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformations.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformations.scala
@@ -124,7 +124,7 @@ object DeepArrayTransformations {
     */
   def nestedAddColumn(df: DataFrame,
                       newColumnName: String,
-                      expression: () => Column): DataFrame = {
+                      expression: Unit => Column): DataFrame = {
     try {
       nestedWithColumnMapHelper(df, newColumnName, "", Some(_ => expression()), None)._1
     } catch {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypePattern.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypePattern.scala
@@ -15,9 +15,7 @@
 
 package za.co.absa.enceladus.utils.types
 
-import org.apache.spark.sql.types.StructField
-
-import scala.util.Try
+import scala.language.implicitConversions
 
 /**
   * Class to carry enhanced information about formatting pattern in conversion from/to string

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/SchemaPathValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/SchemaPathValidator.scala
@@ -17,6 +17,8 @@ package za.co.absa.enceladus.utils.validation
 
 import org.apache.spark.sql.types._
 
+import scala.annotation.tailrec
+
 /**
   * Object responsible for validating paths to fields, it's existence and case sensitivity
   */
@@ -181,6 +183,7 @@ object SchemaPathValidator {
     underlyingType
   }
 
+  @tailrec
   private def getSchemaField(schema: StructType, path: Array[String]): Option[StructField] = {
     if (path.isEmpty) {
       None

--- a/utils/src/test/resources/log4j.properties
+++ b/utils/src/test/resources/log4j.properties
@@ -14,38 +14,52 @@
 #
 
 # Set everything to be logged to the console
-log4j.rootCategory = WARN, general
+log4j.rootCategory=WARN, general
 
-log4j.appender.general = org.apache.log4j.ConsoleAppender
-log4j.appender.general.target = System.err
-log4j.appender.general.layout = org.apache.log4j.PatternLayout
-log4j.appender.general.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.general=org.apache.log4j.ConsoleAppender
+log4j.appender.general.target=System.err
+log4j.appender.general.layout=org.apache.log4j.PatternLayout
+log4j.appender.general.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
 
 # Suppress warnings logged within the code inside the tests
-log4j.logger.za.co.absa.enceladus.conformance.interpreter.OptimizerTimeTracker = ERROR
-log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreter = ERROR
-log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreterGroupExplode = ERROR
-log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.TypeParser$ = ERROR
-log4j.logger.za.co.absa.enceladus.utils.transformations.ArrayTransformations$ = ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.OptimizerTimeTracker=ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreter=ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreterGroupExplode=ERROR
+log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.TypeParser$=ERROR
+log4j.logger.za.co.absa.enceladus.utils.transformations.ArrayTransformations$=ERROR
 
 # Suppress a spamming warning from SparkSession$Builder
-log4j.appender.forsparksessionbuilder = org.apache.log4j.ConsoleAppender
-log4j.appender.forsparksessionbuilder.target = System.err
-log4j.appender.forsparksessionbuilder.layout = org.apache.log4j.PatternLayout
-log4j.appender.forsparksessionbuilder.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
-log4j.appender.forsparksessionbuilder.filter.01 = org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forsparksessionbuilder.filter.01.StringToMatch = Using an existing SparkSession; some configuration may not take effect.
-log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch = false
-log4j.logger.org.apache.spark.sql.SparkSession$Builder = WARN, forsparksessionbuilder
-log4j.additivity.org.apache.spark.sql.SparkSession$Builder = false
+log4j.appender.forsparksessionbuilder=org.apache.log4j.ConsoleAppender
+log4j.appender.forsparksessionbuilder.target=System.err
+log4j.appender.forsparksessionbuilder.layout=org.apache.log4j.PatternLayout
+log4j.appender.forsparksessionbuilder.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forsparksessionbuilder.filter.01=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forsparksessionbuilder.filter.01.StringToMatch=Using an existing SparkSession; some configuration may not take effect.
+log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch=false
+log4j.logger.org.apache.spark.sql.SparkSession$Builder=WARN, forsparksessionbuilder
+log4j.additivity.org.apache.spark.sql.SparkSession$Builder=false
 
 # Suppress validation error logs from SchemaChecker
-log4j.appender.forschemachecker = org.apache.log4j.ConsoleAppender
-log4j.appender.forschemachecker.target = System.err
-log4j.appender.forschemachecker.layout = org.apache.log4j.PatternLayout
-log4j.appender.forschemachecker.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
-log4j.appender.forschemachecker.filter.01 = org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forschemachecker.filter.01.StringToMatch = Validation error for column
-log4j.appender.forschemachecker.filter.01.AcceptOnMatch = false
-log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$ = WARN, forschemachecker
-log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$ = false
+log4j.appender.forschemachecker=org.apache.log4j.ConsoleAppender
+log4j.appender.forschemachecker.target=System.err
+log4j.appender.forschemachecker.layout=org.apache.log4j.PatternLayout
+log4j.appender.forschemachecker.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forschemachecker.filter.01=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forschemachecker.filter.01.StringToMatch=Validation error for column
+log4j.appender.forschemachecker.filter.01.AcceptOnMatch=false
+log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=WARN, forschemachecker
+log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=false
+
+# Suppress validation error logs from KafkaParametersProcessor
+log4j.appender.forkafkaparametersprocessor=org.apache.log4j.ConsoleAppender
+log4j.appender.forkafkaparametersprocessor.target=System.err
+log4j.appender.forkafkaparametersprocessor.layout=org.apache.log4j.PatternLayout
+log4j.appender.forkafkaparametersprocessor.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forkafkaparametersprocessor.filter.01=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forkafkaparametersprocessor.filter.01.StringToMatch=No Kafka parameter was provided.
+log4j.appender.forkafkaparametersprocessor.filter.01.AcceptOnMatch=false
+log4j.appender.forkafkaparametersprocessor.filter.02=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forkafkaparametersprocessor.filter.02.StringToMatch=Missing mandatory Kafka parameter:
+log4j.appender.forkafkaparametersprocessor.filter.02.AcceptOnMatch=false
+log4j.logger.za.co.absa.enceladus.kafka.parameters.KafkaParametersProcessor$=WARN, forkafkaparametersprocessor
+log4j.additivity.za.co.absa.enceladus.kafka.parameters.KafkaParametersProcessor$=false

--- a/utils/src/test/resources/log4j.properties
+++ b/utils/src/test/resources/log4j.properties
@@ -14,8 +14,38 @@
 #
 
 # Set everything to be logged to the console
-log4j.rootCategory=WARN, console
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+log4j.rootCategory = WARN, general
+
+log4j.appender.general = org.apache.log4j.ConsoleAppender
+log4j.appender.general.target = System.err
+log4j.appender.general.layout = org.apache.log4j.PatternLayout
+log4j.appender.general.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+
+# Suppress warnings logged within the code inside the tests
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.OptimizerTimeTracker = ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreter = ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreterGroupExplode = ERROR
+log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.TypeParser$ = ERROR
+log4j.logger.za.co.absa.enceladus.utils.transformations.ArrayTransformations$ = ERROR
+
+# Suppress a spamming warning from SparkSession$Builder
+log4j.appender.forsparksessionbuilder = org.apache.log4j.ConsoleAppender
+log4j.appender.forsparksessionbuilder.target = System.err
+log4j.appender.forsparksessionbuilder.layout = org.apache.log4j.PatternLayout
+log4j.appender.forsparksessionbuilder.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forsparksessionbuilder.filter.01 = org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forsparksessionbuilder.filter.01.StringToMatch = Using an existing SparkSession; some configuration may not take effect.
+log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch = false
+log4j.logger.org.apache.spark.sql.SparkSession$Builder = WARN, forsparksessionbuilder
+log4j.additivity.org.apache.spark.sql.SparkSession$Builder = false
+
+# Suppress validation error logs from SchemaChecker
+log4j.appender.forschemachecker = org.apache.log4j.ConsoleAppender
+log4j.appender.forschemachecker.target = System.err
+log4j.appender.forschemachecker.layout = org.apache.log4j.PatternLayout
+log4j.appender.forschemachecker.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forschemachecker.filter.01 = org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forschemachecker.filter.01.StringToMatch = Validation error for column
+log4j.appender.forschemachecker.filter.01.AcceptOnMatch = false
+log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$ = WARN, forschemachecker
+log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$ = false

--- a/utils/src/test/scala/za/co/absa/enceladus/FsUtilsSpec.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/FsUtilsSpec.scala
@@ -25,7 +25,7 @@ import za.co.absa.enceladus.utils.testUtils.SparkTestBase
   */
 class FsUtilsSpec extends FlatSpec with Matchers with SparkTestBase {
   val fsUtils = new FileSystemVersionUtils(spark.sparkContext.hadoopConfiguration)
-  
+
   "splitUriPath" should "split URI and path" in
   {
     val path = new Path("hdfs://some-host:8020/user/data/input")

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayErrorTransformationSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayErrorTransformationSuite.scala
@@ -873,7 +873,7 @@ class DeepArrayErrorTransformationSuite extends FunSuite with SparkTestBase with
     }.getMessage contains "Output field cannot be empty")
 
     assert(intercept[IllegalArgumentException] {
-      DeepArrayTransformations.nestedAddColumn(df, "value", () => lit("foo")).printSchema()
+      DeepArrayTransformations.nestedAddColumn(df, "value", c => lit("foo")).printSchema()
     }.getMessage contains "The column 'value' already exists")
 
   }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayErrorTransformationSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayErrorTransformationSuite.scala
@@ -1017,20 +1017,20 @@ class DeepArrayErrorTransformationSuite extends FunSuite with SparkTestBase with
 
   private def assertSchema(actualSchema: String, expectedSchema: String): Unit = {
     if (actualSchema != expectedSchema) {
-      logger.debug("EXPECTED:")
-      logger.debug(expectedSchema)
-      logger.debug("ACTUAL:")
-      logger.debug(actualSchema)
+      logger.error("EXPECTED:")
+      logger.error(expectedSchema)
+      logger.error("ACTUAL:")
+      logger.error(actualSchema)
       fail("Actual conformed schema does not match the expected schema (see above).")
     }
   }
 
   private def assertResults(actualResults: String, expectedResults: String): Unit = {
     if (actualResults != expectedResults) {
-      logger.debug("EXPECTED:")
-      logger.debug(expectedResults)
-      logger.debug("ACTUAL:")
-      logger.debug(actualResults)
+      logger.error("EXPECTED:")
+      logger.error(expectedResults)
+      logger.error("ACTUAL:")
+      logger.error(actualResults)
       fail("Actual conformed dataset JSON does not match the expected JSON (see above).")
     }
   }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayErrorTransformationSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayErrorTransformationSuite.scala
@@ -21,10 +21,10 @@ import org.apache.spark.sql.types.{IntegerType, StringType}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.general.JsonUtils
-import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 import DeepArraySamples._
 
-class DeepArrayErrorTransformationSuite extends FunSuite with SparkTestBase {
+class DeepArrayErrorTransformationSuite extends FunSuite with SparkTestBase with LoggerTestBase{
   // scalastyle:off line.size.limit
   // scalastyle:off null
 
@@ -873,7 +873,7 @@ class DeepArrayErrorTransformationSuite extends FunSuite with SparkTestBase {
     }.getMessage contains "Output field cannot be empty")
 
     assert(intercept[IllegalArgumentException] {
-      DeepArrayTransformations.nestedAddColumn(df, "value", _ => lit("foo")).printSchema()
+      DeepArrayTransformations.nestedAddColumn(df, "value", () => lit("foo")).printSchema()
     }.getMessage contains "The column 'value' already exists")
 
   }
@@ -1017,20 +1017,20 @@ class DeepArrayErrorTransformationSuite extends FunSuite with SparkTestBase {
 
   private def assertSchema(actualSchema: String, expectedSchema: String): Unit = {
     if (actualSchema != expectedSchema) {
-      println("EXPECTED:")
-      println(expectedSchema)
-      println("ACTUAL:")
-      println(actualSchema)
+      logger.debug("EXPECTED:")
+      logger.debug(expectedSchema)
+      logger.debug("ACTUAL:")
+      logger.debug(actualSchema)
       fail("Actual conformed schema does not match the expected schema (see above).")
     }
   }
 
   private def assertResults(actualResults: String, expectedResults: String): Unit = {
     if (actualResults != expectedResults) {
-      println("EXPECTED:")
-      println(expectedResults)
-      println("ACTUAL:")
-      println(actualResults)
+      logger.debug("EXPECTED:")
+      logger.debug(expectedResults)
+      logger.debug("ACTUAL:")
+      logger.debug(actualResults)
       fail("Actual conformed dataset JSON does not match the expected JSON (see above).")
     }
   }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformationSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformationSuite.scala
@@ -258,7 +258,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase with Logg
   test("Test lit() of a plain field") {
     val df = spark.sparkContext.parallelize(plainSampleN).toDF
 
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "planet", () => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "planet", c => {
       lit("Earth")
     })
 
@@ -284,7 +284,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase with Logg
     // Struct of struct
     val df = spark.sparkContext.parallelize(structOfStructSampleN).toDF
 
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "employee.address.conformedType", () => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "employee.address.conformedType", c => {
       lit("City")
     })
 
@@ -315,7 +315,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase with Logg
     // Array of struct
     val df = spark.sparkContext.parallelize(arraysOfStructsSampleN).toDF
 
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "person.conformedType", () => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "person.conformedType", c => {
       lit("Person")
     })
 
@@ -344,7 +344,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase with Logg
     // Array of struct
     val df = spark.sparkContext.parallelize(arraysOfStructsSampleN).toDF
 
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "person.department", () => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "person.department", c => {
       lit("IT")
     })
 
@@ -374,7 +374,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase with Logg
     // Array of struct
     val df = spark.sparkContext.parallelize(arraysOfStrtuctsDeepSampleN).toDF
 
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "legs.conditions.conformedSystem", () => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "legs.conditions.conformedSystem", c => {
       lit("Trading")
     })
 

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformationSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformationSuite.scala
@@ -16,7 +16,7 @@
 package za.co.absa.enceladus.utils.transformations
 
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StringType
 import DeepArraySamples._
@@ -27,7 +27,7 @@ import DeepArraySamples._
 // It is declared package private so the names won't pollute public/exported namespace
 
 
-class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
+class DeepArrayTransformationSuite extends FunSuite with SparkTestBase with LoggerTestBase{
   // scalastyle:off line.size.limit
   // scalastyle:off null
 
@@ -212,9 +212,6 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
     // Array of struct
     val df = spark.sparkContext.parallelize(arraysOfStrtuctsDeepSampleN).toDF
 
-    //df.printSchema()
-    //df.toJSON.take(10).foreach(println)
-
     val dfOut = DeepArrayTransformations.nestedWithColumnMap(df, "legs.conditions.conif", "conformedField", c => {
       upper(c)
     })
@@ -261,7 +258,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
   test("Test lit() of a plain field") {
     val df = spark.sparkContext.parallelize(plainSampleN).toDF
 
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "planet", c => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "planet", () => {
       lit("Earth")
     })
 
@@ -287,7 +284,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
     // Struct of struct
     val df = spark.sparkContext.parallelize(structOfStructSampleN).toDF
 
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "employee.address.conformedType", c => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "employee.address.conformedType", () => {
       lit("City")
     })
 
@@ -318,10 +315,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
     // Array of struct
     val df = spark.sparkContext.parallelize(arraysOfStructsSampleN).toDF
 
-    //df.printSchema()
-    //df.toJSON.take(10).foreach(println)
-
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "person.conformedType", c => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "person.conformedType", () => {
       lit("Person")
     })
 
@@ -350,7 +344,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
     // Array of struct
     val df = spark.sparkContext.parallelize(arraysOfStructsSampleN).toDF
 
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "person.department", c => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "person.department", () => {
       lit("IT")
     })
 
@@ -380,10 +374,7 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
     // Array of struct
     val df = spark.sparkContext.parallelize(arraysOfStrtuctsDeepSampleN).toDF
 
-    //df.printSchema()
-    //df.toJSON.take(10).foreach(println)
-
-    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "legs.conditions.conformedSystem", c => {
+    val dfOut = DeepArrayTransformations.nestedAddColumn(df, "legs.conditions.conformedSystem", () => {
       lit("Trading")
     })
 
@@ -850,20 +841,20 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase {
 
   private def assertSchema(actualSchema: String, expectedSchema: String): Unit = {
     if (actualSchema != expectedSchema) {
-      println("EXPECTED:")
-      println(expectedSchema)
-      println("ACTUAL:")
-      println(actualSchema)
+      logger.debug("EXPECTED:")
+      logger.debug(expectedSchema)
+      logger.debug("ACTUAL:")
+      logger.debug(actualSchema)
       fail("Actual conformed schema does not match the expected schema (see above).")
     }
   }
 
   private def assertResults(actualResults: String, expectedResults: String): Unit = {
     if (actualResults != expectedResults) {
-      println("EXPECTED:")
-      println(expectedResults)
-      println("ACTUAL:")
-      println(actualResults)
+      logger.debug("EXPECTED:")
+      logger.debug(expectedResults)
+      logger.debug("ACTUAL:")
+      logger.debug(actualResults)
       fail("Actual conformed dataset JSON does not match the expected JSON (see above).")
     }
   }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformationSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/DeepArrayTransformationSuite.scala
@@ -841,20 +841,20 @@ class DeepArrayTransformationSuite extends FunSuite with SparkTestBase with Logg
 
   private def assertSchema(actualSchema: String, expectedSchema: String): Unit = {
     if (actualSchema != expectedSchema) {
-      logger.debug("EXPECTED:")
-      logger.debug(expectedSchema)
-      logger.debug("ACTUAL:")
-      logger.debug(actualSchema)
+      logger.error("EXPECTED:")
+      logger.error(expectedSchema)
+      logger.error("ACTUAL:")
+      logger.error(actualSchema)
       fail("Actual conformed schema does not match the expected schema (see above).")
     }
   }
 
   private def assertResults(actualResults: String, expectedResults: String): Unit = {
     if (actualResults != expectedResults) {
-      logger.debug("EXPECTED:")
-      logger.debug(expectedResults)
-      logger.debug("ACTUAL:")
-      logger.debug(actualResults)
+      logger.error("EXPECTED:")
+      logger.error(expectedResults)
+      logger.error("ACTUAL:")
+      logger.error(actualResults)
       fail("Actual conformed dataset JSON does not match the expected JSON (see above).")
     }
   }


### PR DESCRIPTION
* Adhere to Scalastyle
* Follow some best-practices:
** typed implicits
** types declared for public members
** limit implicit conversions and if mark them
* Parameterless function as type
* setup logging for tests - style, filtering
* remove direct output to console (println, Dataframe.show, etc)