### PR TITLE
#822: Use defaultWithNull in Conformance

### DIFF
--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
@@ -32,28 +32,30 @@ case class NegationRuleInterpreter(rule: NegationConformanceRule) extends RuleIn
   override def conform(df: Dataset[Row])(implicit spark: SparkSession, dao: EnceladusDAO, progArgs: CmdConfig): Dataset[Row] = {
     NegationRuleInterpreter.validateInputField(progArgs.datasetName, df.schema, rule.inputColumn)
 
-    val fieldType = SchemaUtils.getFieldType(rule.inputColumn, df.schema).get
+    val field = SchemaUtils.getStructField(rule.inputColumn, df.schema).get
+
     val negationErrUdfCall = callUDF("confNegErr", lit(rule.outputColumn), col(rule.inputColumn))
     val errCol = "errCol"
 
-    fieldType match {
+    field.dataType match {
       case _: DecimalType =>
         // Negating decimal cannot fail
         DeepArrayTransformations.nestedWithColumnMap(df, rule.inputColumn, rule.outputColumn, c => negate(c))
       case _: BooleanType =>
+        // Negating Boolean cannot fail
         DeepArrayTransformations.nestedWithColumnMap(df, rule.inputColumn, rule.outputColumn, c => not(c))
       case _: DoubleType | _: FloatType =>
         // Negating floating point numbers cannot fail, but we need to account
         // for signed zeros (see the note for getNegator()).
-        DeepArrayTransformations.nestedWithColumnMap(df, rule.inputColumn, rule.outputColumn, c => getNegator(c, fieldType))
+        DeepArrayTransformations.nestedWithColumnMap(df, rule.inputColumn, rule.outputColumn, c => getNegator(c, field))
       case _ =>
         // The generic negation with checking for error conditions
         DeepArrayTransformations.nestedWithColumnAndErrorMap(df, rule.inputColumn, rule.outputColumn, errCol,
-          c => getNegator(c, fieldType), c => getError(c, negationErrUdfCall, fieldType))
+          c => getNegator(c, field), c => getError(c, negationErrUdfCall, field.dataType))
     }
   }
 
