### PR TITLE
#857 Update schedule fails, trying to write null into dateCreated

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/DatasetService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/DatasetService.scala
@@ -68,7 +68,7 @@ class DatasetService @Autowired() (datasetMongoRepository: DatasetMongoRepositor
 
       newInstance.map({ i =>
         val schedule = newDataset.schedule.get.copy(activeInstance = Some(i))
-        newDataset.setSchedule(Some(schedule))
+        latest.setSchedule(Some(schedule))
       })
     }
   }


### PR DESCRIPTION
This probably worked before the entity clean up, where the dates would be sent along with the update.