### PR TITLE
Feature/165 enable standardization of csv with more than 20480 columns

### DIFF
--- a/menas/ui/service/RestDAO.js
+++ b/menas/ui/service/RestDAO.js
@@ -15,16 +15,23 @@
 
 class RestClient {
 
-  static get(url) {
-    const jqXHR = $.get(url);
+  static cache = _.memoize($.ajax, ({url}) => url);
+
+  static get(url, shouldUseCache = false) {
+    let request = {
+      url: url,
+      async: true
+    };
+    const jqXHR = shouldUseCache ? RestClient.cache(request) : $.ajax(request);
     return jqXHR.then(this.identity(jqXHR), this.handleExpiredSession)
   }
 
-  static getSync(url) {
-    const jqXHR = $.get({
+  static getSync(url, shouldUseCache = false) {
+    let request = {
       url: url,
       async: false
-    });
+    };
+    const jqXHR = shouldUseCache ? RestClient.cache(request) : $.ajax(request);
     return jqXHR.then(this.identity(jqXHR), this.handleExpiredSession)
 
   }
@@ -35,7 +42,7 @@ class RestClient {
       data: JSON.stringify(data),
       contentType: "application/json",
       headers: {
-        "X-CSRF-TOKEN" : localStorage.getItem("csrfToken")
+        "X-CSRF-TOKEN": localStorage.getItem("csrfToken")
       }
     });
     return jqXHR.then(this.identity(jqXHR), this.handleExpiredSession)
@@ -47,7 +54,7 @@ class RestClient {
       data: JSON.stringify(data),
       contentType: "application/json",
       headers: {
-        "X-CSRF-TOKEN" : localStorage.getItem("csrfToken")
+        "X-CSRF-TOKEN": localStorage.getItem("csrfToken")
       }
     });
     return jqXHR.then(this.identity(jqXHR), this.handleExpiredSession)
@@ -57,7 +64,7 @@ class RestClient {
     const jqXHR = $.delete({
       url: url,
       headers: {
-        "X-CSRF-TOKEN" : localStorage.getItem("csrfToken")
+        "X-CSRF-TOKEN": localStorage.getItem("csrfToken")
       }
     });
     return jqXHR.then(this.identity(jqXHR), this.handleExpiredSession)
@@ -89,13 +96,10 @@ class RestDAO {
   }
 
   getList(searchQuery) {
-    let query = ""
-    if(searchQuery) {
-      query = `/${encodeURI(searchQuery)}`
-    }
+    let query = searchQuery ? `/${encodeURI(searchQuery)}` : "";
     return RestClient.get(`api/${this.entityType}/list${query}`)
   }
-  
+
   getSearchSuggestions() {
     return RestClient.get(`api/${this.entityType}/searchSuggestions`)
   }
@@ -109,11 +113,11 @@ class RestDAO {
   }
 
   getByNameAndVersion(name, version) {
-    return RestClient.get(`api/${this.entityType}/detail/${encodeURI(name)}/${encodeURI(version)}`)
+    return RestClient.get(`api/${this.entityType}/detail/${encodeURI(name)}/${encodeURI(version)}`, true)
   }
 
   getByNameAndVersionSync(name, version) {
-    return RestClient.getSync(`api/${this.entityType}/detail/${encodeURI(name)}/${encodeURI(version)}`)
+    return RestClient.getSync(`api/${this.entityType}/detail/${encodeURI(name)}/${encodeURI(version)}`, true)
   }
 
   getAuditTrail(name) {

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/package.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/package.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus
 
-package object stdandardization {
+package object standardization {
 
   /**
     * The trait and the case classes are used for type-safely applying
@@ -27,7 +27,7 @@ package object stdandardization {
 
   case class BooleanParameter(value: Boolean) extends RawFormatParameter
 
-  case class LongParameter(long: Boolean) extends RawFormatParameter
+  case class LongParameter(long: Long) extends RawFormatParameter
 
   case class DoubleParameter(double: Double) extends RawFormatParameter
 }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationCsvSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationCsvSuite.scala
@@ -64,9 +64,11 @@ class StandardizationCsvSuite extends fixture.FunSuite with SparkTestBase with T
   /** Creates a dataframe from an input file name path and command line arguments to Standardization */
   private def getTestDataFrame(tmpFileName: String, args: Array[String], checkMaxColumns: Boolean = false): DataFrame = {
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
-    val schemaOpt = if (checkMaxColumns) Some(schema) else None
-    StandardizationJob
-      .getFormatSpecificReader(cmd, dataSet, schemaOpt)
+    val csvReader = checkMaxColumns match {
+      case true  => StandardizationJob.getFormatSpecificReader(cmd, dataSet, schema.fields.length)
+      case false => StandardizationJob.getFormatSpecificReader(cmd, dataSet)
+    }
+    csvReader
       .schema(schema)
       .load(tmpFileName)
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationCsvSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationCsvSuite.scala
@@ -65,7 +65,7 @@ class StandardizationCsvSuite extends fixture.FunSuite with SparkTestBase with T
   private def getTestDataFrame(tmpFileName: String, args: Array[String]): DataFrame = {
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
     StandardizationJob
-      .getFormatSpecificReader(cmd, dataSet, schema)
+      .getFormatSpecificReader(cmd, dataSet, Some(schema))
       .schema(schema)
       .load(tmpFileName)
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationCsvSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationCsvSuite.scala
@@ -65,7 +65,7 @@ class StandardizationCsvSuite extends fixture.FunSuite with SparkTestBase with T
   private def getTestDataFrame(tmpFileName: String, args: Array[String]): DataFrame = {
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
     StandardizationJob
-      .getFormatSpecificReader(cmd, dataSet)
+      .getFormatSpecificReader(cmd, dataSet, schema)
       .schema(schema)
       .load(tmpFileName)
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
@@ -58,14 +58,14 @@ class StandardizationRerunSuite extends fixture.FunSuite with SparkTestBase with
   }
 
   /** Creates a dataframe from an input file name path and command line arguments to Standardization */
-  private def getTestDataFrame(tmpFileName: String, schemaStr: StructType): DataFrame = {
+  private def getTestDataFrame(tmpFileName: String, schema: StructType): DataFrame = {
     val args = ("--dataset-name SpecialColumns --dataset-version 1 --report-date 2019-07-23 " +
       "--report-version 1 --raw-format csv --header false --delimiter |").split(" ")
 
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
     StandardizationJob
-      .getFormatSpecificReader(cmd, dataSet, schemaStr.fields.length)
-      .schema(schemaStr)
+      .getFormatSpecificReader(cmd, dataSet, schema.fields.length)
+      .schema(schema)
       .load(tmpFileName)
   }
 

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
@@ -64,7 +64,7 @@ class StandardizationRerunSuite extends fixture.FunSuite with SparkTestBase with
 
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
     StandardizationJob
-      .getFormatSpecificReader(cmd, dataSet, Some(schemaStr))
+      .getFormatSpecificReader(cmd, dataSet, schemaStr.fields.length)
       .schema(schemaStr)
       .load(tmpFileName)
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
@@ -64,7 +64,7 @@ class StandardizationRerunSuite extends fixture.FunSuite with SparkTestBase with
 
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
     StandardizationJob
-      .getFormatSpecificReader(cmd, dataSet, schemaStr)
+      .getFormatSpecificReader(cmd, dataSet, Some(schemaStr))
       .schema(schemaStr)
       .load(tmpFileName)
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
@@ -64,7 +64,7 @@ class StandardizationRerunSuite extends fixture.FunSuite with SparkTestBase with
 
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
     StandardizationJob
-      .getFormatSpecificReader(cmd, dataSet)
+      .getFormatSpecificReader(cmd, dataSet, schemaStr)
       .schema(schemaStr)
       .load(tmpFileName)
   }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationRerunSuite.scala
@@ -58,14 +58,14 @@ class StandardizationRerunSuite extends fixture.FunSuite with SparkTestBase with
   }
 
   /** Creates a dataframe from an input file name path and command line arguments to Standardization */
-  private def getTestDataFrame(tmpFileName: String, schema: StructType): DataFrame = {
+  private def getTestDataFrame(tmpFileName: String, schemaWithStringType: StructType): DataFrame = {
     val args = ("--dataset-name SpecialColumns --dataset-version 1 --report-date 2019-07-23 " +
       "--report-version 1 --raw-format csv --header false --delimiter |").split(" ")
 
     val cmd: CmdConfig = CmdConfig.getCmdLineArguments(args)
     StandardizationJob
-      .getFormatSpecificReader(cmd, dataSet, schema.fields.length)
-      .schema(schema)
+      .getFormatSpecificReader(cmd, dataSet, schemaWithStringType.fields.length)
+      .schema(schemaWithStringType)
       .load(tmpFileName)
   }
 
@@ -79,7 +79,7 @@ class StandardizationRerunSuite extends fixture.FunSuite with SparkTestBase with
       StructField("A5", StringType, nullable = true)
     ))
 
-    val schemaStr: StructType = StructType(Seq(
+    val schemaWithStringType: StructType = StructType(Seq(
       StructField("A1", StringType, nullable = true),
       StructField("A2", StringType, nullable = true),
       StructField("A3", StringType, nullable = true),
@@ -100,7 +100,7 @@ class StandardizationRerunSuite extends fixture.FunSuite with SparkTestBase with
         |
         |""".stripMargin.replace("\r\n", "\n")
 
-    val inputDf = getTestDataFrame(tmpFileName, schemaStr)
+    val inputDf = getTestDataFrame(tmpFileName, schemaWithStringType)
 
     val stdDf = StandardizationInterpreter.standardize(inputDf, schema, "").cache()
 


### PR DESCRIPTION
If the number of columns in raw data exceeds the default SCVReader's limit of 20480 this increases the limit based on the schema. This was successfully tested on Asgard (dataset 25600cols): Standardization with 25600 columns takes approx. 11 minutes. The upper limit on the number of columns is not yet known and could be much higher. However, setting the conformance rules in web UI for such wide datasets is a bottleneck which should be addressed in case if further increase becomes necessary.  