### PR TITLE
#719: Decrease the size of the build log - module Conformance

### DIFF
--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/CmdConfig.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/CmdConfig.scala
@@ -108,7 +108,7 @@ object CmdConfig {
 
     opt[String]("menas-auth-keytab").optional().action({ (file, config) =>
       keytabFile = Some(file)
-      if(!fsUtils.localExists(file) && fsUtils.hdfsExists(file)) {
+      if (!fsUtils.localExists(file) && fsUtils.hdfsExists(file)) {
         config.copy(menasCredentials = Some(Right(fsUtils.hdfsFileToLocalTempFile(file))))
       } else {
         config.copy(menasCredentials = Some(Right(file)))
@@ -116,7 +116,7 @@ object CmdConfig {
     }).text("Path to keytab file used for authenticating to menas").validate({ file =>
       if (credsFile.isDefined) {
         failure("Only one authentication method is allowed at a time")
-      } else if(fsUtils.exists(file)) {
+      } else if (fsUtils.exists(file)) {
         success
       } else {
         failure("Keytab file doesn't exist")

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/CmdConfig.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/CmdConfig.scala
@@ -98,12 +98,13 @@ object CmdConfig {
       credsFile = Some(path)
       config.copy(menasCredentials = Some(credential))
     }).text("Path to Menas credentials config file.").validate(path =>
-      // scalastyle:off if.brace
-      if (keytabFile.isDefined) failure("Only one authentication method is allow at a time")
-      else if (MenasCredentials.exists(MenasCredentials.replaceHome(path))) success
-      else failure("Credentials file not found."))
-      // scalastyle:on if.brace
-
+      if (keytabFile.isDefined) {
+        failure("Only one authentication method is allow at a time")
+      } else if (MenasCredentials.exists(MenasCredentials.replaceHome(path))) {
+        success
+      } else {
+        failure("Credentials file not found.")
+      })
 
     opt[String]("menas-auth-keytab").optional().action({ (file, config) =>
       keytabFile = Some(file)
@@ -113,11 +114,13 @@ object CmdConfig {
         config.copy(menasCredentials = Some(Right(file)))
       }
     }).text("Path to keytab file used for authenticating to menas").validate({ file =>
-      // scalastyle:off if.brace
-      if (credsFile.isDefined) failure("Only one authentication method is allowed at a time")
-      else if(fsUtils.exists(file)) success
-      else failure("Keytab file doesn't exist")
-      // scalastyle:on if.brace
+      if (credsFile.isDefined) {
+        failure("Only one authentication method is allowed at a time")
+      } else if(fsUtils.exists(file)) {
+        success
+      } else {
+        failure("Keytab file doesn't exist")
+      }
     })
 
     opt[String]("performance-file").optional().action((value, config) =>

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/CmdConfig.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/CmdConfig.scala
@@ -66,8 +66,11 @@ object CmdConfig {
     opt[Int]('d', "dataset-version").required().action((value, config) =>
       config.copy(datasetVersion = value)).text("Dataset version")
       .validate(value =>
-        if (value > 0) success
-        else failure("Option --dataset-version must be >0"))
+        if (value > 0) {
+          success
+        } else {
+          failure("Option --dataset-version must be >0")
+        })
 
     val reportDateMatcher: Regex = "^\\d{4}-\\d{2}-\\d{2}$".r
     opt[String]('R', "report-date").required().action((value, config) =>
@@ -82,8 +85,11 @@ object CmdConfig {
       config.copy(reportVersion = Some(value)))
       .text("Report version. If not provided, it is inferred based on the publish path (it's an EXPERIMENTAL feature)")
       .validate(value =>
-        if (value > 0) success
-        else failure("Option --report-version must be >0"))
+        if (value > 0) {
+          success
+        } else {
+          failure("Option --report-version must be >0")
+        })
 
     private var credsFile: Option[String] = None
     private var keytabFile: Option[String] = None
@@ -92,21 +98,26 @@ object CmdConfig {
       credsFile = Some(path)
       config.copy(menasCredentials = Some(credential))
     }).text("Path to Menas credentials config file.").validate(path =>
+      // scalastyle:off if.brace
       if (keytabFile.isDefined) failure("Only one authentication method is allow at a time")
       else if (MenasCredentials.exists(MenasCredentials.replaceHome(path))) success
       else failure("Credentials file not found."))
+      // scalastyle:on if.brace
+
 
     opt[String]("menas-auth-keytab").optional().action({ (file, config) =>
       keytabFile = Some(file)
       if(!fsUtils.localExists(file) && fsUtils.hdfsExists(file)) {
         config.copy(menasCredentials = Some(Right(fsUtils.hdfsFileToLocalTempFile(file))))
       } else {
-      config.copy(menasCredentials = Some(Right(file)))
+        config.copy(menasCredentials = Some(Right(file)))
       }
     }).text("Path to keytab file used for authenticating to menas").validate({ file =>
+      // scalastyle:off if.brace
       if (credsFile.isDefined) failure("Only one authentication method is allowed at a time")
       else if(fsUtils.exists(file)) success
       else failure("Keytab file doesn't exist")
+      // scalastyle:on if.brace
     })
 
     opt[String]("performance-file").optional().action((value, config) =>

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -19,7 +19,7 @@ import java.io.{PrintWriter, StringWriter}
 import java.text.MessageFormat
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.apache.log4j.{LogManager, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 import org.apache.spark.sql
 import org.apache.spark.sql.functions.{lit, to_date}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -27,7 +27,7 @@ import za.co.absa.atum.AtumImplicits
 import za.co.absa.atum.AtumImplicits.{DataSetWrapper, StringToPath}
 import za.co.absa.atum.core.Atum
 import za.co.absa.enceladus.conformance.datasource.DataSource
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.conformance.interpreter.rules.ValidationException
 import za.co.absa.enceladus.dao.{EnceladusDAO, EnceladusRestDAO}
 import za.co.absa.enceladus.dao.menasplugin.MenasPlugin
@@ -46,7 +46,7 @@ object DynamicConformanceJob {
   private val reportDateFormat = "yyyy-MM-dd"
   private val infoVersionColumn = "enceladus_info_version"
 
-  private val log: Logger = LogManager.getLogger(this.getClass)
+  private val log: Logger = LoggerFactory.getLogger(this.getClass)
   private val conf: Config = ConfigFactory.load()
 
   def main(args: Array[String]) {
@@ -69,25 +69,27 @@ object DynamicConformanceJob {
       case None => inferVersion(conformance.hdfsPublishPath, cmd.reportDate)
     }
 
-    val stdPath = MessageFormat.format(conf.getString("standardized.hdfs.path"), cmd.datasetName,
-      cmd.datasetVersion.toString, cmd.reportDate, reportVersion.toString)
-    val publishPath: String = buildPublishPath(infoDateColumn, infoVersionColumn, cmd, conformance, reportVersion)
-    log.info(s"stdpath = $stdPath, publishPath = $publishPath")
+    val pathCfg = PathCfg(
+      publishPath = buildPublishPath(infoDateColumn, infoVersionColumn, cmd, conformance, reportVersion),
+      stdPath = MessageFormat.format(conf.getString("standardized.hdfs.path"), cmd.datasetName,
+        cmd.datasetVersion.toString, cmd.reportDate, reportVersion.toString)
+    )
+    log.info(s"stdpath = ${pathCfg.stdPath}, publishPath = ${pathCfg.publishPath}")
     // die before performing any computation if the output path already exists
-    if (fsUtils.hdfsExists(publishPath)) {
+    if (fsUtils.hdfsExists(pathCfg.publishPath)) {
       throw new IllegalStateException(
-        s"Path $publishPath already exists. Increment the run version, or delete $publishPath")
+        s"Path ${pathCfg.publishPath} already exists. Increment the run version, or delete ${pathCfg.publishPath}")
     }
 
     initFunctionalExtensions()
-    val performance = initPerformanceMeasurer(stdPath)
+    val performance = initPerformanceMeasurer(pathCfg.stdPath)
 
     // load data for input and mapping tables
-    val inputData = DataSource.getData(stdPath, dateTokens(0), dateTokens(1), dateTokens(2), "")
+    val inputData = DataSource.getData(pathCfg.stdPath, dateTokens(0), dateTokens(1), dateTokens(2), "")
 
     val result = conform(conformance, inputData, enableCF)
 
-    processResult(result, performance, publishPath, stdPath, reportVersion, args.mkString(" "))
+    processResult(result, performance, pathCfg, reportVersion, args.mkString(" "))
   }
 
   private def isExperimentalRuleEnabled()(implicit cmd: CmdConfig): Boolean = {
@@ -172,8 +174,13 @@ object DynamicConformanceJob {
 
   private def conform(conformance: Dataset, inputData: sql.Dataset[Row], enableCF: Boolean)
                      (implicit spark: SparkSession, cmd: CmdConfig, fsUtils: FileSystemVersionUtils, dao: EnceladusDAO): DataFrame = {
+    implicit val featureSwitcher: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(isExperimentalRuleEnabled())
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled())
+      .setControlFrameworkEnabled(enableCF)
+
     try {
-      DynamicInterpreter.interpret(conformance, inputData, isExperimentalRuleEnabled(), isCatalystWorkaroundEnabled(), enableCF)
+      DynamicInterpreter.interpret(conformance, inputData)
     } catch {
       case e: ValidationException =>
         AtumImplicits.SparkSessionWrapper(spark).setControlMeasurementError("Conformance", e.getMessage, e.techDetails)
@@ -188,7 +195,7 @@ object DynamicConformanceJob {
 
   private def processResult(result: DataFrame,
                             performance: PerformanceMeasurer,
-                            publishPath: String, stdPath: String,
+                            pathCfg: PathCfg,
                             reportVersion: Int,
                             cmdLineArgs: String)
                            (implicit spark: SparkSession, cmd: CmdConfig, fsUtils: FileSystemVersionUtils): Unit = {
@@ -208,16 +215,16 @@ object DynamicConformanceJob {
       throw new IllegalStateException(errMsg)
     }
     // ensure the whole path but version exists
-    fsUtils.createAllButLastSubDir(publishPath)
+    fsUtils.createAllButLastSubDir(pathCfg.publishPath)
 
-    withPartCols.write.parquet(publishPath)
+    withPartCols.write.parquet(pathCfg.publishPath)
 
-    val publishDirSize = fsUtils.getDirectorySize(publishPath)
+    val publishDirSize = fsUtils.getDirectorySize(pathCfg.publishPath)
     performance.finishMeasurement(publishDirSize, recordCount)
     PerformanceMetricTools.addPerformanceMetricsToAtumMetadata(spark, "conform",
-      stdPath, publishPath, EnceladusRestDAO.userName, cmdLineArgs)
+      pathCfg.stdPath, pathCfg.publishPath, EnceladusRestDAO.userName, cmdLineArgs)
 
-    withPartCols.writeInfoFile(publishPath)
+    withPartCols.writeInfoFile(pathCfg.publishPath)
     cmd.performanceMetricsFile.foreach(fileName => {
       try {
         performance.writeMetricsToFile(fileName)
@@ -241,4 +248,8 @@ object DynamicConformanceJob {
         publishPathOverride
     }
   }
+
+  private final case class PathCfg(publishPath: String, stdPath: String)
 }
+
+

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/datasource/DataSource.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/datasource/DataSource.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus.conformance.datasource
 
-import org.apache.log4j.LogManager
+import org.slf4j.LoggerFactory
 import scala.collection.mutable.HashMap
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.Row
@@ -27,12 +27,12 @@ import org.apache.hadoop.fs.Path
  * Utility object to provide access to data in HDFS (including partitioning and caching)
  */
 object DataSource {
-  private val log = LogManager.getLogger("enceladus.conformance.DataSource")
+  private val log = LoggerFactory.getLogger("enceladus.conformance.DataSource")
   private val dfs = HashMap[String, Dataset[Row]]()
 
   /**
    * Get loaded dataframe or load data given the report date and partitioning pattern
-   * 
+   *
    * @param path The base path in HDFS of the data
    * @param reportYear String representing the year in `yyyy` format
    * @param reportMonth String representing the month in `MM` format

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
@@ -33,7 +33,7 @@ import za.co.absa.enceladus.utils.general.Algorithms
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 
 object DynamicInterpreter {
-  private val log = LogManager.getLogger("enceladus.conformance.DynamicInterpreter")
+  private val log = LogManager.getLogger(this.getClass)
 
   /**
     * interpret The dynamic conformance interpreter function

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.conformance.interpreter
+
+/**
+ * Class bundling together switched for features to be used during Conformance
+ * It's a sealed abstract case class to enforce the the provided constructor (apply). This way values can be
+ * changed only via the setters and in case of removal of any of them, compiler will complain whenever they were used.
+ * @param experimentalMappingRuleEnabled     If true the new explode-optimized conformance mapping rule interpreter will be used
+ * @param catalystWorkaroundEnabled If true the Catalyst optimizer workaround is enabled
+ * @param controlFrameworkEnabled     If true sets the checkpoints on the dataset upon conforming
+ */
+sealed abstract case class FeatureSwitches(
+                                            experimentalMappingRuleEnabled: Boolean = false,
+                                            catalystWorkaroundEnabled: Boolean = false,
+                                            controlFrameworkEnabled: Boolean = false
+                                          ) {
+  private def copy(
+                    experimentalMappingRuleEnabled: Boolean = this.experimentalMappingRuleEnabled,
+                    catalystWorkaroundEnabled: Boolean = this.catalystWorkaroundEnabled,
+                    controlFrameworkEnabled: Boolean = this.controlFrameworkEnabled
+          ): FeatureSwitches = {
+    new FeatureSwitches(experimentalMappingRuleEnabled, catalystWorkaroundEnabled, controlFrameworkEnabled) {}
+  }
+
+  def setExperimentalMappingRuleEnabled(value: Boolean): FeatureSwitches = {
+    copy(experimentalMappingRuleEnabled = value)
+  }
+
+  def setCatalystWorkaroundEnabled(value: Boolean): FeatureSwitches = {
+    copy(catalystWorkaroundEnabled = value)
+  }
+
+  def setControlFrameworkEnabled(value: Boolean): FeatureSwitches = {
+    copy(controlFrameworkEnabled = value)
+  }
+
+}
+
+object FeatureSwitches {
+  def apply(): FeatureSwitches = new FeatureSwitches() {}
+}

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
@@ -18,10 +18,11 @@ package za.co.absa.enceladus.conformance.interpreter
 /**
  * Class bundling together switched for features to be used during Conformance
  * It's a sealed abstract case class to enforce the the provided constructor (apply). This way values can be
- * changed only via the setters and in case of removal of any of them, compiler will complain whenever they were used.
- * @param experimentalMappingRuleEnabled     If true the new explode-optimized conformance mapping rule interpreter will be used
- * @param catalystWorkaroundEnabled If true the Catalyst optimizer workaround is enabled
- * @param controlFrameworkEnabled     If true sets the checkpoints on the dataset upon conforming
+ * changed only via the setters. This way enforces setting them by name only instead of by position like it would be in
+ * the case of classical constructor.
+ * @param experimentalMappingRuleEnabled  If true the new explode-optimized conformance mapping rule interpreter will be used
+ * @param catalystWorkaroundEnabled       If true the Catalyst optimizer workaround is enabled
+ * @param controlFrameworkEnabled         If true sets the checkpoints on the dataset upon conforming
  */
 sealed abstract case class FeatureSwitches(
                                             experimentalMappingRuleEnabled: Boolean = false,

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterContext.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterContext.scala
@@ -27,9 +27,7 @@ import za.co.absa.enceladus.model.{Dataset => ConfDataset}
 case class InterpreterContext (
                                 schema: StructType,
                                 conformance: ConfDataset,
-                                experimentalMappingRule: Boolean,
-                                isCatalystWorkaroundEnabled: Boolean,
-                                enableControlFramework: Boolean,
+                                featureSwitches: FeatureSwitches,
                                 jobShortName: String,
                                 spark: SparkSession,
                                 dao: EnceladusDAO,

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/OptimizerTimeTracker.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/OptimizerTimeTracker.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus.conformance.interpreter
 
-import org.apache.log4j.LogManager
+import org.slf4j.LoggerFactory
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions.{col, lit}
 import za.co.absa.enceladus.utils.schema.SchemaUtils
@@ -23,7 +23,7 @@ import za.co.absa.enceladus.utils.schema.SchemaUtils
 class OptimizerTimeTracker(inputDf: DataFrame, isWorkaroundEnabled: Boolean)(implicit spark: SparkSession) {
   import spark.implicits._
 
-  private val log = LogManager.getLogger(this.getClass)
+  private val log = LoggerFactory.getLogger(this.getClass)
 
   private val maxToleratedPlanGenerationPerRuleMs = 100L
   private val initialElapsedTimeBaselineMs = 300L
@@ -33,7 +33,7 @@ class OptimizerTimeTracker(inputDf: DataFrame, isWorkaroundEnabled: Boolean)(imp
   private val idField1 = SchemaUtils.getUniqueName("tmpId", Option(inputDf.schema))
   private val idField2 = s"${idField1}_2"
   private val dfWithId = inputDf.withColumn(idField1, lit(1))
-  private val dfJustId = Seq(1).toDF(idField2)
+  private val dfJustId = Seq(1).toDF(idField2).cache()
 
   /**
     * Returns a dataframe prepared to apply the Catalyst workaround

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/OptimizerTimeTracker.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/OptimizerTimeTracker.scala
@@ -33,7 +33,7 @@ class OptimizerTimeTracker(inputDf: DataFrame, isWorkaroundEnabled: Boolean)(imp
   private val idField1 = SchemaUtils.getUniqueName("tmpId", Option(inputDf.schema))
   private val idField2 = s"${idField1}_2"
   private val dfWithId = inputDf.withColumn(idField1, lit(1))
-  private val dfJustId = Seq(1).toDF(idField2).cache
+  private val dfJustId = Seq(1).toDF(idField2)
 
   /**
     * Returns a dataframe prepared to apply the Catalyst workaround

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleInterpreter.scala
@@ -50,7 +50,7 @@ case class CastingRuleInterpreter(rule: CastingConformanceRule) extends RuleInte
         }, c => {
           when(c.isNotNull.and(c.cast(rule.outputDataType).isNull),
             callUDF("confCastErr", lit(rule.outputColumn), c.cast(StringType)))
-            .otherwise(null)
+            .otherwise(null) // scalastyle:ignore null
         })
     }
   }

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/LiteralRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/LiteralRuleInterpreter.scala
@@ -40,7 +40,7 @@ case class LiteralRuleInterpreter(rule: LiteralConformanceRule) extends RuleInte
 
   /** Handles literal conformance rule for nested fields. */
   private def conformNestedField(df: Dataset[Row])(implicit spark: SparkSession): Dataset[Row] = {
-    DeepArrayTransformations.nestedAddColumn(df, rule.outputColumn, c => inferStrictestType(rule.value))
+    DeepArrayTransformations.nestedAddColumn(df, rule.outputColumn, () => inferStrictestType(rule.value))
   }
 
   /** Handles literal conformance rule for root (non-nested) fields. */

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/LiteralRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/LiteralRuleInterpreter.scala
@@ -40,7 +40,7 @@ case class LiteralRuleInterpreter(rule: LiteralConformanceRule) extends RuleInte
 
   /** Handles literal conformance rule for nested fields. */
   private def conformNestedField(df: Dataset[Row])(implicit spark: SparkSession): Dataset[Row] = {
-    DeepArrayTransformations.nestedAddColumn(df, rule.outputColumn, () => inferStrictestType(rule.value))
+    DeepArrayTransformations.nestedAddColumn(df, rule.outputColumn, c => inferStrictestType(rule.value))
   }
 
   /** Handles literal conformance rule for root (non-nested) fields. */

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleInterpreterGroupExplode.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleInterpreterGroupExplode.scala
@@ -39,7 +39,6 @@ case class MappingRuleInterpreterGroupExplode(rule: MappingConformanceRule,
                                               conformance: ConfDataset,
                                               explodeContext: ExplosionContext)
   extends RuleInterpreter {
-  // scalastyle:off null
 
   private val conf = ConfigFactory.load()
 
@@ -110,7 +109,7 @@ case class MappingRuleInterpreterGroupExplode(rule: MappingConformanceRule,
           case None => c
         }
       }, _ => {
-        when(errorCondition, mappingErrUdfCall).otherwise(null)
+        when(errorCondition, mappingErrUdfCall).otherwise(null) // scalastyle:ignore null
       }
     )
     errorsDf

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
@@ -73,11 +73,13 @@ case class NegationRuleInterpreter(rule: NegationConformanceRule) extends RuleIn
 
   private def getError(inputColumn: Column, errorColumnUDF: Column, fieldType: DataType): Column = {
     fieldType match {
+      // scalastyle:off null
       case _: ByteType => when(inputColumn === Byte.MinValue, errorColumnUDF).otherwise(null)
       case _: ShortType => when(inputColumn === Short.MinValue, errorColumnUDF).otherwise(null)
       case _: IntegerType => when(inputColumn === Int.MinValue, errorColumnUDF).otherwise(null)
       case _: LongType => when(inputColumn === Long.MinValue, errorColumnUDF).otherwise(null)
       case _ => null
+      // scalastyle:on null
     }
   }
 

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/RuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/RuleInterpreter.scala
@@ -15,13 +15,14 @@
 
 package za.co.absa.enceladus.conformance.interpreter.rules
 
-import org.apache.log4j.LogManager
+import org.slf4j.{Logger, LoggerFactory}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.conformance.CmdConfig
 import org.apache.spark.sql.Column
+
 import scala.util.Try
 import org.apache.spark.sql.functions._
 import za.co.absa.enceladus.utils.transformations.ArrayTransformations
@@ -29,7 +30,7 @@ import za.co.absa.enceladus.utils.transformations.ArrayTransformations
 trait RuleInterpreter {
   def conform(df: Dataset[Row])(implicit spark: SparkSession, dao: EnceladusDAO, progArgs: CmdConfig): Dataset[Row]
 
-  val log = LogManager.getLogger(this.getClass)
+  protected val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   /**
    * inferStrictestType Function which takes a string value, tries to infer the strictest applicable SQL type and returns a column literal object
@@ -40,7 +41,7 @@ trait RuleInterpreter {
     // TODO: use commons for determining the types - faster & more efficient than throwing & catching exceptions
     val intTry = Try({
       val parsed = input.toInt
-      assert(parsed.toString() == input)
+      assert(parsed.toString == input)
       lit(parsed)
     })
     val longTry = Try({

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/SparkSessionConfRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/SparkSessionConfRuleInterpreter.scala
@@ -42,7 +42,7 @@ case class SparkSessionConfRuleInterpreter(rule: SparkSessionConfConformanceRule
   /** Handles Spark session config conformance rule for nested fields. */
   private def conformNestedField(df: Dataset[Row])(implicit spark: SparkSession): Dataset[Row] = {
     val configValue = spark.sessionState.conf.getConfString(rule.sparkConfKey)
-    DeepArrayTransformations.nestedAddColumn(df, rule.outputColumn, c => inferStrictestType(configValue))
+    DeepArrayTransformations.nestedAddColumn(df, rule.outputColumn, () => inferStrictestType(configValue))
   }
 
   /** Handles Spark session config conformance rule for root (non-nested) fields. */

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/SparkSessionConfRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/SparkSessionConfRuleInterpreter.scala
@@ -42,7 +42,7 @@ case class SparkSessionConfRuleInterpreter(rule: SparkSessionConfConformanceRule
   /** Handles Spark session config conformance rule for nested fields. */
   private def conformNestedField(df: Dataset[Row])(implicit spark: SparkSession): Dataset[Row] = {
     val configValue = spark.sessionState.conf.getConfString(rule.sparkConfKey)
-    DeepArrayTransformations.nestedAddColumn(df, rule.outputColumn, () => inferStrictestType(configValue))
+    DeepArrayTransformations.nestedAddColumn(df, rule.outputColumn, c => inferStrictestType(configValue))
   }
 
   /** Handles Spark session config conformance rule for root (non-nested) fields. */

--- a/conformance/src/test/resources/log4j.properties
+++ b/conformance/src/test/resources/log4j.properties
@@ -1,0 +1,51 @@
+#
+# Copyright 2018-2019 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory = WARN, general
+
+log4j.appender.general = org.apache.log4j.ConsoleAppender
+log4j.appender.general.target = System.err
+log4j.appender.general.layout = org.apache.log4j.PatternLayout
+log4j.appender.general.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+
+# Suppress warnings logged within the code inside the tests
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.OptimizerTimeTracker = ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreter = ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreterGroupExplode = ERROR
+log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.TypeParser$ = ERROR
+log4j.logger.za.co.absa.enceladus.utils.transformations.ArrayTransformations$ = ERROR
+
+# Suppress a spamming warning from SparkSession$Builder
+log4j.appender.forsparksessionbuilder = org.apache.log4j.ConsoleAppender
+log4j.appender.forsparksessionbuilder.target = System.err
+log4j.appender.forsparksessionbuilder.layout = org.apache.log4j.PatternLayout
+log4j.appender.forsparksessionbuilder.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forsparksessionbuilder.filter.01 = org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forsparksessionbuilder.filter.01.StringToMatch = Using an existing SparkSession; some configuration may not take effect.
+log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch = false
+log4j.logger.org.apache.spark.sql.SparkSession$Builder = WARN, forsparksessionbuilder
+log4j.additivity.org.apache.spark.sql.SparkSession$Builder = false
+
+# Suppress validation error logs from SchemaChecker
+log4j.appender.forschemachecker = org.apache.log4j.ConsoleAppender
+log4j.appender.forschemachecker.target = System.err
+log4j.appender.forschemachecker.layout = org.apache.log4j.PatternLayout
+log4j.appender.forschemachecker.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forschemachecker.filter.01 = org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forschemachecker.filter.01.StringToMatch = Validation error for column
+log4j.appender.forschemachecker.filter.01.AcceptOnMatch = false
+log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$ = WARN, forschemachecker
+log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$ = false

--- a/conformance/src/test/resources/log4j.properties
+++ b/conformance/src/test/resources/log4j.properties
@@ -25,8 +25,6 @@ log4j.appender.general.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}
 log4j.logger.za.co.absa.enceladus.conformance.interpreter.OptimizerTimeTracker=ERROR
 log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreter=ERROR
 log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreterGroupExplode=ERROR
-log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.TypeParser$=ERROR
-log4j.logger.za.co.absa.enceladus.utils.transformations.ArrayTransformations$=ERROR
 
 # Suppress a spamming warning from SparkSession$Builder
 log4j.appender.forsparksessionbuilder=org.apache.log4j.ConsoleAppender
@@ -39,27 +37,3 @@ log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch=false
 log4j.logger.org.apache.spark.sql.SparkSession$Builder=WARN, forsparksessionbuilder
 log4j.additivity.org.apache.spark.sql.SparkSession$Builder=false
 
-# Suppress validation error logs from SchemaChecker
-log4j.appender.forschemachecker=org.apache.log4j.ConsoleAppender
-log4j.appender.forschemachecker.target=System.err
-log4j.appender.forschemachecker.layout=org.apache.log4j.PatternLayout
-log4j.appender.forschemachecker.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
-log4j.appender.forschemachecker.filter.01=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forschemachecker.filter.01.StringToMatch=Validation error for column
-log4j.appender.forschemachecker.filter.01.AcceptOnMatch=false
-log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=WARN, forschemachecker
-log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=false
-
-# Suppress validation error logs from KafkaParametersProcessor
-log4j.appender.forkafkaparametersprocessor=org.apache.log4j.ConsoleAppender
-log4j.appender.forkafkaparametersprocessor.target=System.err
-log4j.appender.forkafkaparametersprocessor.layout=org.apache.log4j.PatternLayout
-log4j.appender.forkafkaparametersprocessor.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
-log4j.appender.forkafkaparametersprocessor.filter.01=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forkafkaparametersprocessor.filter.01.StringToMatch=No Kafka parameter was provided.
-log4j.appender.forkafkaparametersprocessor.filter.01.AcceptOnMatch=false
-log4j.appender.forkafkaparametersprocessor.filter.02=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forkafkaparametersprocessor.filter.02.StringToMatch=Missing mandatory Kafka parameter:
-log4j.appender.forkafkaparametersprocessor.filter.02.AcceptOnMatch=false
-log4j.logger.za.co.absa.enceladus.kafka.parameters.KafkaParametersProcessor$=WARN, forkafkaparametersprocessor
-log4j.additivity.za.co.absa.enceladus.kafka.parameters.KafkaParametersProcessor$=false

--- a/conformance/src/test/resources/log4j.properties
+++ b/conformance/src/test/resources/log4j.properties
@@ -14,38 +14,52 @@
 #
 
 # Set everything to be logged to the console
-log4j.rootCategory = WARN, general
+log4j.rootCategory=WARN, general
 
-log4j.appender.general = org.apache.log4j.ConsoleAppender
-log4j.appender.general.target = System.err
-log4j.appender.general.layout = org.apache.log4j.PatternLayout
-log4j.appender.general.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.general=org.apache.log4j.ConsoleAppender
+log4j.appender.general.target=System.err
+log4j.appender.general.layout=org.apache.log4j.PatternLayout
+log4j.appender.general.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
 
 # Suppress warnings logged within the code inside the tests
-log4j.logger.za.co.absa.enceladus.conformance.interpreter.OptimizerTimeTracker = ERROR
-log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreter = ERROR
-log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreterGroupExplode = ERROR
-log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.TypeParser$ = ERROR
-log4j.logger.za.co.absa.enceladus.utils.transformations.ArrayTransformations$ = ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.OptimizerTimeTracker=ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreter=ERROR
+log4j.logger.za.co.absa.enceladus.conformance.interpreter.rules.MappingRuleInterpreterGroupExplode=ERROR
+log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.TypeParser$=ERROR
+log4j.logger.za.co.absa.enceladus.utils.transformations.ArrayTransformations$=ERROR
 
 # Suppress a spamming warning from SparkSession$Builder
-log4j.appender.forsparksessionbuilder = org.apache.log4j.ConsoleAppender
-log4j.appender.forsparksessionbuilder.target = System.err
-log4j.appender.forsparksessionbuilder.layout = org.apache.log4j.PatternLayout
-log4j.appender.forsparksessionbuilder.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
-log4j.appender.forsparksessionbuilder.filter.01 = org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forsparksessionbuilder.filter.01.StringToMatch = Using an existing SparkSession; some configuration may not take effect.
-log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch = false
-log4j.logger.org.apache.spark.sql.SparkSession$Builder = WARN, forsparksessionbuilder
-log4j.additivity.org.apache.spark.sql.SparkSession$Builder = false
+log4j.appender.forsparksessionbuilder=org.apache.log4j.ConsoleAppender
+log4j.appender.forsparksessionbuilder.target=System.err
+log4j.appender.forsparksessionbuilder.layout=org.apache.log4j.PatternLayout
+log4j.appender.forsparksessionbuilder.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forsparksessionbuilder.filter.01=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forsparksessionbuilder.filter.01.StringToMatch=Using an existing SparkSession; some configuration may not take effect.
+log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch=false
+log4j.logger.org.apache.spark.sql.SparkSession$Builder=WARN, forsparksessionbuilder
+log4j.additivity.org.apache.spark.sql.SparkSession$Builder=false
 
 # Suppress validation error logs from SchemaChecker
-log4j.appender.forschemachecker = org.apache.log4j.ConsoleAppender
-log4j.appender.forschemachecker.target = System.err
-log4j.appender.forschemachecker.layout = org.apache.log4j.PatternLayout
-log4j.appender.forschemachecker.layout.ConversionPattern = [%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
-log4j.appender.forschemachecker.filter.01 = org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forschemachecker.filter.01.StringToMatch = Validation error for column
-log4j.appender.forschemachecker.filter.01.AcceptOnMatch = false
-log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$ = WARN, forschemachecker
-log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$ = false
+log4j.appender.forschemachecker=org.apache.log4j.ConsoleAppender
+log4j.appender.forschemachecker.target=System.err
+log4j.appender.forschemachecker.layout=org.apache.log4j.PatternLayout
+log4j.appender.forschemachecker.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forschemachecker.filter.01=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forschemachecker.filter.01.StringToMatch=Validation error for column
+log4j.appender.forschemachecker.filter.01.AcceptOnMatch=false
+log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=WARN, forschemachecker
+log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=false
+
+# Suppress validation error logs from KafkaParametersProcessor
+log4j.appender.forkafkaparametersprocessor=org.apache.log4j.ConsoleAppender
+log4j.appender.forkafkaparametersprocessor.target=System.err
+log4j.appender.forkafkaparametersprocessor.layout=org.apache.log4j.PatternLayout
+log4j.appender.forkafkaparametersprocessor.layout.ConversionPattern=[%p] %d{yy/MM/dd HH:mm:ss} %c{1}: %m%n
+log4j.appender.forkafkaparametersprocessor.filter.01=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forkafkaparametersprocessor.filter.01.StringToMatch=No Kafka parameter was provided.
+log4j.appender.forkafkaparametersprocessor.filter.01.AcceptOnMatch=false
+log4j.appender.forkafkaparametersprocessor.filter.02=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.forkafkaparametersprocessor.filter.02.StringToMatch=Missing mandatory Kafka parameter:
+log4j.appender.forkafkaparametersprocessor.filter.02.AcceptOnMatch=false
+log4j.logger.za.co.absa.enceladus.kafka.parameters.KafkaParametersProcessor$=WARN, forkafkaparametersprocessor
+log4j.additivity.za.co.absa.enceladus.kafka.parameters.KafkaParametersProcessor$=false

--- a/conformance/src/test/scala/za/co/absa/enceladus/ConfigSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/ConfigSuite.scala
@@ -183,10 +183,10 @@ class ConfigSuite extends FunSuite with SparkTestBase {
     val publishPathFolderPrefix = DynamicConformanceJob.buildPublishPath(infoDateColumn, infoVersionColumn,
         cmdConfigFolderPrefix, conformanceDataset, cmdConfigFolderPrefix.reportVersion.get)
     assert(publishPathFolderPrefix === s"$hdfsPublishPath/$folderPrefix/$infoDateColumn=$reportDate/$infoVersionColumn=$reportVersion")
-    val publishPathPublishPathOverride = DynamicConformanceJob.buildPublishPath(infoDateColumn, infoVersionColumn, 
+    val publishPathPublishPathOverride = DynamicConformanceJob.buildPublishPath(infoDateColumn, infoVersionColumn,
         cmdConfigPublishPathOverride, conformanceDataset, cmdConfigPublishPathOverride.reportVersion.get)
     assert(publishPathPublishPathOverride === hdfsPublishPathOverride)
-    val publishPathPublishPathOverrideAndFolderPrefix = DynamicConformanceJob.buildPublishPath(infoDateColumn, infoVersionColumn, 
+    val publishPathPublishPathOverrideAndFolderPrefix = DynamicConformanceJob.buildPublishPath(infoDateColumn, infoVersionColumn,
         cmdConfigPublishPathOverrideAndFolderPrefix, conformanceDataset, cmdConfigPublishPathOverrideAndFolderPrefix.reportVersion.get)
     assert(publishPathPublishPathOverrideAndFolderPrefix === hdfsPublishPathOverride)
   }

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ArrayConformanceSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ArrayConformanceSuite.scala
@@ -52,13 +52,13 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
   def testArrayTypeConformance(useExperimentalMappingRule: Boolean): Unit = {
     val df = spark.createDataFrame(ArraySamples.testData)
     mockWhen(dao.getSchema("test", 0)) thenReturn df.schema
-
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
     val conformedDf = DynamicInterpreter.interpret(ArraySamples.conformanceDef,
-      df,
-      useExperimentalMappingRule,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      df)
     val expected = ArraySamples.conformedData.toArray.sortBy(_.order).toList
     val conformed = conformedDf.as[ConformedOuter].collect().sortBy(_.order).toList
     assertResult(expected)(conformed)
@@ -76,12 +76,13 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
   def testConformanceMatchingNull(useExperimentalMappingRule: Boolean): Unit = {
     val df = spark.createDataFrame(NullArraySamples.testData)
     mockWhen(dao.getSchema("test", 0)) thenReturn df.schema
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
     val conformedDf = DynamicInterpreter.interpret(NullArraySamples.mappingOnlyConformanceDef,
-      df,
-      useExperimentalMappingRule,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      df)
 
     val expected = NullArraySamples.conformedData.toArray.sortBy(_.order).toList
     val conformed = conformedDf.as[OuterErr].collect().sortBy(_.order).toList
@@ -104,12 +105,13 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
 
     val df = spark.createDataFrame(EmtpyArraySamples.testData)
     mockWhen(dao.getSchema("test", 0)) thenReturn df.schema
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
     val conformedDf = DynamicInterpreter.interpret(EmtpyArraySamples.mappingOnlyConformanceDef,
-      df,
-      useExperimentalMappingRule,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      df)
     val expected = EmtpyArraySamples.conformedData.toArray.sortBy(_.order).toList
     val conformed = conformedDf.as[OuterErr].collect().sortBy(_.order).toList
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ArrayConformanceSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ArrayConformanceSuite.scala
@@ -29,8 +29,8 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
   import spark.implicits._
   // spark.enableControlFrameworkTracking()
 
-  implicit var dao: EnceladusDAO = null
-  implicit var progArgs: CmdConfig = null
+  implicit var dao: EnceladusDAO = _
+  implicit var progArgs: CmdConfig = _
 
   private val enableCF = false
   private val isCatalystWorkaroundEnabled = true
@@ -58,7 +58,7 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
       df,
       useExperimentalMappingRule,
       isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF).cache()
+      enableControlFramework = enableCF)
     val expected = ArraySamples.conformedData.toArray.sortBy(_.order).toList
     val conformed = conformedDf.as[ConformedOuter].collect().sortBy(_.order).toList
     assertResult(expected)(conformed)
@@ -81,7 +81,7 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
       df,
       useExperimentalMappingRule,
       isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF).cache()
+      enableControlFramework = enableCF)
 
     val expected = NullArraySamples.conformedData.toArray.sortBy(_.order).toList
     val conformed = conformedDf.as[OuterErr].collect().sortBy(_.order).toList
@@ -109,7 +109,7 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
       df,
       useExperimentalMappingRule,
       isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF).cache()
+      enableControlFramework = enableCF)
     val expected = EmtpyArraySamples.conformedData.toArray.sortBy(_.order).toList
     val conformed = conformedDf.as[OuterErr].collect().sortBy(_.order).toList
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
@@ -16,11 +16,11 @@
 package za.co.absa.enceladus.conformance.interpreter
 
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.model.{ Dataset => ConfDataset }
-import org.mockito.Mockito.{ mock, when => mockWhen }
+import za.co.absa.enceladus.model.{Dataset => ConfDataset}
+import org.mockito.Mockito.{mock, when => mockWhen}
 import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.model.conformanceRule.MappingConformanceRule
 import za.co.absa.enceladus.model.MappingTable
@@ -30,7 +30,7 @@ case class MyMappingTableInner(description: String, name: String)
 case class MyData(id: Int, toJoin: Int)
 case class MyDataConfd(id: Int, toJoin: Int, confMapping: MyMappingTableInner)
 
-class ChorusMockSuite extends FunSuite with SparkTestBase {
+class ChorusMockSuite extends FunSuite with SparkTestBase with LoggerTestBase{
 
   def testChorusMockData(useExperimentalMappingRule: Boolean): Unit = {
     val d = Seq(
@@ -54,8 +54,8 @@ class ChorusMockSuite extends FunSuite with SparkTestBase {
     DataSource.setData("myMappingTable", mappingDf)
 
     val conformanceDef = ConfDataset(
-      name = "My dummy conformance workflow", // whatev here
-      version = 0, // whatev here
+      name = "My dummy conformance workflow", // whatever here
+      version = 0, // whatever here
       hdfsPath = "/a/b/c",
       hdfsPublishPath = "/publish/a/b/c",
 
@@ -73,14 +73,11 @@ class ChorusMockSuite extends FunSuite with SparkTestBase {
       enableControlFramework = enableCF)
       .repartition(2)
 
-    confd.show(100, false)
-    confd.printSchema()
+    logDataFrameContent(confd)
 
     confd.write.mode("overwrite").parquet("_testOutput")
-    //
     val readAgain = spark.read.parquet("_testOutput")
 
-    assert(readAgain.show.isInstanceOf[Unit])
     assert(readAgain.count === 3)
   }
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
@@ -30,7 +30,7 @@ case class MyMappingTableInner(description: String, name: String)
 case class MyData(id: Int, toJoin: Int)
 case class MyDataConfd(id: Int, toJoin: Int, confMapping: MyMappingTableInner)
 
-class ChorusMockSuite extends FunSuite with SparkTestBase with LoggerTestBase{
+class ChorusMockSuite extends FunSuite with SparkTestBase with LoggerTestBase {
 
   def testChorusMockData(useExperimentalMappingRule: Boolean): Unit = {
     val d = Seq(
@@ -66,11 +66,13 @@ class ChorusMockSuite extends FunSuite with SparkTestBase with LoggerTestBase{
         MappingConformanceRule(order = 1, controlCheckpoint = false, mappingTable = "myMappingTable", mappingTableVersion = 0,
           attributeMappings = Map("id" -> "toJoin"), targetAttribute = "mappedAttr", outputColumn = "confMapping")))
 
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
+
     val confd = DynamicInterpreter.interpret(conformanceDef,
-      inputDf,
-      useExperimentalMappingRule,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      inputDf)
       .repartition(2)
 
     logDataFrameContent(confd)

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
@@ -71,9 +71,7 @@ class ChorusMockSuite extends FunSuite with SparkTestBase with LoggerTestBase {
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val confd = DynamicInterpreter.interpret(conformanceDef,
-      inputDf)
-      .repartition(2)
+    val confd = DynamicInterpreter.interpret(conformanceDef, inputDf).repartition(2)
 
     logDataFrameContent(confd)
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -42,7 +42,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
   }
 
   def testEndToEndDynamicConformance(useExperimentalMappingRule: Boolean): Unit = {
-    // Enable Conformance framework
+    // Enable Conformance Framework
     import za.co.absa.atum.AtumImplicits._
     spark.enableControlMeasuresTracking("src/test/testData/employee/2017/11/01/_INFO", "src/test/testData/_testOutput/_INFO")
 
@@ -64,12 +64,13 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
     mockWhen(dao.getMappingTable("department", 0)) thenReturn EmployeeConformance.departmentMT
     mockWhen(dao.getMappingTable("role", 0)) thenReturn EmployeeConformance.roleMT
     mockWhen(dao.getSchema("Employee", 0)) thenReturn dfs.schema
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
     val conformed = DynamicInterpreter.interpret(EmployeeConformance.employeeDS,
-      dfs,
-      useExperimentalMappingRule,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      dfs)
 
     val data = conformed.as[ConformedEmployee].collect.sortBy(_.employee_id).toList
     val expected = EmployeeConformance.conformedEmployees.sortBy(_.employee_id).toList
@@ -118,12 +119,13 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
     mockWhen(dao.getMappingTable("currency", 0)) thenReturn TradeConformance.currencyMT
     mockWhen(dao.getMappingTable("product", 0)) thenReturn TradeConformance.productMT
     mockWhen(dao.getSchema("Trade", 0)) thenReturn dfs.schema
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
     val conformed = DynamicInterpreter.interpret(TradeConformance.tradeDS,
-      dfs,
-      useExperimentalMappingRule,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF).cache
+      dfs).cache
 
     val data = conformed.repartition(1).orderBy($"id").toJSON.collect.mkString("\n")
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -42,7 +42,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
   }
 
   def testEndToEndDynamicConformance(useExperimentalMappingRule: Boolean): Unit = {
-    // Enable Conformance Framweork
+    // Enable Conformance framework
     import za.co.absa.atum.AtumImplicits._
     spark.enableControlMeasuresTracking("src/test/testData/employee/2017/11/01/_INFO", "src/test/testData/_testOutput/_INFO")
 
@@ -69,7 +69,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
       dfs,
       useExperimentalMappingRule,
       isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF).cache
+      enableControlFramework = enableCF)
 
     val data = conformed.as[ConformedEmployee].collect.sortBy(_.employee_id).toList
     val expected = EmployeeConformance.conformedEmployees.sortBy(_.employee_id).toList
@@ -99,7 +99,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
   }
 
   def testEndToEndArrayConformance(useExperimentalMappingRule: Boolean): Unit = {
-    // Enable Conformance Framweork
+    // Enable Conformance Framework
     import za.co.absa.atum.AtumImplicits._
     spark.enableControlMeasuresTracking("src/test/testData/_tradeData/2017/11/01/_INFO", "src/test/testData/_tradeOutput/_INFO")
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -69,8 +69,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val conformed = DynamicInterpreter.interpret(EmployeeConformance.employeeDS,
-      dfs)
+    val conformed = DynamicInterpreter.interpret(EmployeeConformance.employeeDS, dfs)
 
     val data = conformed.as[ConformedEmployee].collect.sortBy(_.employee_id).toList
     val expected = EmployeeConformance.conformedEmployees.sortBy(_.employee_id).toList
@@ -124,8 +123,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val conformed = DynamicInterpreter.interpret(TradeConformance.tradeDS,
-      dfs).cache
+    val conformed = DynamicInterpreter.interpret(TradeConformance.tradeDS, dfs).cache
 
     val data = conformed.repartition(1).orderBy($"id").toJSON.collect.mkString("\n")
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/NestedStructSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/NestedStructSuite.scala
@@ -27,48 +27,56 @@ import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 class NestedStructSuite extends FunSuite with SparkTestBase with NestedStructsFixture {
 
   test("Test Dynamic Conformance does not hang on many mixed conformance rules") {
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(false)
+      .setCatalystWorkaroundEnabled(true)
+      .setControlFrameworkEnabled(false)
+
     val conformed = DynamicInterpreter.interpret(
       nestedStructsDS,
-      standardizedDf,
-      experimentalMappingRule = false,
-      isCatalystWorkaroundEnabled = true,
-      enableControlFramework = false
+      standardizedDf
     )
 
     assert(conformed.count() == 20)
   }
 
   test("Test Dynamic Conformance does not hang on many uppercase conformance rules") {
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(false)
+      .setCatalystWorkaroundEnabled(true)
+      .setControlFrameworkEnabled(false)
+
     val conformed = DynamicInterpreter.interpret(
       nestedStructsUpperDS,
-      standardizedDf,
-      experimentalMappingRule = false,
-      isCatalystWorkaroundEnabled = true,
-      enableControlFramework = false
+      standardizedDf
     )
 
     assert(conformed.count() == 20)
   }
 
   test("Test Dynamic Conformance does not hang on many negation conformance rules") {
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(false)
+      .setCatalystWorkaroundEnabled(true)
+      .setControlFrameworkEnabled(false)
+
     val conformed = DynamicInterpreter.interpret(
       nestedStructsNegationDS,
-      standardizedDf,
-      experimentalMappingRule = false,
-      isCatalystWorkaroundEnabled = true,
-      enableControlFramework = false
+      standardizedDf
     )
 
     assert(conformed.count() == 20)
   }
 
   test("Test Dynamic Conformance does not hang on many casting conformance rules") {
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(false)
+      .setCatalystWorkaroundEnabled(true)
+      .setControlFrameworkEnabled(false)
+
     val conformed = DynamicInterpreter.interpret(
       nestedStructsCastingDS,
-      standardizedDf,
-      experimentalMappingRule = false,
-      isCatalystWorkaroundEnabled = true,
-      enableControlFramework = false
+      standardizedDf
     )
 
     assert(conformed.count() == 20)

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/NestedStructSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/NestedStructSuite.scala
@@ -32,10 +32,7 @@ class NestedStructSuite extends FunSuite with SparkTestBase with NestedStructsFi
       .setCatalystWorkaroundEnabled(true)
       .setControlFrameworkEnabled(false)
 
-    val conformed = DynamicInterpreter.interpret(
-      nestedStructsDS,
-      standardizedDf
-    )
+    val conformed = DynamicInterpreter.interpret(nestedStructsDS, standardizedDf)
 
     assert(conformed.count() == 20)
   }
@@ -46,10 +43,7 @@ class NestedStructSuite extends FunSuite with SparkTestBase with NestedStructsFi
       .setCatalystWorkaroundEnabled(true)
       .setControlFrameworkEnabled(false)
 
-    val conformed = DynamicInterpreter.interpret(
-      nestedStructsUpperDS,
-      standardizedDf
-    )
+    val conformed = DynamicInterpreter.interpret(nestedStructsUpperDS, standardizedDf)
 
     assert(conformed.count() == 20)
   }
@@ -60,10 +54,7 @@ class NestedStructSuite extends FunSuite with SparkTestBase with NestedStructsFi
       .setCatalystWorkaroundEnabled(true)
       .setControlFrameworkEnabled(false)
 
-    val conformed = DynamicInterpreter.interpret(
-      nestedStructsNegationDS,
-      standardizedDf
-    )
+    val conformed = DynamicInterpreter.interpret( nestedStructsNegationDS, standardizedDf)
 
     assert(conformed.count() == 20)
   }
@@ -74,10 +65,7 @@ class NestedStructSuite extends FunSuite with SparkTestBase with NestedStructsFi
       .setCatalystWorkaroundEnabled(true)
       .setControlFrameworkEnabled(false)
 
-    val conformed = DynamicInterpreter.interpret(
-      nestedStructsCastingDS,
-      standardizedDf
-    )
+    val conformed = DynamicInterpreter.interpret(nestedStructsCastingDS, standardizedDf)
 
     assert(conformed.count() == 20)
   }

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/NestedStructsFixture.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/NestedStructsFixture.scala
@@ -18,7 +18,7 @@ package za.co.absa.enceladus.conformance.interpreter.fixtures
 import java.io.File
 
 import org.apache.commons.io.{FileUtils, IOUtils}
-import org.apache.log4j.{LogManager, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import za.co.absa.enceladus.conformance.CmdConfig
@@ -149,7 +149,7 @@ trait NestedStructsFixture extends BeforeAndAfterAll with SparkTestBase {
       castingRule7)
   )
 
-  private val log: Logger = LogManager.getLogger(this.getClass)
+  private val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   private val infoFileContents: String = IOUtils.toString(this.getClass
     .getResourceAsStream("/interpreter/nestedStructs/info.json"), "UTF-8")

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
@@ -22,9 +22,9 @@ import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, RuleVal
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.samples.CastingRuleSamples
 import za.co.absa.enceladus.utils.general.JsonUtils
-import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 
-class CastingRuleSuite extends FunSuite with SparkTestBase {
+class CastingRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
 
   test("Casting conformance rule test") {
 
@@ -51,16 +51,14 @@ class CastingRuleSuite extends FunSuite with SparkTestBase {
     val conformedJSON = JsonUtils.prettySparkJSON(conformed.orderBy($"id").toJSON.collect)
 
     if (conformedJSON != CastingRuleSamples.conformedOrdersJSON) {
-      println("EXPECTED:")
-      println(CastingRuleSamples.conformedOrdersJSON)
-      println("ACTUAL:")
-      println(conformedJSON)
-      println("DETAILS (Input):")
-      inputDf.printSchema()
-      inputDf.show
-      println("DETAILS (Conformed):")
-      conformed.printSchema()
-      conformed.show
+      logger.debug("EXPECTED:")
+      logger.debug(CastingRuleSamples.conformedOrdersJSON)
+      logger.debug("ACTUAL:")
+      logger.debug(conformedJSON)
+      logger.debug("DETAILS (Input):")
+      logDataFrameContent(inputDf)
+      logger.debug("DETAILS (Conformed):")
+      logDataFrameContent(conformed)
       fail("Actual conformed dataset JSON does not match the expected JSON (see above).")
     }
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
@@ -48,8 +48,7 @@ class CastingRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val conformed = DynamicInterpreter.interpret(CastingRuleSamples.ordersDS,
-      inputDf).cache
+    val conformed = DynamicInterpreter.interpret(CastingRuleSamples.ordersDS, inputDf).cache
 
     val conformedJSON = JsonUtils.prettySparkJSON(conformed.orderBy($"id").toJSON.collect)
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
@@ -18,11 +18,12 @@ package za.co.absa.enceladus.conformance.interpreter.rules
 import org.mockito.Mockito.{mock, when => mockWhen}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, RuleValidators}
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches, RuleValidators}
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.samples.CastingRuleSamples
 import za.co.absa.enceladus.utils.general.JsonUtils
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import org.slf4j.event.Level.ERROR
 
 class CastingRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
 
@@ -42,23 +43,25 @@ class CastingRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
     val mappingTablePattern = "{0}/{1}/{2}"
 
     import spark.implicits._
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
+
     val conformed = DynamicInterpreter.interpret(CastingRuleSamples.ordersDS,
-      inputDf,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF).cache
+      inputDf).cache
 
     val conformedJSON = JsonUtils.prettySparkJSON(conformed.orderBy($"id").toJSON.collect)
 
     if (conformedJSON != CastingRuleSamples.conformedOrdersJSON) {
-      logger.debug("EXPECTED:")
-      logger.debug(CastingRuleSamples.conformedOrdersJSON)
-      logger.debug("ACTUAL:")
-      logger.debug(conformedJSON)
-      logger.debug("DETAILS (Input):")
-      logDataFrameContent(inputDf)
-      logger.debug("DETAILS (Conformed):")
-      logDataFrameContent(conformed)
+      logger.error("EXPECTED:")
+      logger.error(CastingRuleSamples.conformedOrdersJSON)
+      logger.error("ACTUAL:")
+      logger.error(conformedJSON)
+      logger.error("DETAILS (Input):")
+      logDataFrameContent(inputDf, ERROR)
+      logger.error("DETAILS (Conformed):")
+      logDataFrameContent(conformed, ERROR)
       fail("Actual conformed dataset JSON does not match the expected JSON (see above).")
     }
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/LiteralRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/LiteralRuleSuite.scala
@@ -87,4 +87,5 @@ class LiteralRuleSuite extends FunSuite with SparkTestBase with TestRuleBehavior
     conformanceRuleShouldMatchExpected(inputDf, literalOrdersDS3, conformedLiteralOrdersJSON3)
   }
 
+  // scalastyle:on line.size.limit
 }

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
@@ -23,9 +23,9 @@ import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.model.{Dataset => ConfDataset}
 import za.co.absa.enceladus.samples.NegationRuleSamples
-import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 
-class NegationRuleSuite extends FunSuite with SparkTestBase {
+class NegationRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
 
   import spark.implicits._
 
@@ -110,16 +110,14 @@ class NegationRuleSuite extends FunSuite with SparkTestBase {
     val conformedJSON = conformed.toJSON.collect().mkString("\n")
 
     if (conformedJSON != expectedJSON) {
-      println("EXPECTED:")
-      println(expectedJSON)
-      println("ACTUAL:")
-      println(conformedJSON)
-      println("DETAILS (Input):")
-      inputDf.printSchema()
-      inputDf.show
-      println("DETAILS (Conformed):")
-      conformed.printSchema()
-      conformed.show
+      logger.debug("EXPECTED:")
+      logger.debug(expectedJSON)
+      logger.debug("ACTUAL:")
+      logger.debug(conformedJSON)
+      logger.debug("DETAILS (Input):")
+      logDataFrameContent(inputDf)
+      logger.debug("DETAILS (Conformed):")
+      logDataFrameContent(conformed)
 
       fail("Actual conformed dataset JSON does not match the expected JSON (see above).")
     }

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
@@ -106,8 +106,7 @@ class NegationRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val conformed = DynamicInterpreter.interpret(enceladusDataset,
-      inputDf).cache
+    val conformed = DynamicInterpreter.interpret(enceladusDataset, inputDf).cache
 
     val conformedJSON = conformed.toJSON.collect().mkString("\n")
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/RulesSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/RulesSuite.scala
@@ -35,7 +35,7 @@ class RulesSuite extends FunSuite with SparkTestBase {
     val countryRule = EmployeeConformance.countryRule
     val countryCondGen = MappingRuleInterpreterGroupExplode.getJoinCondition(countryRule).expr
     val countryCond = (lit(true)
-      && (col(s"${MappingRuleInterpreterGroupExplode.inputDfAlias}.country") === col(s"${MappingRuleInterpreterGroupExplode.mappingTableAlias}.country_code"))) expr
+      && (col(s"${MappingRuleInterpreterGroupExplode.inputDfAlias}.country") === col(s"${MappingRuleInterpreterGroupExplode.mappingTableAlias}.country_code"))).expr
 
     assert(countryCondGen.semanticEquals(countryCond))
   }
@@ -44,7 +44,7 @@ class RulesSuite extends FunSuite with SparkTestBase {
     val deptRule = EmployeeConformance.departmentRule
     val deptCondGen = MappingRuleInterpreterGroupExplode.getJoinCondition(deptRule).expr
     val deptCond = (lit(true) &&
-      (col(s"${MappingRuleInterpreterGroupExplode.inputDfAlias}.dept") === col(s"${MappingRuleInterpreterGroupExplode.mappingTableAlias}.dept_id"))) expr
+      (col(s"${MappingRuleInterpreterGroupExplode.inputDfAlias}.dept") === col(s"${MappingRuleInterpreterGroupExplode.mappingTableAlias}.dept_id"))).expr
 
     assert(deptCondGen.semanticEquals(deptCond))
   }
@@ -54,7 +54,7 @@ class RulesSuite extends FunSuite with SparkTestBase {
     val roleCondGen = MappingRuleInterpreterGroupExplode.getJoinCondition(roleRule).expr
     val roleCond = (lit(true) &&
       (col(s"${MappingRuleInterpreterGroupExplode.inputDfAlias}.role") <=> col(s"${MappingRuleInterpreterGroupExplode.mappingTableAlias}.role_id")) &&
-      (col(s"${MappingRuleInterpreterGroupExplode.inputDfAlias}.conformed_country") <=> col(s"${MappingRuleInterpreterGroupExplode.mappingTableAlias}.country"))) expr
+      (col(s"${MappingRuleInterpreterGroupExplode.inputDfAlias}.conformed_country") <=> col(s"${MappingRuleInterpreterGroupExplode.mappingTableAlias}.country"))).expr
 
     assert(roleCondGen.semanticEquals(roleCond))
   }
@@ -67,7 +67,7 @@ class RulesSuite extends FunSuite with SparkTestBase {
   }
 
   test("Infest strictest type long") {
-    val colGen = dummyInterpreter.inferStrictestType((Long.MaxValue - 1) toString).expr
+    val colGen = dummyInterpreter.inferStrictestType((Long.MaxValue - 1).toString).expr
     val colMan = lit(Long.MaxValue - 1).expr
 
     assert(colGen.semanticEquals(colMan))
@@ -128,9 +128,9 @@ class RulesSuite extends FunSuite with SparkTestBase {
       MappingRuleInterpreterGroupExplode.ensureDefaultValueMatchSchema("not_string", schema, "name", "struct('Unknown' as name)")
     }.getMessage contains "A string expected")
 
-    println(intercept[ValidationException] {
+    intercept[ValidationException] {
       MappingRuleInterpreterGroupExplode.ensureDefaultValueMatchSchema("id_null", schema, "id", "null")
-    }.getMessage)
+    }
 
     intercept[ValidationException] {
       MappingRuleInterpreterGroupExplode.ensureDefaultValueMatchSchema("id_test", schema, "id", "wrong")

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
@@ -46,8 +46,7 @@ trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase
       .setControlFrameworkEnabled(enableCF)
 
 
-    val conformed = DynamicInterpreter.interpret(inputDataset,
-      inputDf)
+    val conformed = DynamicInterpreter.interpret(inputDataset, inputDf)
 
     val conformedJSON = conformed.orderBy($"id").toJSON.collect().mkString("\n")
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
@@ -44,7 +44,7 @@ trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase
       inputDf,
       experimentalMR,
       isCatalystWorkaroundEnabled,
-      enableCF).cache
+      enableCF)
 
     val conformedJSON = conformed.orderBy($"id").toJSON.collect().mkString("\n")
 
@@ -55,7 +55,7 @@ trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase
       logger.error(conformedJSON)
       logger.error("DETAILS (Input):")
       logDataFrameContent(inputDf, ERROR)
-      println("DETAILS (Conformed):")
+      logger.error("DETAILS (Conformed):")
       logDataFrameContent(conformed, ERROR)
       fail("Actual conformed dataset JSON does not match the expected JSON (see log).")
     }

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
@@ -19,7 +19,7 @@ import org.apache.spark.sql.DataFrame
 import org.mockito.Mockito.{mock, when => mockWhen}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
@@ -40,11 +40,14 @@ trait TestRuleBehaviors  extends FunSuite with SparkTestBase with LoggerTestBase
     mockWhen(dao.getDataset("Library Conformance", 1)) thenReturn inputDataset
 
     import spark.implicits._
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
+
+
     val conformed = DynamicInterpreter.interpret(inputDataset,
-      inputDf,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+      inputDf)
 
     val conformedJSON = conformed.orderBy($"id").toJSON.collect().mkString("\n")
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/custom/CustomRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/custom/CustomRuleSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.functions._
 import org.mockito.Mockito.mock
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.conformance.interpreter.rules.RuleInterpreter
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.model.{conformanceRule, Dataset => ConfDataset}
@@ -79,13 +79,14 @@ class CustomRuleSuite extends FunSuite with SparkTestBase {
     )
   )
 
-  val expected = Seq(MineConfd(1, 1d, Seq()), MineConfd(4, 2d, Seq()), MineConfd(9, 3d, Seq()), MineConfd(16, 4d, Seq()))
+  private val expected = Seq(MineConfd(1, 1d, Seq()), MineConfd(4, 2d, Seq()), MineConfd(9, 3d, Seq()), MineConfd(16, 4d, Seq()))
+  implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+    .setExperimentalMappingRuleEnabled(experimentalMR)
+    .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+    .setControlFrameworkEnabled(enableCF)
 
   val actualDf: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-    inputData,
-    experimentalMR,
-    isCatalystWorkaroundEnabled,
-    enableCF)
+    inputData)
 
   val actual: Seq[MineConfd] = actualDf.as[MineConfd].collect().toSeq
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/custom/CustomRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/custom/CustomRuleSuite.scala
@@ -85,8 +85,7 @@ class CustomRuleSuite extends FunSuite with SparkTestBase {
     .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
     .setControlFrameworkEnabled(enableCF)
 
-  val actualDf: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-    inputData)
+  val actualDf: DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
   val actual: Seq[MineConfd] = actualDf.as[MineConfd].collect().toSeq
 

--- a/conformance/src/test/scala/za/co/absa/enceladus/samples/EmployeeConformance.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/samples/EmployeeConformance.scala
@@ -21,9 +21,9 @@ import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.error.Mapping
 
 object EmployeeConformance {
-  val countryMT = new MappingTable(name = "country", version = 0, hdfsPath = "src/test/testData/country", schemaName = "country", schemaVersion = 0)
-  val departmentMT = new MappingTable(name = "department", version = 0, hdfsPath = "src/test/testData/department", schemaName = "dept", schemaVersion = 0, defaultMappingValue = List(DefaultValue("department_name","'Unknown dept'")))
-  val roleMT = new MappingTable(name = "role", version = 0, hdfsPath = "src/test/testData/role", schemaName = "role", schemaVersion = 0, defaultMappingValue = List())
+  val countryMT = MappingTable(name = "country", version = 0, hdfsPath = "src/test/testData/country", schemaName = "country", schemaVersion = 0)
+  val departmentMT = MappingTable(name = "department", version = 0, hdfsPath = "src/test/testData/department", schemaName = "dept", schemaVersion = 0, defaultMappingValue = List(DefaultValue("department_name","'Unknown dept'")))
+  val roleMT = MappingTable(name = "role", version = 0, hdfsPath = "src/test/testData/role", schemaName = "role", schemaVersion = 0, defaultMappingValue = List())
 
   val countryRule = new MappingConformanceRule(order = 0, mappingTable = "country", controlCheckpoint = false,
     mappingTableVersion = 0, attributeMappings = Map("country_code" -> "country" ), targetAttribute = "country_name", outputColumn = "conformed_country")
@@ -54,7 +54,7 @@ object EmployeeConformance {
       schemaName = "Employee", schemaVersion = 0,
       conformance = List(countryRule, departmentRule, roleRule, litRule, upperRule, lit2Rule, dropRule, concatRule, sparkConfRule, singleColRule, castingColRules) )
 
-  val conformedEmployees = Seq(
+  val conformedEmployees: Seq[ConformedEmployee] = Seq(
     ConformedEmployee(employee_id = 0, name = "John", surname = "Doe0", dept= 0, role = 1, country = "CZE", conformed_country = "Czech Republic", conformed_department = "Tooling Squad",
       conformed_role = "Big Data Engineer", errCol= List(), MyLiteral = "abcdef", MyUpperLiteral = "ABCDEF", Concatenated = "abcdefABCDEF", SparkConfAttr = "hello :)",
       ConformedRole(1), ConformedEmployeeId = "0"),
@@ -67,7 +67,7 @@ object EmployeeConformance {
     ConformedEmployee(employee_id = 3, name = "John", surname = "Doe3", dept= 3, role = 2, country = "SWE", conformed_country = null, conformed_department = "Unknown dept",
       conformed_role = "External dev", errCol= List(
           ErrorMessage.confMappingErr("conformed_country", Seq("SWE"), Seq(Mapping("country_code", "country"))),
-          ErrorMessage.confMappingErr("conformed_department", Seq("3"), Seq(Mapping("dept_id", "dept"))) 
+          ErrorMessage.confMappingErr("conformed_department", Seq("3"), Seq(Mapping("dept_id", "dept")))
       ), MyLiteral = "abcdef", MyUpperLiteral = "ABCDEF", Concatenated = "abcdefABCDEF", SparkConfAttr = "hello :)", ConformedRole(2), ConformedEmployeeId = "3"),
     ConformedEmployee(employee_id = 4, name = "John", surname = "Doe4", dept= 1, role = 2, country = "IN", conformed_country = "India", conformed_department = "Ingestion Squad",
       conformed_role = "Ingestion Developer", errCol= List(), MyLiteral = "abcdef", MyUpperLiteral = "ABCDEF", Concatenated = "abcdefABCDEF", SparkConfAttr = "hello :)",
@@ -81,5 +81,5 @@ object EmployeeConformance {
 case class ConformedEmployee(employee_id: Int, name: String, surname: String, dept: Int, role: Int, country: String, conformed_country: String, conformed_department: String,
     conformed_role: String, errCol: List[ErrorMessage], MyLiteral: String, MyUpperLiteral: String, Concatenated: String, SparkConfAttr: String, ConformedRoleId: ConformedRole,
     ConformedEmployeeId: String)
-    
+
 case class ConformedRole(roleId: Int)

--- a/conformance/src/test/scala/za/co/absa/enceladus/samples/TradeConformance.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/samples/TradeConformance.scala
@@ -18,7 +18,7 @@ package za.co.absa.enceladus.samples
 import java.io.File
 
 import org.apache.commons.io.{FileUtils, IOUtils}
-import org.apache.log4j.{LogManager, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import za.co.absa.enceladus.model.conformanceRule._
 import za.co.absa.enceladus.model.{Dataset, DefaultValue, MappingTable}
@@ -26,7 +26,7 @@ import za.co.absa.enceladus.model.{Dataset, DefaultValue, MappingTable}
 import scala.util.control.NonFatal
 
 object TradeConformance {
-  private val log: Logger = LogManager.getLogger(this.getClass)
+  private val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   val countryMT = MappingTable(name = "country", version = 0, hdfsPath = "src/test/testData/_countryMT",
     schemaName = "country", schemaVersion = 0)

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
@@ -73,8 +73,7 @@ object CustomRuleSample1 {
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData)
+    val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     outputData.show(false)
     //scalastyleon: magicnumber

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
@@ -17,7 +17,7 @@ package za.co.absa.enceladus.examples
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.{EnceladusDAO, EnceladusRestDAO}
 import za.co.absa.enceladus.examples.interpreter.rules.custom.UppercaseCustomConformanceRule
 import za.co.absa.enceladus.model.Dataset
@@ -68,11 +68,13 @@ object CustomRuleSample1 {
       )
     )
 
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
+
     val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      inputData)
 
     outputData.show(false)
     //scalastyleon: magicnumber

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
@@ -74,8 +74,7 @@ object CustomRuleSample2 {
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData)
+    val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     outputData.show(false)
     // scalastyle:on magic.number

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
@@ -17,7 +17,7 @@ package za.co.absa.enceladus.examples
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.{EnceladusDAO, EnceladusRestDAO}
 import za.co.absa.enceladus.examples.interpreter.rules.custom.LPadCustomConformanceRule
 import za.co.absa.enceladus.model.Dataset
@@ -69,11 +69,13 @@ object CustomRuleSample2 {
       )
     )
 
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
+
     val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      inputData)
 
     outputData.show(false)
     // scalastyle:on magic.number

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
@@ -17,7 +17,7 @@ package za.co.absa.enceladus.examples
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.{EnceladusDAO, EnceladusRestDAO}
 import za.co.absa.enceladus.examples.interpreter.rules.custom.{LPadCustomConformanceRule, UppercaseCustomConformanceRule}
 import za.co.absa.enceladus.model.Dataset
@@ -66,11 +66,14 @@ object CustomRuleSample3 {
       )
     )
     // scalastyle:on magic.number
+
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
+
     val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      inputData)
 
     outputData.show()
   }

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
@@ -72,8 +72,7 @@ object CustomRuleSample3 {
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData)
+    val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     outputData.show()
   }

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
@@ -131,14 +131,10 @@ object CustomRuleSample4 {
 
   def main(args: Array[String]): Unit = {
     val cmd: CmdConfigLocal = getCmdLineArguments(args)
-
     implicit val spark: SparkSession = buildSparkSession()
 
     implicit val progArgs: CmdConfig = CmdConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: EnceladusDAO = EnceladusRestDAO // you may have to hard-code your own implementation here (if not working with Menas)
-    val experimentalMR= true
-    val isCatalystWorkaroundEnabled = true
-    val enableCF: Boolean = false
 
     val dfReader: DataFrameReader = {
       val dfReader0 = spark.read
@@ -177,13 +173,11 @@ object CustomRuleSample4 {
     )
     // scalastyle:on magic.number
     implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
-      .setExperimentalMappingRuleEnabled(experimentalMR)
-      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
-      .setControlFrameworkEnabled(enableCF)
+      .setExperimentalMappingRuleEnabled(true)
+      .setCatalystWorkaroundEnabled(true)
+      .setControlFrameworkEnabled(false)
 
-    val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData)
-
+    val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
     outputData.show()
     saveToCsv(outputData, cmd.outPath)
   }

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
@@ -19,7 +19,7 @@ import org.apache.spark.sql.functions.{col, concat, concat_ws, lit}
 import org.apache.spark.sql.{DataFrame, DataFrameReader, SparkSession}
 import scopt.OptionParser
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.{EnceladusDAO, EnceladusRestDAO}
 import za.co.absa.enceladus.examples.interpreter.rules.custom.{LPadCustomConformanceRule, UppercaseCustomConformanceRule}
 import za.co.absa.enceladus.model.Dataset
@@ -176,11 +176,13 @@ object CustomRuleSample4 {
       )
     )
     // scalastyle:on magic.number
+    implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
+
     val outputData: DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+      inputData)
 
     outputData.show()
     saveToCsv(outputData, cmd.outPath)

--- a/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/UppercaseCustomConformanceRuleSuite.scala
+++ b/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/UppercaseCustomConformanceRuleSuite.scala
@@ -19,7 +19,7 @@ import org.apache.spark.sql
 import org.apache.spark.sql.DataFrame
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.{EnceladusDAO, EnceladusRestDAO}
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
@@ -62,12 +62,12 @@ class UppercaseCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         UppercaseCustomConformanceRule(order = 0, outputColumn = "doneUpper", controlCheckpoint = false, inputColumn = "mandatoryString")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableControlFramework = enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: Seq[TestOutputRow] = outputData.as[TestOutputRow].collect().toSeq
     val expected: Seq[TestOutputRow] = (input zip Seq("HELLO WORLD", "ONE RING TO RULE THEM ALL", "ALREADY CAPS")).map(x => TestOutputRow(x._1, x._2))
@@ -96,11 +96,12 @@ class UppercaseCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
       )
     )
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
+
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: Seq[TestOutputRow] = outputData.as[TestOutputRow].collect().toSeq
     val expected: Seq[TestOutputRow] = (input zip Seq("1", "4", "9")).map(x => TestOutputRow(x._1, x._2))
@@ -128,12 +129,12 @@ class UppercaseCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         UppercaseCustomConformanceRule(order = 0, outputColumn = "doneUpper", controlCheckpoint = false, inputColumn = "nullableString")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: List[TestOutputRow] = outputData.as[TestOutputRow].collect().toList
     val expected: List[TestOutputRow] = (input zip Seq("WHAT A BEAUTIFUL PLACE", "ONE RING TO FIND THEM", null)).map(x => TestOutputRow(x._1, x._2)).toList

--- a/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/XPadCustomConformanceRuleSuite.scala
+++ b/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/XPadCustomConformanceRuleSuite.scala
@@ -19,7 +19,7 @@ import org.apache.spark.sql
 import org.apache.spark.sql.DataFrame
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.conformance.CmdConfig
-import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.{EnceladusDAO, EnceladusRestDAO}
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
@@ -59,12 +59,12 @@ class LpadCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         LPadCustomConformanceRule(order = 0, outputColumn = "targetField", controlCheckpoint = false, inputColumn = "stringField", len = 8, pad = "~")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: List[XPadTestOutputRow] = outputData.as[XPadTestOutputRow].collect().toList
     val expected: List[XPadTestOutputRow] = (input zip List("~~~Short", "This is long", "~~~~~~~~")).map(x => XPadTestOutputRow(x._1, x._2))
@@ -92,12 +92,12 @@ class LpadCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         LPadCustomConformanceRule(order = 0, outputColumn = "targetField", controlCheckpoint = false, inputColumn = "intField", len = 3, pad = "0")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: Seq[XPadTestOutputRow] = outputData.as[XPadTestOutputRow].collect().toSeq
     val expected: Seq[XPadTestOutputRow] = (input zip Seq("007", "042", "100000")).map(x => XPadTestOutputRow(x._1, x._2))
@@ -125,12 +125,12 @@ class LpadCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         LPadCustomConformanceRule(order = 0, outputColumn = "targetField", controlCheckpoint = false, inputColumn = "stringField", len = 10, pad = "123")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: List[XPadTestOutputRow] = outputData.as[XPadTestOutputRow].collect().toList
     val expected: List[XPadTestOutputRow] = (input zip List("12abcdefgh", "1231231$$$", "1231231231")).map(x => XPadTestOutputRow(x._1, x._2))
@@ -158,12 +158,12 @@ class LpadCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         LPadCustomConformanceRule(order = 0, outputColumn = "targetField", controlCheckpoint = false, inputColumn = "stringField", len = -5, pad = ".")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: List[XPadTestOutputRow] = outputData.as[XPadTestOutputRow].collect().toList
     val expected: List[XPadTestOutputRow] = (input zip List("A", "AAAAAAAAAAAAAAAAAAAA", "")).map(x => XPadTestOutputRow(x._1, x._2))
@@ -204,12 +204,12 @@ class RpadCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         RPadCustomConformanceRule(order = 0, outputColumn = "targetField", controlCheckpoint = false, inputColumn = "stringField", len = 8, ".")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: List[XPadTestOutputRow] = outputData.as[XPadTestOutputRow].collect().toList
     val expected: List[XPadTestOutputRow] = (input zip List("Short...", "This is long", "........")).map(x => XPadTestOutputRow(x._1, x._2))
@@ -237,12 +237,12 @@ class RpadCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         RPadCustomConformanceRule(order = 0, outputColumn = "targetField", controlCheckpoint = false, inputColumn = "intField", len = 3, pad = "0")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: Seq[XPadTestOutputRow] = outputData.as[XPadTestOutputRow].collect().toSeq
     val expected: Seq[XPadTestOutputRow] = (input zip Seq("100", "420", "100000")).map(x => XPadTestOutputRow(x._1, x._2))
@@ -270,12 +270,12 @@ class RpadCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         RPadCustomConformanceRule(order = 0, outputColumn = "targetField", controlCheckpoint = false, inputColumn = "stringField", len = 10, pad = "123")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: List[XPadTestOutputRow] = outputData.as[XPadTestOutputRow].collect().toList
     val expected: List[XPadTestOutputRow] = (input zip List("abcdefgh12", "$$$1231231", "1231231231")).map(x => XPadTestOutputRow(x._1, x._2))
@@ -303,12 +303,12 @@ class RpadCustomConformanceRuleSuite extends FunSuite with SparkTestBase {
         RPadCustomConformanceRule(order = 0, outputColumn = "targetField", controlCheckpoint = false, inputColumn = "stringField", len = -5, pad = "#")
       )
     )
+    implicit val featureSwitches:FeatureSwitches = FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(experimentalMR)
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
+      .setControlFrameworkEnabled(enableCF)
 
-    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef,
-      inputData,
-      experimentalMR,
-      isCatalystWorkaroundEnabled,
-      enableCF)
+    val outputData: sql.DataFrame = DynamicInterpreter.interpret(conformanceDef, inputData)
 
     val output: List[XPadTestOutputRow] = outputData.as[XPadTestOutputRow].collect().toList
     val expected: List[XPadTestOutputRow] = (input zip List("A", "AAAAAAAAAAAAAAAAAAAA", "")).map(x => XPadTestOutputRow(x._1, x._2))

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkTestBase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkTestBase.scala
@@ -36,6 +36,7 @@ trait SparkTestBase { self =>
     .master(sparkMaster)
     .appName(s"Enceladus test - ${self.getClass.getName}")
     .config("spark.ui.enabled", "false")
+    .config("spark.debug.maxToStringFields", 100)
 
   implicit val spark: SparkSession = if (sparkMaster == "yarn") {
     val confDir = config.getString("enceladus.utils.testUtils.hadoop.conf.dir")


### PR DESCRIPTION
* Adhere to Scalastyle
* Follow some best-practices:
** typed implicits
** types declared for public members
* Parameterless function as type
* setup logging for tests - style, filtering
* remove direct output to console (println, Dataframe.show, etc)
* replaced deprecated class
* no call of Spark cache method in tests to decrease warnings of already cached data