### PR TITLE
#962 Fix a deprecation warning.

### DIFF
--- a/migrations/src/main/scala/za/co/absa/enceladus/migrations/framework/dao/ScalaMongoImplicits.scala
+++ b/migrations/src/main/scala/za/co/absa/enceladus/migrations/framework/dao/ScalaMongoImplicits.scala
@@ -52,7 +52,7 @@ object ScalaMongoImplicits {
 
         override def onError(e: Throwable): Unit = p.failure(new RuntimeException("Error fetching MongoDB documents.", e))
 
-        override def onComplete(): Unit = p.success()
+        override def onComplete(): Unit = p.success((): Unit)
       })
 
       // An infinite wait since processing all documents in a collection can take a long time


### PR DESCRIPTION
Adaptation of argument list by inserting () has been deprecated: this is unlikely to be what you want.
        signature: Promise.success(value: T): Promise.this.type
  given arguments: <none>
 after adaptation: Promise.success((): Unit)