### PR TITLE
#799: Uploading schema with default value having integer breaks the schema

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
@@ -122,9 +122,9 @@ class SparkMenasSchemaConvertor @Autowired()(val objMapper: ObjectMapper) {
           // construction ensures it
           case (key: String, value: String) => (key, value)
           case (key: String, null) => (key, null) // scalastyle:ignore null - some values can be null, particularly default, can be null
-          case (key, _) => throw SchemaParsingException(
+          case (key, value) => throw SchemaParsingException(
             schemaType = "",
-            message = s"Value for metadata key '$key' has to be a string",
+            message = s"Value for metadata key '$key' (of value $value) to be a string or null",
             field = Option(field.name)
           )
         }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
@@ -116,18 +116,20 @@ class SparkMenasSchemaConvertor @Autowired()(val objMapper: ObjectMapper) {
       case _                    => None
     }
 
-    val childrenPath = SchemaUtils.appendPath(path, field.name)
     val metadata: Map[String, String] = objMapper.readValue(field.metadata.json, classOf[Map[Any, Any]])
         .collect{
           // objMapper.readValue(_, classOf[Map[String, String]] doesn't actually enforce typing within the Map, this
           // construction ensures it
           case (key: String, value: String) => (key, value)
+          case (key: String, null) => (key, null) // scalastyle:ignore null - some values can be null, particularly default, can be null
           case (key, _) => throw SchemaParsingException(
             schemaType = "",
             message = s"Value for metadata key '$key' has to be a string",
             field = Option(field.name)
           )
         }
+
+    val childrenPath = SchemaUtils.appendPath(path, field.name)
 
     SchemaField(
       name = field.name,

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertor.scala
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import java.io.ByteArrayOutputStream
 
+import za.co.absa.enceladus.menas.models.rest.exceptions.SchemaParsingException
+import za.co.absa.enceladus.utils.schema.SchemaUtils
+
 import scala.util.control.NonFatal
 
 @Component
@@ -97,36 +100,60 @@ class SparkMenasSchemaConvertor @Autowired()(val objMapper: ObjectMapper) {
     }
   }
 
+  @throws[SchemaParsingException]
   def convertSparkToMenasFields(sparkFields: Seq[StructField]): Seq[SchemaField] = {
     convertSparkToMenasFields(sparkFields, "")
   }
 
   /** Converts a seq of spark struct fields to menas representation */
   def convertSparkToMenasFields(sparkFields: Seq[StructField], path: String): Seq[SchemaField] = {
-    sparkFields.map({ field =>
-      val arr = field.dataType match {
-        case arrayType: ArrayType => Some(arrayType)
-        case _                    => None
-      }
+    sparkFields.map(sparkToMenasField(_, path))
+  }
 
-      SchemaField(
-        name = field.name,
-        `type` = field.dataType.typeName,
-        path = path,
-        elementType = arr.map(_.elementType.typeName),
-        containsNull = arr.map(_.containsNull),
-        nullable = field.nullable,
-        metadata = objMapper.readValue(field.metadata.json, classOf[Map[String, String]]),
-        children = getChildren(field.dataType, s"$path${if (path.isEmpty) "" else "."}${field.name}"))
-    }).toList
+  private def sparkToMenasField(field: StructField, path: String): SchemaField = {
+    val arr = field.dataType match {
+      case arrayType: ArrayType => Some(arrayType)
+      case _                    => None
+    }
+
+    val childrenPath = SchemaUtils.appendPath(path, field.name)
+    val metadata: Map[String, String] = objMapper.readValue(field.metadata.json, classOf[Map[Any, Any]])
+        .collect{
+          // objMapper.readValue(_, classOf[Map[String, String]] doesn't actually enforce typing within the Map, this
+          // construction ensures it
+          case (key: String, value: String) => (key, value)
+          case (key, _) => throw SchemaParsingException(
+            schemaType = "",
+            message = s"Value for metadata key '$key' has to be a string",
+            field = Option(field.name)
+          )
+        }
+
+    SchemaField(
+      name = field.name,
+      `type` = field.dataType.typeName,
+      path = path,
+      elementType = arr.map(_.elementType.typeName),
+      containsNull = arr.map(_.containsNull),
+      nullable = field.nullable,
+      metadata = metadata,
+      children = getChildren(field.dataType, childrenPath)
+    )
   }
 
   /** Calculate the children field for the spark to menas conversion */
-  private def getChildren(spark: DataType, path: String): List[SchemaField] = {
-    spark match {
+  private def getChildren(fieldDataType: DataType, path: String): List[SchemaField] = {
+    fieldDataType match {
       case s: StructType => convertSparkToMenasFields(s.fields, path).toList
-      case a@ArrayType(el: ArrayType, _) if a.elementType.isInstanceOf[ArrayType] => List(SchemaField(name = "", `type` = el.typeName, path = path, elementType = Some(el.elementType.typeName),
-        containsNull = Some(el.containsNull), nullable = a.containsNull, metadata = Map(), children = getChildren(el, path)))
+      case a@ArrayType(el: ArrayType, _) => List(SchemaField(
+        name = "",
+        `type` = el.typeName,
+        path = path,
+        elementType = Some(el.elementType.typeName),
+        containsNull = Some(el.containsNull),
+        nullable = a.containsNull,
+        metadata = Map(),
+        children = getChildren(el, path)))
       case a: ArrayType => getChildren(a.elementType, path)
       case m: MapType => getChildren(m.valueType, path)
       case _: DataType => List()

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertorSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertorSuite.scala
@@ -95,7 +95,7 @@ class SparkMenasSchemaConvertorSuite extends FunSuite with SparkTestBase {
       sparkConvertor.convertSparkToMenasFields(sparkDefinition)
     }
 
-    assert(caught == SchemaParsingException(schemaType = "", message = "Value for metadata key 'default' has to be a string", field = Option(fieldName)))
+    assert(caught == SchemaParsingException(schemaType = "", message = "Value for metadata key 'default' (of value 0) to be a string or null", field = Option(fieldName)))
   }
 
   test("convertSparkToMenasFields and convertMenasToSparkFields with nulls in values of metadata") {

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertorSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/utils/converters/SparkMenasSchemaConvertorSuite.scala
@@ -24,44 +24,24 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.databind.SerializationFeature
+import za.co.absa.enceladus.menas.models.rest.exceptions.SchemaParsingException
 
 class SparkMenasSchemaConvertorSuite extends FunSuite with SparkTestBase {
-  val objectMapper = new ObjectMapper()
+  private val objectMapper = new ObjectMapper()
     .registerModule(DefaultScalaModule)
     .registerModule(new JavaTimeModule())
     .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-  val sparkConvertor = new SparkMenasSchemaConvertor(objectMapper)
+  private val sparkConvertor = new SparkMenasSchemaConvertor(objectMapper)
 
-  val sparkSimleFlat = Seq(
+  private val sparkSimleFlat = Seq(
     StructField(name = "a", dataType = IntegerType, nullable = true, metadata = new MetadataBuilder().putString("format", "xyz.abc").putString("precision", "14.56").build),
     StructField(name = "b", dataType = DecimalType.apply(38, 18), nullable = false),
     StructField(name = "c", dataType = StringType))
 
-  val menasSimpleFlat = Seq(
+  private val menasSimpleFlat = Seq(
     SchemaField(name = "a", `type` = "integer", path = "", elementType = None, containsNull = None, nullable = true, metadata = Map("format" -> "xyz.abc", "precision" -> "14.56"), children = List()),
     SchemaField(name = "b", `type` = "decimal(38,18)", path = "", elementType = None, containsNull = None, nullable = false, metadata = Map(), children = List()),
     SchemaField(name = "c", `type` = "string", path = "", elementType = None, containsNull = None, nullable = true, metadata = Map(), children = List()))
-
-  val sparkComplex = Seq(
-    StructField(name = "a", dataType = IntegerType, nullable = true, metadata = new MetadataBuilder().putString("format", "xyz.abc").putString("precision", "14.56").build),
-    StructField(name = "b", dataType = StructType(Seq(
-      StructField(name = "c", dataType = ArrayType.apply(IntegerType)),
-      StructField(name = "d", dataType = ArrayType.apply(StructType(Seq(
-        StructField(name = "e", dataType = StringType),
-        StructField(name = "f", dataType = DoubleType))))),
-      StructField(name = "g", dataType = ArrayType.apply(ArrayType.apply(StructType(Seq(
-        StructField(name = "h", dataType = IntegerType)))))))), nullable = false))
-
-  val menasComplex = Seq(
-    SchemaField(name = "a", `type` = "integer", path = "", elementType = None, containsNull = None, nullable = true, metadata = Map("format" -> "xyz.abc", "precision" -> "14.56"), children = List()),
-    SchemaField(name = "b", `type` = "struct", path = "", elementType = None, containsNull = None, nullable = false, metadata = Map(), children = List(
-      SchemaField(name = "c", `type` = "array", path = "b", elementType = Some("integer"), containsNull = Some(true), nullable = true, metadata = Map(), children = List()),
-      SchemaField(name = "d", `type` = "array", path = "b", elementType = Some("struct"), containsNull = Some(true), nullable = true, metadata = Map(), children = List(
-        SchemaField(name = "e", `type` = "string", path = "b.d", elementType = None, containsNull = None, nullable = true, metadata = Map(), children = List()),
-        SchemaField(name = "f", `type` = "double", path = "b.d", elementType = None, containsNull = None, nullable = true, metadata = Map(), children = List()))),
-      SchemaField(name = "g", `type` = "array", path = "b", elementType = Some("array"), containsNull = Some(true), nullable = true, metadata = Map(), children = List(
-        SchemaField(name = "", `type` = "array", path = "b.g", elementType = Some("struct"), containsNull = Some(true), nullable = true, metadata = Map(), children = List(
-          SchemaField(name = "h", `type` = "integer", path = "b.g", elementType = None, containsNull = None, nullable = true, metadata = Map(), children = List()))))))))
 
   test("convertSparkToMenasFields Simple Test") {
     val res = sparkConvertor.convertSparkToMenasFields(sparkSimleFlat)
@@ -72,6 +52,26 @@ class SparkMenasSchemaConvertorSuite extends FunSuite with SparkTestBase {
   }
 
   test("convertSparkToMenas Complex Test") {
+    val sparkComplex = Seq(
+      StructField(name = "a", dataType = IntegerType, nullable = true, metadata = new MetadataBuilder().putString("format", "xyz.abc").putString("precision", "14.56").build),
+      StructField(name = "b", dataType = StructType(Seq(
+        StructField(name = "c", dataType = ArrayType.apply(IntegerType)),
+        StructField(name = "d", dataType = ArrayType.apply(StructType(Seq(
+          StructField(name = "e", dataType = StringType),
+          StructField(name = "f", dataType = DoubleType))))),
+        StructField(name = "g", dataType = ArrayType.apply(ArrayType.apply(StructType(Seq(
+          StructField(name = "h", dataType = IntegerType)))))))), nullable = false))
+
+    val menasComplex = Seq(
+      SchemaField(name = "a", `type` = "integer", path = "", elementType = None, containsNull = None, nullable = true, metadata = Map("format" -> "xyz.abc", "precision" -> "14.56"), children = List()),
+      SchemaField(name = "b", `type` = "struct", path = "", elementType = None, containsNull = None, nullable = false, metadata = Map(), children = List(
+        SchemaField(name = "c", `type` = "array", path = "b", elementType = Some("integer"), containsNull = Some(true), nullable = true, metadata = Map(), children = List()),
+        SchemaField(name = "d", `type` = "array", path = "b", elementType = Some("struct"), containsNull = Some(true), nullable = true, metadata = Map(), children = List(
+          SchemaField(name = "e", `type` = "string", path = "b.d", elementType = None, containsNull = None, nullable = true, metadata = Map(), children = List()),
+          SchemaField(name = "f", `type` = "double", path = "b.d", elementType = None, containsNull = None, nullable = true, metadata = Map(), children = List()))),
+        SchemaField(name = "g", `type` = "array", path = "b", elementType = Some("array"), containsNull = Some(true), nullable = true, metadata = Map(), children = List(
+          SchemaField(name = "", `type` = "array", path = "b.g", elementType = Some("struct"), containsNull = Some(true), nullable = true, metadata = Map(), children = List(
+            SchemaField(name = "h", `type` = "integer", path = "b.g", elementType = None, containsNull = None, nullable = true, metadata = Map(), children = List()))))))))
 
     val res = sparkConvertor.convertSparkToMenasFields(sparkComplex)
 
@@ -84,6 +84,19 @@ class SparkMenasSchemaConvertorSuite extends FunSuite with SparkTestBase {
     val res = sparkConvertor.convertMenasToSparkFields(menasSimpleFlat)
 
     assertResult(sparkSimleFlat)(res)
+  }
+
+  test("ConvertSparkToMenas with non-string values in metadata") {
+    val fieldName = "field_name"
+    val sparkDefinition = Seq(
+      StructField(name = fieldName, dataType = IntegerType, nullable = true, metadata = new MetadataBuilder().putLong("default", 0).build)
+    )
+
+    val caught = intercept[SchemaParsingException] {
+      sparkConvertor.convertSparkToMenasFields(sparkDefinition)
+    }
+
+    assert(caught == SchemaParsingException(schemaType = "", message = "Value for metadata key 'default' has to be a string", field = Option(fieldName)))
   }
 
 }

--- a/menas/ui/components/schema/schemaDetail.controller.js
+++ b/menas/ui/components/schema/schemaDetail.controller.js
@@ -182,7 +182,7 @@ sap.ui.define([
         this.byId("schemaIconTabBar").setSelectedKey("info");
       } else if (status === 400) {
         const sSchemaType = this.byId("schemaFormatSelect").getSelectedItem().getText();
-        const errorMessage = ResponseUtils.getErrorMessage(oParams.getParameter("responseRaw"));
+        const errorMessage = ResponseUtils.getBadRequestErrorMessage(oParams.getParameter("responseRaw"));
         const errorMessageDetails = errorMessage ? `\n\nDetails:\n${errorMessage}` : "";
         MessageBox.error(`Error parsing the schema file. Ensure that the file is a valid ${sSchemaType} schema and ` +
           `try again.${errorMessageDetails}`)

--- a/menas/ui/service/ResponseUtils.js
+++ b/menas/ui/service/ResponseUtils.js
@@ -25,12 +25,23 @@ class ResponseUtils {
    * }
    *
    */
-  static getErrorMessage(rawResponse) {
+  static getBadRequestErrorMessage(rawResponse) {
     let errorMessageDetails = "";
     try {
       const oParsedResponse = JSON.parse(rawResponse);
       if (oParsedResponse.message) {
         errorMessageDetails = oParsedResponse.message;
+      }
+      if (oParsedResponse.error) {
+        if (oParsedResponse.error.line) {
+          errorMessageDetails += "\nLine: " + oParsedResponse.error.line
+        }
+        if (oParsedResponse.error.column) {
+          errorMessageDetails += "\nColumn: " + oParsedResponse.error.column
+        }
+        if (oParsedResponse.error.field) {
+          errorMessageDetails += "\nField: " + oParsedResponse.error.field
+        }
       }
     } catch (e) {
       console.error(`Unable to parse the raw response from the server. Error: ${e}. Response: ${rawResponse}`)


### PR DESCRIPTION
* Parsing the schema fields' metadata, that they are all of type String
* Reordering the database save operations, so that the parsing is done before
* Enhanced feedback info in case parsing fails