### PR TITLE
#826 Add environment name to login and home page

### DIFF
--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -60,6 +60,7 @@ za.co.absa.enceladus.menas.mongo.connection.database=menas
 za.co.absa.enceladus.migration.mongo.query.timeout.seconds=300
 
 za.co.absa.enceladus.menas.version=@project.version@
+za.co.absa.enceladus.menas.environment=localhost
 
 za.co.absa.enceladus.menas.spark.master=local[1]
 

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
@@ -86,7 +86,7 @@ class WebSecurityConfig {
         .authorizeRequests()
           .antMatchers("/index.html", "/resources/**", "/generic/**",
             "/service/**", "/webjars/**", "/css/**", "/components/**",
-            "/api/oozie/isEnabled", "/api/user/version", s"/$menasVersion/**")
+            "/api/oozie/isEnabled", "/api/user/version", s"/$menasVersion/**", "/api/configuration/**")
           .permitAll()
         .anyRequest()
           .authenticated()

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/ConfigurationController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/ConfigurationController.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.controllers
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.{GetMapping, RequestMapping, RestController}
+
+@RestController
+@RequestMapping(Array("/api/configuration"))
+class ConfigurationController extends BaseController {
+  @Value("${za.co.absa.enceladus.menas.environment}")
+  val menasEnvironment: String = ""
+
+  @GetMapping(path = Array("/environment"))
+  def getEnvironment(): String = {
+    menasEnvironment
+  }
+}

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -50,6 +50,7 @@ za.co.absa.enceladus.menas.mongo.connection.database=menas_it
 za.co.absa.enceladus.migration.mongo.query.timeout.seconds=300
 
 za.co.absa.enceladus.menas.version=@project.version@
+za.co.absa.enceladus.menas.environment=localhost
 
 za.co.absa.enceladus.menas.spark.master=local[1]
 

--- a/menas/ui/components/home/landingPage.controller.js
+++ b/menas/ui/components/home/landingPage.controller.js
@@ -35,6 +35,10 @@ sap.ui.define([
         shortLimit: 9999,
         style: "short"
       });
+
+      ConfigRestClient.getEnvironmentName()
+        .then( sEnvironmentName => sap.ui.getCore().getModel().setProperty("/menasEnvironment", sEnvironmentName) )
+        .fail(console.log("Failed to get Environment variable"));
     },
 
     tileNumberFormatter: function(nNum) {

--- a/menas/ui/components/home/landingPage.controller.js
+++ b/menas/ui/components/home/landingPage.controller.js
@@ -38,7 +38,7 @@ sap.ui.define([
 
       ConfigRestClient.getEnvironmentName()
         .then( sEnvironmentName => sap.ui.getCore().getModel().setProperty("/menasEnvironment", sEnvironmentName) )
-        .fail(console.log("Failed to get Environment variable"));
+        .fail(console.log("Failed to get Environment name"));
     },
 
     tileNumberFormatter: function(nNum) {

--- a/menas/ui/components/home/landingPage.view.xml
+++ b/menas/ui/components/home/landingPage.view.xml
@@ -15,11 +15,11 @@
 
 <core:View xmlns:core="sap.ui.core" xmlns:mvc="sap.ui.core.mvc" xmlns="sap.m" controllerName="components.home.landingPage" xmlns:html="http://www.w3.org/1999/xhtml"
     xmlns:lab="it.designfuture.chartjs">
-    <Page title="Menas" enableScrolling="false">
+    <Page title="Menas on {/menasEnvironment}" enableScrolling="false">
         <customHeader>
             <Bar>
                 <contentMiddle>
-                    <Title text="Menas" />
+                    <Title text="Menas on {/menasEnvironment}" />
                 </contentMiddle>
                 <contentRight>
                     <core:Fragment type="XML" fragmentName="components.userInfo" />

--- a/menas/ui/components/login/loginDetail.controller.js
+++ b/menas/ui/components/login/loginDetail.controller.js
@@ -47,7 +47,7 @@ sap.ui.define([
 
       ConfigRestClient.getEnvironmentName()
         .then( sEnvironmentName => sap.ui.getCore().getModel().setProperty("/menasEnvironment", sEnvironmentName) )
-        .fail(console.log("Failed to get Environment variable"));
+        .fail(console.log("Failed to get Environment name"));
 
       this._eventBus.subscribe("menas", "resize", this.handleMaster, this);
     },

--- a/menas/ui/components/login/loginDetail.controller.js
+++ b/menas/ui/components/login/loginDetail.controller.js
@@ -45,6 +45,10 @@ sap.ui.define([
         this.handleMaster();
       }, this);
 
+      ConfigRestClient.getEnvironmentName()
+        .then( sEnvironmentName => sap.ui.getCore().getModel().setProperty("/menasEnvironment", sEnvironmentName) )
+        .fail(console.log("Failed to get Environment variable"));
+
       this._eventBus.subscribe("menas", "resize", this.handleMaster, this);
     },
 

--- a/menas/ui/components/login/loginDetail.view.xml
+++ b/menas/ui/components/login/loginDetail.view.xml
@@ -15,7 +15,7 @@
 
 <core:View id="loginDetailView" xmlns:core="sap.ui.core" xmlns:mvc="sap.ui.core.mvc" xmlns="sap.m" 
     xmlns:form="sap.ui.layout.form" controllerName="components.login.loginDetail">
-    <Page title="Login" enableScrolling="true">
+    <Page title="Login to {/menasEnvironment}" enableScrolling="true">
         <content>
             <VBox id="loginForm" fitContainer="true" justifyContent="Center" alignItems="Center">
                 <items>

--- a/menas/ui/service/RestDAO.js
+++ b/menas/ui/service/RestDAO.js
@@ -209,3 +209,10 @@ class MappingTableRestDAO extends DependentRestDAO {
   }
 
 }
+
+class ConfigRestClient {
+
+  static getEnvironmentName() {
+    return RestClient.get(`api/configuration/environment`)
+  }
+}


### PR DESCRIPTION
With this PR and with advice from @GeorgiChochov (BTW many thanks!!) I created a controller `ConfigurationController`. This controller could, later on, hold more than just the environment name, but we could even move `menasVersion` to it from `UserInfoController`.  `ConfigurationController` is for the API calls that do not require authentication.