### PR TITLE
#788 Fix experimental mapping rule non-deterministic bug

### DIFF
--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
@@ -84,19 +84,19 @@ object DynamicInterpreter {
     val conformedDf = steps.foldLeft(dfInputWithIdForWorkaround)({
       case (df, rule) =>
         val (ruleAppliedDf, ec) = applyConformanceRule(df, rule, explodeContext)
-        explodeContext = ec
 
         val conformedDf = if (explodeContext.explosions.isEmpty &&
           optimizerTimeTracker.isCatalystWorkaroundRequired(ruleAppliedDf, rulesApplied)) {
           // Apply a workaround BEFORE applying the rule so that the execution plan generation still runs fast
-          val (workAroundDf, ec) = applyConformanceRule(
+          val (workAroundDf, ecInner) = applyConformanceRule(
             optimizerTimeTracker.applyCatalystWorkaround(df),
             rule,
             explodeContext)
-          explodeContext = ec
+          explodeContext = ecInner
           optimizerTimeTracker.recordExecutionPlanOptimizationTime(workAroundDf)
           workAroundDf
         } else {
+          explodeContext = ec
           ruleAppliedDf
         }
         rulesApplied += 1

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -25,10 +25,13 @@ import za.co.absa.enceladus.samples.{ConformedEmployee, EmployeeConformance, Tra
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 import org.json4s._
 import org.json4s.native.JsonParser._
+import org.slf4j.LoggerFactory
 
 import scala.io.Source
 
 class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAll {
+
+  private val log = LoggerFactory.getLogger(this.getClass)
 
   override def beforeAll(): Unit = {
     super.beforeAll
@@ -146,7 +149,13 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
 
     val checkpoints = parse(infoFile).extract[ControlMeasure].checkpoints
 
-    assert(data == expected)
+    if (data != expected) {
+      log.error("EXPECTED:")
+      log.error(expected)
+      log.error("ACTUAL:")
+      log.error(data)
+      assert(data == expected)
+    }
 
     // check that all the expected checkpoints are there
     assert(checkpoints.lengthCompare(12) == 0)

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -15,6 +15,8 @@
 
 package za.co.absa.enceladus.conformance.interpreter
 
+import org.json4s._
+import org.json4s.native.JsonParser._
 import org.mockito.Mockito.{mock, when => mockWhen}
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import za.co.absa.atum.model.ControlMeasure
@@ -22,16 +24,11 @@ import za.co.absa.enceladus.conformance.CmdConfig
 import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.dao.EnceladusDAO
 import za.co.absa.enceladus.samples.{ConformedEmployee, EmployeeConformance, TradeConformance}
-import za.co.absa.enceladus.utils.testUtils.SparkTestBase
-import org.json4s._
-import org.json4s.native.JsonParser._
-import org.slf4j.LoggerFactory
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 
 import scala.io.Source
 
-class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAll {
-
-  private val log = LoggerFactory.getLogger(this.getClass)
+class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAll with LoggerTestBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll
@@ -150,10 +147,10 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
     val checkpoints = parse(infoFile).extract[ControlMeasure].checkpoints
 
     if (data != expected) {
-      log.error("EXPECTED:")
-      log.error(expected)
-      log.error("ACTUAL:")
-      log.error(data)
+      logger.error("EXPECTED:")
+      logger.error(expected)
+      logger.error("ACTUAL:")
+      logger.error(data)
       assert(data == expected)
     }
 


### PR DESCRIPTION
This is caused by wrong explodeContext being used when a Catalyst
workaround is applied. This led to an additional array explosion
inside an explosion context, which was not actually applied.
That lead to actual explosions not being collapsed.