### PR TITLE
884 Enable Spring Boot Actuator

### DIFF
--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -126,6 +126,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
         <!-- SECURITY -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -71,6 +71,21 @@ za.co.absa.enceladus.spline.urlTemplate=//localhost:8080/spline/dataset/lineage/
 #system-wide time zone
 timezone="UTC"
 
+#---------- Actuator
+management.endpoints.web.base-path=/admin
+management.endpoints.jmx.exposure.exclude=*
+management.endpoints.web.exposure.include=health,threaddump,heapdump,loggers
+
+management.endpoints.enabled-by-default=false
+
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=always
+management.endpoint.threaddump.enabled=true
+management.endpoint.heapdump.enabled=true
+management.endpoint.loggers.enabled=true
+
+management.health.jms.enabled=false
+
 #---------- Monitoring
 # Limit on the number of documents to be fetch in a single mongodb query and shown in UI
 za.co.absa.enceladus.menas.monitoring.fetch.limit=500

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
@@ -85,7 +85,7 @@ class WebSecurityConfig {
         .and()
         .authorizeRequests()
           .antMatchers("/index.html", "/resources/**", "/generic/**",
-            "/service/**", "/webjars/**", "/css/**", "/components/**",
+            "/service/**", "/webjars/**", "/css/**", "/components/**", "/admin/health",
             "/api/oozie/isEnabled", "/api/user/version", s"/$menasVersion/**", "/api/configuration/**")
           .permitAll()
         .anyRequest()

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/health/HdfsHealthChecker.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/health/HdfsHealthChecker.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.health
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.health.{Health, HealthIndicator}
+import org.springframework.stereotype.Component
+
+import scala.util.{Failure, Success, Try}
+
+@Component("HDFSConnection")
+class HdfsHealthChecker @Autowired()(hdfs: FileSystem) extends HealthIndicator {
+
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  override protected def health(): Health = {
+    Try(hdfs.getFileStatus(new Path("/"))) match {
+      case Success(_) =>
+        Health.up().build()
+      case Failure(e) =>
+        log.error("HDFS connection is down", e)
+        Health.down().withException(e).build()
+    }
+  }
+
+}

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/health/HdfsHealthChecker.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/health/HdfsHealthChecker.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus.menas.health
 
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.FileSystem
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.actuate.health.{Health, HealthIndicator}
@@ -29,7 +29,9 @@ class HdfsHealthChecker @Autowired()(hdfs: FileSystem) extends HealthIndicator {
   private val log = LoggerFactory.getLogger(this.getClass)
 
   override protected def health(): Health = {
-    Try(hdfs.getFileStatus(new Path("/"))) match {
+    Try {
+      hdfs.getStatus()
+    } match {
       case Success(_) =>
         Health.up().build()
       case Failure(e) =>

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/health/MongoHealthChecker.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/health/MongoHealthChecker.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.health
+
+import java.util.concurrent.TimeUnit
+
+import org.mongodb.scala.MongoDatabase
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.health.{Health, HealthIndicator}
+import org.springframework.stereotype.Component
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success, Try}
+
+@Component("MongoDBConnection")
+class MongoHealthChecker @Autowired()(mongoDb: MongoDatabase) extends HealthIndicator {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  override protected def health(): Health = {
+    Try {
+      Await.ready(mongoDb.listCollectionNames().toFuture(), Duration(1, TimeUnit.SECONDS))
+    } match {
+      case Success(_) =>
+        Health.up().build()
+      case Failure(e) =>
+        log.error("MongoDB connection is down", e)
+        Health.down().withException(e).build()
+    }
+  }
+
+}

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/health/MongoHealthChecker.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/health/MongoHealthChecker.scala
@@ -18,6 +18,7 @@ package za.co.absa.enceladus.menas.health
 import java.util.concurrent.TimeUnit
 
 import org.mongodb.scala.MongoDatabase
+import org.mongodb.scala.bson.collection.immutable.Document
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.actuate.health.{Health, HealthIndicator}
@@ -31,9 +32,11 @@ import scala.util.{Failure, Success, Try}
 class MongoHealthChecker @Autowired()(mongoDb: MongoDatabase) extends HealthIndicator {
   private val log = LoggerFactory.getLogger(this.getClass)
 
+  private val ping = Document("{ ping : 1 }")
+
   override protected def health(): Health = {
     Try {
-      Await.ready(mongoDb.listCollectionNames().toFuture(), Duration(1, TimeUnit.SECONDS))
+      Await.ready(mongoDb.runCommand(ping).toFuture(), Duration(1, TimeUnit.SECONDS))
     } match {
       case Success(_) =>
         Health.up().build()


### PR DESCRIPTION
Includes the following endpoints:
`GET /admin` - list of all actuator endpoints - requires authentication (once permissions is sorted this should be stricter #30)
`GET /admin/heapdump` - downloads a heapdump of the application - requires authentication
`GET /admin/threaddump` - list of the threaddump of the application - requires authentication
`GET /admin/loggers` - list of all the application loggers and their log levels - requires authentication
`POST /admin/loggers/{logger}` - change the log level of a logger in runtime - requires authentication
`GET /admin/health` - get a detailed status report of the application's health - DOES NOT require authentication :
```json
{
  "status": "UP",
  "details": {
    "HDFSConnection": {
      "status": "UP"
    },
    "MongoDBConnection": {
      "status": "UP"
    },
    "diskSpace": {
      "status": "UP",
      "details": {
        "total": 1000240963584,
        "free": 766613557248,
        "threshold": 10485760
      }
    }
  }
}
```