### PR TITLE
#398: sourcecolumn metadata value doesn't work

### DIFF
--- a/conformance/pom.xml
+++ b/conformance/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/dataModel/pom.xml
+++ b/dataModel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/external/fixedWidth/pom.xml
+++ b/external/fixedWidth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>enceladus-parent</artifactId>
         <groupId>za.co.absa</groupId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/external/kafka/pom.xml
+++ b/external/kafka/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>enceladus-parent</artifactId>
         <groupId>za.co.absa</groupId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/migrations-cli/pom.xml
+++ b/migrations-cli/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/migrations/pom.xml
+++ b/migrations/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>za.co.absa</groupId>
     <artifactId>enceladus-parent</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>pom</packaging>
 
     <name>Enceladus</name>

--- a/selenium/pom.xml
+++ b/selenium/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/standardization/pom.xml
+++ b/standardization/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -96,7 +96,8 @@ object TypeParser extends StandardizationCommon {
     val parserClass: (String, StructType, Option[Parent]) => TypeParser = field.dataType match {
       case _: ArrayType     => ArrayParser(TypedStructField.asArrayTypeStructField(field), _, _, _)
       case _: StructType    => StructParser(TypedStructField.asStructTypeStructField(field), _, _, _)
-      case _: ByteType      => IntegralParser(TypedStructField(field), _, _, _,Set(ShortType, IntegerType, LongType), Byte.MinValue, Byte.MaxValue)
+      case _: ByteType      =>
+        IntegralParser(TypedStructField(field), _, _, _, Set(ShortType, IntegerType, LongType), Byte.MinValue, Byte.MaxValue)
       case _: ShortType     => IntegralParser(TypedStructField(field), _, _, _, Set(IntegerType, LongType), Short.MinValue, Short.MaxValue)
       case _: IntegerType   => IntegralParser(TypedStructField(field), _, _, _, Set(LongType), Int.MinValue, Int.MaxValue)
       case _: LongType      => IntegralParser(TypedStructField(field), _, _, _, Set.empty, Long.MinValue, Long.MaxValue)
@@ -196,7 +197,6 @@ object TypeParser extends StandardizationCommon {
           typedLit(Seq.empty[ErrorMessage])
         ))
       }
-
 
       val std: Column = when(size(err) > lit(0), // there was an error on cast
         field.defaultValueWithGlobal.get.orNull // Error should never appear here, then converting Option to value or Null

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>enceladus-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
* to produce the output data frame the desired schema for renaming is used, which contains the metadata
* to prevent error column from being dropped it's added explicitly