-  private def getNegator(inputColumn: Column, inputDataType: DataType): Column = {
+  private def getNegator(inputColumn: Column, field: StructField): Column = {
     // Just a couple JVM things:
     // 1. Beware of silent integer overflow, -Int.MinValue == Int.MaxValue + 1 == Int.MinValue
     //    Proof:
@@ -63,13 +65,18 @@ case class NegationRuleInterpreter(rule: NegationConformanceRule) extends RuleIn
     // 2. Beware negative floating-point zeroes, i.e. 0.0 * -1 == -0.0
     //    Equality (0.0 == -0.0) holds true, but Spark SQL considers 0.0 and -0.0 distinct and fails joins
     // The above is true not only for JVM, but for the most of the CPU/hardware implementations of numeric data types
+
+    def defaultValue(dt: DataType, nullable: Boolean): Any = {
+      Defaults.getGlobalDefaultWithNull(dt, field.nullable).get.orNull
+    }
+
     val neg = negate(inputColumn)
-    inputDataType match {
+    field.dataType match {
       case _: DoubleType | _: FloatType => when(inputColumn === 0.0, 0.0).otherwise(neg)
-      case dt: ByteType => when(inputColumn === Byte.MinValue, Defaults.getGlobalDefault(dt)).otherwise(neg)
-      case dt: ShortType => when(inputColumn === Short.MinValue, Defaults.getGlobalDefault(dt)).otherwise(neg)
-      case dt: IntegerType => when(inputColumn === Int.MinValue, Defaults.getGlobalDefault(dt)).otherwise(neg)
-      case dt: LongType => when(inputColumn === Long.MinValue, Defaults.getGlobalDefault(dt)).otherwise(neg)
+      case dt: ByteType => when(inputColumn === Byte.MinValue, defaultValue(dt, field.nullable)).otherwise(neg)
+      case dt: ShortType => when(inputColumn === Short.MinValue, defaultValue(dt, field.nullable)).otherwise(neg)
+      case dt: IntegerType => when(inputColumn === Int.MinValue,defaultValue(dt, field.nullable)).otherwise(neg)
+      case dt: LongType => when(inputColumn === Long.MinValue, defaultValue(dt, field.nullable)).otherwise(neg)
       case _ => neg
     }
   }

--- a/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
@@ -47,7 +47,7 @@ class NegationRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
     val expectedDataset = NegationRuleSamples.dataset
     val expectedJSON = NegationRuleSamples.Positive.conformedJSON
 
-    testRule(inputDataset, expectedDataset, expectedJSON)
+    testRule(inputDataset, expectedDataset, expectedJSON, nullableSchema = true)
   }
 
   test("Negation conformance rule should negate negative numeric values") {
@@ -55,7 +55,7 @@ class NegationRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
     val expectedDataset = NegationRuleSamples.dataset
     val expectedJSON = NegationRuleSamples.Negative.conformedJSON
 
-    testRule(inputDataset, expectedDataset, expectedJSON)
+    testRule(inputDataset, expectedDataset, expectedJSON, nullableSchema = true)
   }
 
   test("Negation conformance rule should not change zero numeric values (Keep in mind positive " +
@@ -64,7 +64,7 @@ class NegationRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
     val expectedDataset = NegationRuleSamples.dataset
     val expectedJSON = NegationRuleSamples.Zero.conformedJSON
 
-    testRule(inputDataset, expectedDataset, expectedJSON)
+    testRule(inputDataset, expectedDataset, expectedJSON, nullableSchema = true)
   }
 
   test("Negation conformance rule should negate max numeric values") {
@@ -72,7 +72,7 @@ class NegationRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
     val expectedDataset = NegationRuleSamples.dataset
     val expectedJSON = NegationRuleSamples.Max.conformedJSON
 
-    testRule(inputDataset, expectedDataset, expectedJSON)
+    testRule(inputDataset, expectedDataset, expectedJSON, nullableSchema = true)
   }
 
   test("Negation conformance rule should produce errors when negating min numeric values due to Silent " +
@@ -90,7 +90,7 @@ class NegationRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
     val expectedDataset = NegationRuleSamples.dataset
     val expectedJSON = NegationRuleSamples.MinWithNullableColumns.conformedJSON
 
-    testRule(inputDataset, expectedDataset, expectedJSON)
+    testRule(inputDataset, expectedDataset, expectedJSON, nullableSchema = true)
   }
 
   test("Negation conformance rule should disregard null numeric values") {
@@ -98,10 +98,10 @@ class NegationRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase{
     val expectedDataset = NegationRuleSamples.dataset
     val expectedJSON = NegationRuleSamples.Null.conformedJSON
 
-    testRule(inputDataset, expectedDataset, expectedJSON)
+    testRule(inputDataset, expectedDataset, expectedJSON, nullableSchema = true)
   }
 
-  private def testRule(inputDataset: Dataset[String], enceladusDataset: ConfDataset, expectedJSON: String, nullableSchema: Boolean = true): Unit = {
+  private def testRule(inputDataset: Dataset[String], enceladusDataset: ConfDataset, expectedJSON: String, nullableSchema: Boolean): Unit = {
     val schema = if (nullableSchema) {
       NegationRuleSamples.schemaNullable
     } else {

--- a/conformance/src/test/scala/za/co/absa/enceladus/samples/NegationRuleSamples.scala
+++ b/conformance/src/test/scala/za/co/absa/enceladus/samples/NegationRuleSamples.scala
@@ -23,16 +23,20 @@ object NegationRuleSamples {
 
   val schema = StructType(
     Array(
-      StructField("byte", ByteType),
-      StructField("short", ShortType),
-      StructField("integer", IntegerType),
-      StructField("long", LongType),
-      StructField("float", FloatType),
-      StructField("double", DoubleType),
-      StructField("decimal", DecimalType(32, 2)),
-      StructField("date", DateType),
-      StructField("boolean", BooleanType)
+      StructField("byte", ByteType, nullable = false),
+      StructField("short", ShortType, nullable = false),
+      StructField("integer", IntegerType, nullable = false),
+      StructField("long", LongType, nullable = false),
+      StructField("float", FloatType, nullable = false),
+      StructField("double", DoubleType, nullable = false),
+      StructField("decimal", DecimalType(32, 2), nullable = false),
+      StructField("date", DateType, nullable = false),
+      StructField("boolean", BooleanType, nullable = false)
     )
+  )
+
+  val schemaNullable = StructType(
+    schema.fields.map(_.copy(nullable = true))
   )
 
   val negateByte = NegationConformanceRule(order = 1, outputColumn = "ConformedByte", controlCheckpoint = false, inputColumn = "byte")
@@ -106,6 +110,21 @@ object NegationRuleSamples {
          |  "boolean": true}""".stripMargin)
 
     val conformedJSON = """{"byte":-128,"short":-32768,"integer":-2147483648,"long":-9223372036854775808,"float":-3.4028235E38,"double":-1.7976931348623157E308,"decimal":0.00,"date":"2018-06-11","boolean":true,"errCol":[{"errType":"confNegError","errCode":"E00004","errMsg":"Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged","errCol":"ConformedByte","rawValues":["-128"],"mappings":[]},{"errType":"confNegError","errCode":"E00004","errMsg":"Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged","errCol":"ConformedShort","rawValues":["-32768"],"mappings":[]},{"errType":"confNegError","errCode":"E00004","errMsg":"Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged","errCol":"ConformedInt","rawValues":["-2147483648"],"mappings":[]},{"errType":"confNegError","errCode":"E00004","errMsg":"Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged","errCol":"ConformedLong","rawValues":["-9223372036854775808"],"mappings":[]}],"ConformedByte":0,"ConformedShort":0,"ConformedInt":0,"ConformedLong":0,"ConformedFloat":3.4028234663852886E38,"ConformedDouble":1.7976931348623157E308,"ConformedDecimal":0.00,"ConformedBoolean":false}"""
+  }
+
+  object MinWithNullableColumns {
+    val data: Seq[String] = Seq(
+      s"""{ "byte": ${Byte.MinValue},
+         |  "short": ${Short.MinValue},
+         |  "integer": ${Int.MinValue},
+         |  "long": ${Long.MinValue},
+         |  "float": ${Float.MinValue},
+         |  "double": ${Double.MinValue},
+         |  "decimal": 0,
+         |  "date": "2018-06-11",
+         |  "boolean": true}""".stripMargin)
+
+    val conformedJSON = """{"byte":-128,"short":-32768,"integer":-2147483648,"long":-9223372036854775808,"float":-3.4028235E38,"double":-1.7976931348623157E308,"decimal":0.00,"date":"2018-06-11","boolean":true,"errCol":[{"errType":"confNegError","errCode":"E00004","errMsg":"Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged","errCol":"ConformedByte","rawValues":["-128"],"mappings":[]},{"errType":"confNegError","errCode":"E00004","errMsg":"Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged","errCol":"ConformedShort","rawValues":["-32768"],"mappings":[]},{"errType":"confNegError","errCode":"E00004","errMsg":"Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged","errCol":"ConformedInt","rawValues":["-2147483648"],"mappings":[]},{"errType":"confNegError","errCode":"E00004","errMsg":"Conformance Error - Negation of numeric type with minimum value overflows and remains unchanged","errCol":"ConformedLong","rawValues":["-9223372036854775808"],"mappings":[]}],"ConformedFloat":3.4028234663852886E38,"ConformedDouble":1.7976931348623157E308,"ConformedDecimal":0.00,"ConformedBoolean":false}"""
   }
 
   object Max {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SchemaUtils.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SchemaUtils.scala
@@ -72,27 +72,6 @@ object SchemaUtils {
     getField(path, schema).map(_.dataType)
   }
 
-  def fieldExists(path: String, schema: StructType): Boolean = {
-    def existsHelper(pt: List[String], st: DataType): Boolean = {
-      if (pt.isEmpty) {
-        true
-      } else {
-        st match {
-          case str: StructType => Try {
-            existsHelper(pt.tail, str(pt.head).dataType)
-          }.getOrElse(false)
-          case ArrayType(el: StructType, _) => Try {
-            existsHelper(pt.tail, el(pt.head).dataType)
-          }.getOrElse(false)
-          case _ => false
-        }
-      }
-    }
-
-    val pathTokens = path.split('.').toList
-    existsHelper(pathTokens, schema)
-  }
-
   /**
     * Checks if the specified path is an array of structs
     *

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SchemaUtils.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SchemaUtils.scala
@@ -23,6 +23,45 @@ import scala.util.{Random, Try}
 object SchemaUtils {
 
   /**
+   * Get a field from a text path and a given schema
+   * @param path   The dot-separated path to the field
+   * @param schema The schema which should contain the specified path
+   * @return       Some(the requested field) or None if the field does not exist
+   */
+  def getStructField(path: String, schema: StructType): Option[StructField] = {
+
+    @tailrec
+    def goThroughArrays(dataType: DataType): DataType = {
+      dataType match {
+        case ArrayType(dt, _) => goThroughArrays(dt)
+        case result => result
+      }
+    }
+
+    @tailrec
+    def diveInto(names: List[String], structField: StructField): Option[StructField] = {
+      if (names.isEmpty) {
+        Option(structField)
+      } else {
+        structField.dataType match {
+          case str: StructType              => diveInto(names.tail, str(names.head))
+          case ArrayType(el: DataType, _) =>
+            goThroughArrays(el) match {
+              case struct: StructType => diveInto(names.tail, struct(names.head))
+              case _ => None
+            }
+          case _                            => None
+        }
+      }
+    }
+
+    val pathTokens = path.split('.').toList
+    Try{
+      diveInto(pathTokens.tail, schema(pathTokens.head))
+    }.getOrElse(None)
+  }
+
+  /**
     * Get a type of a field from a text path and a given schema
     *
     * @param path   The dot-separated path to the field
@@ -30,24 +69,7 @@ object SchemaUtils {
     * @return Some(the type of the field) or None if the field does not exist
     */
   def getFieldType(path: String, schema: StructType): Option[DataType] = {
-    def typeHelper(pt: List[String], st: DataType): Option[DataType] = {
-      if (pt.isEmpty) {
-        Some(st)
-      } else {
-        st match {
-          case str: StructType => Try {
-            typeHelper(pt.tail, str(pt.head).dataType)
-          }.getOrElse(None)
-          case ArrayType(el: StructType, _) => Try {
-            typeHelper(pt.tail, el(pt.head).dataType)
-          }.getOrElse(None)
-          case _ => None
-        }
-      }
-    }
-
-    val pathTokens = path.split('.').toList
-    typeHelper(pathTokens, schema)
+    getStructField(path, schema).map(_.dataType)
   }
 
   def fieldExists(path: String, schema: StructType): Boolean = {
@@ -101,26 +123,18 @@ object SchemaUtils {
     * @return Some(nullable) or None if the field does not exist
     */
   def getFieldNullability(path: String, schema: StructType): Option[Boolean] = {
-    def typeHelper(pt: List[String], st: DataType, nl: Option[Boolean]): Option[Boolean] = {
-      if (pt.isEmpty) {
-        nl
-      } else {
-        st match {
-          case str: StructType => Try {
-            typeHelper(pt.tail, str(pt.head).dataType, Some(str.apply(pt.head).nullable))
-          }.getOrElse(None)
-          case ArrayType(el: StructType, _) => Try {
-            typeHelper(pt.tail, el(pt.head).dataType, Some(el(pt.head).nullable))
-          }.getOrElse(None)
-          case _ => None
-        }
-      }
-    }
-
-    val pathTokens = path.split('.').toList
-    typeHelper(pathTokens, schema, None)
+    getStructField(path, schema).map(_.nullable)
   }
 
+  /**
+   * Checks if a field specified by a path and a schema exists
+   * @param path   The dot-separated path to the field
+   * @param schema The schema which should contain the specified path
+   * @return       True if the field exists false otherwise
+   */
+  def fieldExists(path: String, schema: StructType): Boolean = {
+    getStructField(path, schema).nonEmpty
+  }
 
   /**
     * Get first array column's path out of complete path.
@@ -132,6 +146,7 @@ object SchemaUtils {
     * @return The path of the first array field or "" if none were found
     */
   def getFirstArrayPath(path: String, schema: StructType): String = {
+    @tailrec
     def helper(remPath: Seq[String], pathAcc: Seq[String]): Seq[String] = {
       if (remPath.isEmpty) Seq() else {
         val currPath = (pathAcc :+ remPath.head).mkString(".")
@@ -152,7 +167,7 @@ object SchemaUtils {
     * Get paths for all array subfields of this given datatype
     */
   def getAllArraySubPaths(path: String, name: String, dt: DataType): Seq[String] = {
-    val currPath = (if (path.isEmpty) name else if (name.isEmpty()) path else s"$path.${name}")
+    val currPath = fullPath(path, name)
     dt match {
       case s: StructType => s.fields.flatMap(f => getAllArraySubPaths(currPath, f.name, f.dataType))
       case a@ArrayType(elType, nullable) => getAllArraySubPaths(path, name, elType) :+ currPath
@@ -170,6 +185,7 @@ object SchemaUtils {
     * @return Seq of dot-separated paths for all array fields in the provided path
     */
   def getAllArraysInPath(path: String, schema: StructType): Seq[String] = {
+    @tailrec
     def helper(remPath: Seq[String], pathAcc: Seq[String], arrayAcc: Seq[String]): Seq[String] = {
       if (remPath.isEmpty) arrayAcc else {
         val currPath = (pathAcc :+ remPath.head).mkString(".")
@@ -274,8 +290,28 @@ object SchemaUtils {
     * @param fieldName Name of the field to be appended to the path
     * @return The path with the new field appended or the field itself if path is empty
     */
-  private[enceladus] def appendPath(path: String, fieldName: String) = {
-    if (path.isEmpty) fieldName else s"$path.$fieldName"
+  def appendPath(path: String, fieldName: String): String = {
+    if (path.isEmpty) {
+      fieldName
+    } else {
+      s"$path.$fieldName"
+    }
+  }
+
+  /**
+   * Combines path and field name using dot notation
+   * @param path      The dot-separated existing path
+   * @param fieldName Name of the field to be appended to the path
+   * @return          The combined path and field name
+   */
+  def fullPath(path: String, fieldName: String): String = {
+    if (path.isEmpty) {
+      fieldName
+    } else if (fieldName.isEmpty) {
+      path
+    } else {
+      s"$path.${fieldName}"
+    }
   }
 
   /**
@@ -384,6 +420,7 @@ object SchemaUtils {
     * @return true if the specified field is an array
     */
   def isArray(schema: StructType, fieldPathName: String): Boolean = {
+    @tailrec
     def arrayHelper(arrayField: ArrayType, path: Seq[String]): Boolean = {
       val currentField = path.head
       val isLeaf = path.lengthCompare(1) <= 0
@@ -498,7 +535,6 @@ object SchemaUtils {
                   s"Primitive fields cannot have child fields $currentField is a primitive in $column")
             }
           }
-
         }
       )
       isOnlyField

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/schema/SchemaUtilsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/schema/SchemaUtilsSuite.scala
@@ -39,6 +39,14 @@ class SchemaUtilsSuite extends FunSuite {
         StructField("d", ArrayType(StructType(Seq(
           StructField("e", IntegerType))))))))))))))
 
+  val arrayOfArraysSchema = StructType(Seq(
+    StructField("a", ArrayType(ArrayType(IntegerType)), nullable = false),
+    StructField("b", ArrayType(ArrayType(StructType(Seq(
+        StructField("c", StringType, nullable = false)
+      ))
+    )), nullable = true)
+  ))
+
   val structFieldNoMetadata = StructField("a", IntegerType)
 
   val structFieldWithMetadataNotSourceColumn = StructField("a", IntegerType, nullable = false, new MetadataBuilder().putString("meta", "data").build)
@@ -307,11 +315,34 @@ class SchemaUtilsSuite extends FunSuite {
     ))
 
     assert(!isOnlyField(schema, "a"))
-    assert(!isOnlyField(schema, "a"))
-    assert(!isOnlyField(schema, "a"))
     assert(!isOnlyField(schema, "b.e"))
     assert(!isOnlyField(schema, "b.f"))
     assert(isOnlyField(schema, "c.d"))
   }
 
+  test("Test getStructField on array of arrays") {
+    assert(getStructField("a", arrayOfArraysSchema).contains(StructField("a",ArrayType(ArrayType(IntegerType)),nullable = false)))
+    assert(getStructField("b", arrayOfArraysSchema).contains(StructField("b",ArrayType(ArrayType(StructType(Seq(StructField("c",StringType,nullable = false))))), nullable = true)))
+    assert(getStructField("b.c", arrayOfArraysSchema).contains(StructField("c",StringType,nullable = false)))
+    assert(getStructField("b.d", arrayOfArraysSchema).isEmpty)
+  }
+
+  test("Test fieldExists") {
+    assert(fieldExists("a", schema))
+    assert(fieldExists("b", schema))
+    assert(fieldExists("b.c", schema))
+    assert(fieldExists("b.d", schema))
+    assert(fieldExists("b.d.e", schema))
+    assert(fieldExists("f", schema))
+    assert(fieldExists("f.g", schema))
+    assert(fieldExists("f.g.h", schema))
+    assert(!fieldExists("z", schema))
+    assert(!fieldExists("x.y.z", schema))
+    assert(!fieldExists("f.g.h.a", schema))
+
+    assert(fieldExists("a", arrayOfArraysSchema))
+    assert(fieldExists("b", arrayOfArraysSchema))
+    assert(fieldExists("b.c", arrayOfArraysSchema))
+    assert(!fieldExists("b.d", arrayOfArraysSchema))
+  }
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/schema/SchemaUtilsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/schema/SchemaUtilsSuite.scala
@@ -321,10 +321,10 @@ class SchemaUtilsSuite extends FunSuite {
   }
 
   test("Test getStructField on array of arrays") {
-    assert(getStructField("a", arrayOfArraysSchema).contains(StructField("a",ArrayType(ArrayType(IntegerType)),nullable = false)))
-    assert(getStructField("b", arrayOfArraysSchema).contains(StructField("b",ArrayType(ArrayType(StructType(Seq(StructField("c",StringType,nullable = false))))), nullable = true)))
-    assert(getStructField("b.c", arrayOfArraysSchema).contains(StructField("c",StringType,nullable = false)))
-    assert(getStructField("b.d", arrayOfArraysSchema).isEmpty)
+    assert(getField("a", arrayOfArraysSchema).contains(StructField("a",ArrayType(ArrayType(IntegerType)),nullable = false)))
+    assert(getField("b", arrayOfArraysSchema).contains(StructField("b",ArrayType(ArrayType(StructType(Seq(StructField("c",StringType,nullable = false))))), nullable = true)))
+    assert(getField("b.c", arrayOfArraysSchema).contains(StructField("c",StringType,nullable = false)))
+    assert(getField("b.d", arrayOfArraysSchema).isEmpty)
   }
 
   test("Test fieldExists") {


### PR DESCRIPTION
* Negation Rule uses Defaults.getGlobalDefaultWithNull instead of Defaults.getGlobalDefault
* Support for Arrays in Arrays in SchemaUtils
* Unified similar code in SchemaUtils
* added getStructField and fieldExists into SchemaUtils
* Updated and enhanced UTs