### PR TITLE
#58: Handling string formatting in represented by string numerics

### DIFF
--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
@@ -24,7 +24,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.NegationConformanceRule
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.transformations.DeepArrayTransformations
-import za.co.absa.enceladus.utils.types.Defaults
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.validation.SchemaPathValidator
 
 case class NegationRuleInterpreter(rule: NegationConformanceRule) extends RuleInterpreter {
@@ -67,7 +67,7 @@ case class NegationRuleInterpreter(rule: NegationConformanceRule) extends RuleIn
     // The above is true not only for JVM, but for the most of the CPU/hardware implementations of numeric data types
 
     def defaultValue(dt: DataType, nullable: Boolean): Any = {
-      Defaults.getGlobalDefaultWithNull(dt, field.nullable).get.orNull
+      GlobalDefaults.getDataTypeDefaultValueWithNull(dt, field.nullable).get.orNull
     }
 
     val neg = negate(inputColumn)

--- a/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
+++ b/conformance/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
@@ -24,7 +24,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.NegationConformanceRule
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.transformations.DeepArrayTransformations
-import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
+import za.co.absa.enceladus.utils.types.GlobalDefaults
 import za.co.absa.enceladus.utils.validation.SchemaPathValidator
 
 case class NegationRuleInterpreter(rule: NegationConformanceRule) extends RuleInterpreter {

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
@@ -56,7 +56,7 @@ object CustomRuleSample4 {
 
     opt[String]("row-tag").optional.action((value, config) =>
       config.copy(rowTag = Some(value))).text("use the specific row tag instead of 'ROW' for XML format")
-      .validate(value =>
+      .validate(_ =>
         if (inputFormat.isDefined && inputFormat.get.equalsIgnoreCase("xml")) {
           success
         } else {
@@ -66,7 +66,7 @@ object CustomRuleSample4 {
 
     opt[String]("delimiter").optional.action((value, config) =>
       config.copy(csvDelimiter = Some(value))).text("use the specific delimiter instead of ',' for CSV format")
-      .validate(value =>
+      .validate(_ =>
         if (inputFormat.isEmpty || inputFormat.get.equalsIgnoreCase("csv")) {
           success
         } else {
@@ -77,7 +77,7 @@ object CustomRuleSample4 {
     // no need for validation for boolean since scopt itself will do
     opt[Boolean]("header").optional.action((value, config) =>
       config.copy(csvHeader = Some(value))).text("use the header option to consider CSV header")
-      .validate(value =>
+      .validate(_ =>
         if (inputFormat.isEmpty || inputFormat.get.equalsIgnoreCase("csv")) {
           success
         } else {
@@ -144,10 +144,6 @@ object CustomRuleSample4 {
     val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/main/resources/user.keytab.example")
     implicit val progArgs: CmdConfig = CmdConfig(menasCredentials = meansCredentials) // here we may need to specify some parameters (for certain rules)
     implicit val dao: MenasDAO = RestDaoFactory.getInstance(progArgs.menasCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)
-
-    val experimentalMR= true
-    val isCatalystWorkaroundEnabled = true
-    val enableCF: Boolean = false
 
     val dfReader: DataFrameReader = {
       val dfReader0 = spark.read

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
@@ -23,13 +23,14 @@ import za.co.absa.enceladus.standardization.interpreter.dataTypes._
 import za.co.absa.enceladus.standardization.interpreter.stages.{SchemaChecker, SparkXMLHack, TypeParser}
 import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
 import za.co.absa.enceladus.utils.transformations.ArrayTransformations
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.validation.ValidationException
 
 /**
   * Object representing set of tools for performing the actual standardization
   */
 object StandardizationInterpreter{
-
+  private implicit val defaults: Defaults = GlobalDefaults
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   /**

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -21,6 +21,7 @@ import java.util.Date
 import java.util.regex.Pattern
 
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.types._
 import za.co.absa.enceladus.standardization.interpreter.dataTypes.ParseOutput
 import za.co.absa.enceladus.utils.schema.SchemaUtils
@@ -33,7 +34,7 @@ import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
 import za.co.absa.enceladus.utils.time.DateTimePattern
 import za.co.absa.enceladus.utils.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.enceladus.utils.types.TypedStructField._
-import za.co.absa.enceladus.utils.udf.UDFResult
+import za.co.absa.enceladus.utils.udf.UDFBuilder
 
 import scala.reflect.runtime.universe._
 import scala.util.Random
@@ -283,13 +284,9 @@ object TypeParser {
     }
 
     private def standardizeUsingUdf(): ParseOutput = {
-      val udfFnc = udf[UDFResult[N], String](udfParsing)
+      //TODO #1047 val udfFnc: UserDefinedFunction = UDFBuilder.typedStructFieldStringUdf(field, columnIdForUdf, defaultValue)
+      val udfFnc: UserDefinedFunction = UDFBuilder.stringUdfViaNumericParser(field.parser.get, field.nullable, columnIdForUdf, defaultValue)
       ParseOutput(udfFnc(column)("result").cast(field.dataType).as(fieldOutputName), udfFnc(column)("error"))
-    }
-
-    private def udfParsing(input: String): UDFResult[N] = {
-      val result = field.stringToTyped(input)
-      UDFResult.fromTry(result, columnIdForUdf, input, defaultValue)
     }
   }
 

--- a/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/standardization/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -284,7 +284,6 @@ object TypeParser {
     }
 
     private def standardizeUsingUdf(): ParseOutput = {
-      //TODO #1047 val udfFnc: UserDefinedFunction = UDFBuilder.typedStructFieldStringUdf(field, columnIdForUdf, defaultValue)
       val udfFnc: UserDefinedFunction = UDFBuilder.stringUdfViaNumericParser(field.parser.get, field.nullable, columnIdForUdf, defaultValue)
       ParseOutput(udfFnc(column)("result").cast(field.dataType).as(fieldOutputName), udfFnc(column)("error"))
     }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
@@ -272,8 +272,6 @@ class StandardizationInterpreter_DecimalSuite extends FunSuite with SparkTestBas
       ("06-Negative", "~54 123,789", BigDecimal("-54123.790000000000000000"), BigDecimal("-54123.789000000000000000"), Seq.empty)
     )
 
-    std.show(false)
-
     assertResult(exp)(std.as[(String, String, BigDecimal, BigDecimal, Seq[ErrorMessage])].collect().toList)
   }
 

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -18,12 +18,19 @@ package za.co.absa.enceladus.standardization.interpreter
 import org.apache.spark.sql.types.{DoubleType, FloatType, MetadataBuilder, StringType, StructField, StructType}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 
 class StandardizationInterpreter_FractionalSuite extends FunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary
+
+  private def err(value: String, cnt: Int): Seq[ErrorMessage] = {
+    val item = ErrorMessage.stdCastErr("src",value)
+    val array = Array.fill(cnt) (item)
+    array.toList
+  }
 
   private val desiredSchema = StructType(Seq(
     StructField("description", StringType, nullable = false),
@@ -34,9 +41,9 @@ class StandardizationInterpreter_FractionalSuite extends FunSuite with SparkTest
   private val desiredSchemaWithInfinity = StructType(Seq(
     StructField("description", StringType, nullable = false),
     StructField("floatField", FloatType, nullable = false,
-      new MetadataBuilder().putString("allowinfinity", value = "true").build),
+      new MetadataBuilder().putString("allow_infinity", value = "true").build),
     StructField("doubleField", DoubleType, nullable = true,
-      new MetadataBuilder().putString("allowinfinity", value = "true").build)
+      new MetadataBuilder().putString("allow_infinity", value = "true").build)
   ))
 
   test("From String") {
@@ -145,7 +152,7 @@ class StandardizationInterpreter_FractionalSuite extends FunSuite with SparkTest
       ("01-Euler", "2.71", "2.71"),
       ("02-Null", null, null),
       ("03-Long", Long.MaxValue.toString, Long.MinValue.toString),
-      ("04-infinity", "-Infinity", "Infinity"),
+      ("04-infinity", "-∞", "∞"),
       ("05-Really big", "123456789123456791245678912324789123456789123456789.12",
         "-1234567891234567912456789123247891234567891234567891234567891234567891234567891234567891234567891234567891234"
         + "567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234678912345"
@@ -207,4 +214,169 @@ class StandardizationInterpreter_FractionalSuite extends FunSuite with SparkTest
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)
   }
 
+  test("No pattern, but altered symbols") {
+    val input = Seq(
+      ("01-Positive", "+3"),
+      ("02-Negative", "~8123,4"),
+      ("03-Null", null),
+      ("04-Big", "7899012345678901234567890123456789012346789,123456789"),
+      ("05-Big II", "+1E40"),
+      ("06-Big III", "2E308"),
+      ("07-Small", "~7899012345678901234567890123456789012346789,123456789"),
+      ("08-Small II", "~1,1E40"),
+      ("09-Small III", "~3E308"),
+      ("10-Wrong", "hello"),
+      ("11-Infinity", "+∞"),
+      ("12-Negative Infinity", "~∞"),
+      ("13-Old decimal", "5.5"),
+      ("14-Old minus", "-10"),
+      ("15-Infinity as word", "Infinity")
+    )
+
+    val src = input.toDF("description", "src")
+
+    val decimalSeparator = ","
+    val minusSign = "~"
+    val srcField = "src"
+
+    val desiredSchemaWithAlters = StructType(Seq(
+      StructField("description", StringType, nullable = false),
+      StructField("src", StringType, nullable = true),
+      StructField("small", FloatType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("big", DoubleType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.DefaultValue, "+1000,001")
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("small_with_infinity", FloatType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DefaultValue, "~999999,9999")
+        .putString(MetadataKeys.AllowInfinity, "True")
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("big_with_infinity", DoubleType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.AllowInfinity, "True")
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build())
+    ))
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithAlters, "").cache()
+    logDataFrameContent(std)
+
+    val exp = List(
+      ("01-Positive", "+3", 3.0F, Some(3.0D), Some(3.0F), 3.0D, Seq.empty),
+      ("02-Negative", "~8123,4", -8123.4F, Some(-8123.4D), Some(-8123.4F), -8123.4D, Seq.empty),
+      ("03-Null", null, 0F, None, None, 0D, Array.fill(2)(ErrorMessage.stdNullErr("src")).toList),
+      ("04-Big", "7899012345678901234567890123456789012346789,123456789", 0F, Some(7.899012345678901E42D), Some(Float.PositiveInfinity), 7.899012345678901E42,
+        err("7899012345678901234567890123456789012346789,123456789", 1)
+      ),
+      ("05-Big II", "+1E40", 0F, Some(1.0E40D), Some(Float.PositiveInfinity), 1.0E40D, err("+1E40", 1)),
+      ("06-Big III", "2E308", 0F, Some(1000.001D), Some(Float.PositiveInfinity), Double.PositiveInfinity, err("2E308", 2)),
+      ("07-Small", "~7899012345678901234567890123456789012346789,123456789", 0F, Some(-7.899012345678901E42D), Some(Float.NegativeInfinity), -7.899012345678901E42,
+        err("~7899012345678901234567890123456789012346789,123456789", 1)
+      ),
+      ("08-Small II", "~1,1E40", 0F, Some(-1.1E40D), Some(Float.NegativeInfinity), -1.1E40D, err("~1,1E40", 1)),
+      ("09-Small III", "~3E308", 0F, Some(1000.001D), Some(Float.NegativeInfinity), Double.NegativeInfinity, err("~3E308", 2)),
+      ("10-Wrong", "hello", 0F, Some(1000.001D), Some(-1000000.0F), 0D, err("hello", 4)),
+      ("11-Infinity", "+∞", 0F, Some(1000.001D), Some(Float.PositiveInfinity), Double.PositiveInfinity, err("+∞", 2)),
+      ("12-Negative Infinity", "~∞", 0F, Some(1000.001D), Some(Float.NegativeInfinity), Double.NegativeInfinity, err("~∞", 2)),
+      ("13-Old decimal", "5.5", 0F, Some(1000.001D), Some(-1000000.0F), 0D, err("5.5", 4)),
+      ("14-Old minus", "-10", 0F, Some(1000.001D), Some(-1000000.0F), 0D, err("-10", 4)),
+      ("15-Infinity as word", "Infinity", 0F, Some(1000.001D), Some(-1000000.0F), 0D, err("Infinity", 4))
+    )
+    assertResult(exp)(std.as[(String, String, Float, Option[Double], Option[Float], Double, Seq[ErrorMessage])].collect().toList)
+  }
+
+  test("Using patterns") {
+    val input = Seq(
+      ("01-Positive", "+3°"),
+      ("02-Negative", "(8 123,4°)"),
+      ("03-Null", null),
+      ("04-Big", "+789 9012 345 678 901 234 567 890 123 456 789 012 346 789,123456789°"),
+      ("05-Big II", "+1E40°"),
+      ("06-Big III", "+2E308°"),
+      ("07-Small", "(789 9012 345 678 901 234 567 890 123 456 789 012 346 789,123456789°)"),
+      ("08-Small II", "(1,1E40°)"),
+      ("09-Small III", "(3E308°)"),
+      ("10-Wrong", "hello"),
+      ("11-Not adhering to pattern", "(1 234,56)"),
+      ("12-Not adhering to pattern II","+1,234.56°"),
+      ("13-Infinity", "+∞°"),
+      ("14-Negative Infinity", "(∞°)")
+    )
+
+    val src = input.toDF("description", "src")
+
+    val pattern = "+#,000.#°;(#,000.#°)"
+    val decimalSeparator = ","
+    val groupingSeparator = " "
+    val srcField = "src"
+
+    val desiredSchemaWithPatterns = StructType(Seq(
+      StructField("description", StringType, nullable = false),
+      StructField("src", StringType, nullable = true),
+      StructField("small", FloatType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.Pattern, pattern)
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .build()),
+      StructField("big", DoubleType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.Pattern, pattern)
+        .putString(MetadataKeys.DefaultValue, "+1 000,001°")
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .build()),
+      StructField("small_with_infinity", FloatType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.Pattern, pattern)
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DefaultValue, "(999 999,9999°)")
+        .putString(MetadataKeys.AllowInfinity, "True")
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .build()),
+      StructField("big_with_infinity", DoubleType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.Pattern, pattern)
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.AllowInfinity, "True")
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .build())
+    ))
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithPatterns, "").cache()
+    logDataFrameContent(std)
+
+    val exp = List(
+      ("01-Positive", "+3°", 3.0F, Some(3.0D), Some(3.0F), 3.0D, Seq.empty),
+      ("02-Negative", "(8 123,4°)", -8123.4F, Some(-8123.4D), Some(-8123.4F), -8123.4D, Seq.empty),
+      ("03-Null", null, 0F, None, None, 0D, Array.fill(2)(ErrorMessage.stdNullErr("src")).toList),
+      ("04-Big", "+789 9012 345 678 901 234 567 890 123 456 789 012 346 789,123456789°", 0F, Some(7.899012345678901E42D), Some(Float.PositiveInfinity), 7.899012345678901E42,
+        err("+789 9012 345 678 901 234 567 890 123 456 789 012 346 789,123456789°", 1)
+      ),
+      ("05-Big II", "+1E40°", 0F, Some(1.0E40D), Some(Float.PositiveInfinity), 1.0E40D, err("+1E40°", 1)),
+      ("06-Big III", "+2E308°", 0F, Some(1000.001D), Some(Float.PositiveInfinity), Double.PositiveInfinity, err("+2E308°", 2)),
+      ("07-Small", "(789 9012 345 678 901 234 567 890 123 456 789 012 346 789,123456789°)", 0F, Some(-7.899012345678901E42D), Some(Float.NegativeInfinity), -7.899012345678901E42,
+        err("(789 9012 345 678 901 234 567 890 123 456 789 012 346 789,123456789°)", 1)
+      ),
+      ("08-Small II", "(1,1E40°)", 0F, Some(-1.1E40D), Some(Float.NegativeInfinity), -1.1E40D, err("(1,1E40°)", 1)),
+      ("09-Small III", "(3E308°)", 0F, Some(1000.001D), Some(Float.NegativeInfinity), Double.NegativeInfinity, err("(3E308°)", 2)),
+      ("10-Wrong", "hello", 0F, Some(1000.001D), Some(-1000000.0F), 0D, err("hello", 4)),
+      ("11-Not adhering to pattern", "(1 234,56)", 0F, Some(1000.001D), Some(-1000000.0F), 0D, err("(1 234,56)", 4)),
+      ("12-Not adhering to pattern II","+1,234.56°", 0F, Some(1000.001D), Some(-1000000.0F), 0D, err("+1,234.56°", 4)),
+      ("13-Infinity", "+∞°", 0F, Some(1000.001D), Some(Float.PositiveInfinity), Double.PositiveInfinity, err("+∞°", 2)),
+      ("14-Negative Infinity", "(∞°)", 0F, Some(1000.001D), Some(Float.NegativeInfinity), Double.NegativeInfinity, err("(∞°)", 2))
+    )
+
+    assertResult(exp)(std.as[(String, String, Float, Option[Double], Option[Float], Double, Seq[ErrorMessage])].collect().toList)
+  }
 }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
@@ -509,7 +509,7 @@ class StandardizationInterpreter_IntegralSuite extends FunSuite with SparkTestBa
         .putString(MetadataKeys.MinusSign, minusSign)
         .build()),
       StructField("sf", ShortType, nullable = true, new MetadataBuilder()
-        .putString(MetadataKeys.DefaultValue, "§13")
+        .putString(MetadataKeys.DefaultValue, "§13") //NB 13 is 10 in decimal base
         .putString(MetadataKeys.SourceColumn, srcField)
         .putString(MetadataKeys.Radix, "7")
         .putString(MetadataKeys.MinusSign, minusSign)
@@ -521,7 +521,7 @@ class StandardizationInterpreter_IntegralSuite extends FunSuite with SparkTestBa
         .build()),
       StructField("lf", LongType, nullable = false, new MetadataBuilder()
         .putString(MetadataKeys.SourceColumn, srcField)
-        .putString(MetadataKeys.DefaultValue, "Ada")
+        .putString(MetadataKeys.DefaultValue, "Ada") // NB Ada is 7651 in decimal base
         .putString(MetadataKeys.Radix, "27")
         .putString(MetadataKeys.MinusSign, minusSign)
         .build())
@@ -547,4 +547,6 @@ class StandardizationInterpreter_IntegralSuite extends FunSuite with SparkTestBa
 
     assertResult(exp)(std.as[(String, String, Byte, Option[Short], Option[Int], Long, Seq[ErrorMessage])].collect().toList)
   }
+
+
 }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
@@ -18,9 +18,10 @@ package za.co.absa.enceladus.standardization.interpreter
 import java.text.{DecimalFormat, NumberFormat}
 import java.util.Locale
 
-import org.apache.spark.sql.types.{ByteType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{ByteType, IntegerType, LongType, MetadataBuilder, ShortType, StringType, StructField, StructType}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 
 class StandardizationInterpreter_IntegralSuite extends FunSuite with SparkTestBase with LoggerTestBase{
@@ -45,6 +46,12 @@ class StandardizationInterpreter_IntegralSuite extends FunSuite with SparkTestBa
     StructField("integersize", IntegerType, nullable = true),
     StructField("longsize", LongType, nullable = true)
   ))
+
+  private def err(value: String, cnt: Int): Seq[ErrorMessage] = {
+    val item = ErrorMessage.stdCastErr("src",value)
+    val array = Array.fill(cnt) (item)
+    array.toList
+  }
 
   test("Under-/overflow from CSV") {
     val src = spark.read
@@ -350,4 +357,194 @@ class StandardizationInterpreter_IntegralSuite extends FunSuite with SparkTestBa
     assertResult(exp)(std.as[IntegralRow].collect().sortBy(_.description).toList)
   }
 
+  test("No pattern, but altered symbols") {
+    val input = Seq(
+      ("01-Normal", "3"),
+      ("02-Null", null),
+      ("03-Far negative", "^100000000"),
+      ("04-Wrong", "hello")
+    )
+    val decimalSeparator = ","
+    val groupingSeparator = "."
+    val minusSign = "^"
+    val srcField = "src"
+
+    val src = input.toDF("description", srcField)
+
+    val desiredSchemaWithAlters = StructType(Seq(
+      StructField("description", StringType, nullable = false),
+      StructField("src", StringType, nullable = true),
+      StructField("bf", ByteType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("sf", ShortType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.DefaultValue, "^1")
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("if", IntegerType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("lf", LongType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DefaultValue, "1000")
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build())
+    ))
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithAlters, "").cache()
+    logDataFrameContent(std)
+
+    val exp = List(
+      ("01-Normal", "3", 3, Some(3), Some(3), 3, Seq.empty),
+      ("02-Null", null, 0, None, None, 1000, Array.fill(2)(ErrorMessage.stdNullErr(srcField)).toList),
+      ("03-Far negative", "^100000000", 0, Some(-1), Some(-100000000), -100000000, err("^100000000", 2)),
+      ("04-Wrong", "hello", 0, Some(-1), None, 1000, err("hello", 4))
+    )
+
+    assertResult(exp)(std.as[(String, String, Byte, Option[Short], Option[Int], Long, Seq[ErrorMessage])].collect().toList)
+  }
+
+  test("Using patterns") {
+    val input = Seq(
+      ("01-Normal", "3 feet"),
+      ("02-Null", null),
+      ("03-Far negative", "^100.000.000 feet"),
+      ("04-Wrong", "hello"),
+      ("05-Not adhering to pattern", "123,456,789 feet")
+    )
+    val pattern = "#,##0 feet"
+    val decimalSeparator = ","
+    val groupingSeparator = "."
+    val minusSign = "^"
+    val srcField = "src"
+
+    val src = input.toDF("description", srcField)
+
+    val desiredSchemaWithPatterns = StructType(Seq(
+      StructField("description", StringType, nullable = false),
+      StructField("src", StringType, nullable = true),
+      StructField("bf", ByteType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.Pattern, pattern)
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("sf", ShortType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.Pattern, pattern)
+        .putString(MetadataKeys.DefaultValue, "^1 feet")
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("if", IntegerType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.Pattern, pattern)
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("lf", LongType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.Pattern, pattern)
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DefaultValue, "1.000 feet")
+        .putString(MetadataKeys.DecimalSeparator, decimalSeparator)
+        .putString(MetadataKeys.GroupingSeparator, groupingSeparator)
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build())
+    ))
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithPatterns, "").cache()
+    logDataFrameContent(std)
+
+    val exp = List(
+      ("01-Normal", "3 feet", 3, Some(3), Some(3), 3, Seq.empty),
+      ("02-Null", null, 0, None, None, 1000, Array.fill(2)(ErrorMessage.stdNullErr(srcField)).toList),
+      ("03-Far negative", "^100.000.000 feet", 0, Some(-1), Some(-100000000), -100000000, err("^100.000.000 feet", 2)),
+      ("04-Wrong", "hello", 0, Some(-1), None, 1000, err("hello", 4)),
+      ("05-Not adhering to pattern", "123,456,789 feet", 0, Some(-1), None, 1000, err("123,456,789 feet", 4))
+    )
+
+    assertResult(exp)(std.as[(String, String, Byte, Option[Short], Option[Int], Long, Seq[ErrorMessage])].collect().toList)
+  }
+
+  test("Changed Radix") {
+    val input = Seq(
+      ("00-Null", null),
+      ("01-Binary", "+1101"),
+      ("02-Binary negative", "§1001"),
+      ("03-Septary", "35"),
+      ("04-Septary negative", "§103"),
+      ("05-Hex", "FF"),
+      ("06-Hex negative", "§A1"),
+      ("07-Hex 0x", "+0xB6"),
+      ("08-Hex 0x negative", "§0x3c"),
+      ("09-Radix 27", "Hello"),
+      ("10-Radix 27 negative", "§Mail"),
+      ("11-Wrong for all", "0XoXo")
+    )
+    val srcField = "src"
+    val minusSign = "§"
+
+    val src = input.toDF("description", srcField)
+
+    val desiredSchemaWithAlters = StructType(Seq(
+      StructField("description", StringType, nullable = false),
+      StructField("src", StringType, nullable = true),
+      StructField("bf", ByteType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.Radix, "2")
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("sf", ShortType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.DefaultValue, "§13")
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.Radix, "7")
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("if", IntegerType, nullable = true, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.Radix, "16")
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build()),
+      StructField("lf", LongType, nullable = false, new MetadataBuilder()
+        .putString(MetadataKeys.SourceColumn, srcField)
+        .putString(MetadataKeys.DefaultValue, "Ada")
+        .putString(MetadataKeys.Radix, "27")
+        .putString(MetadataKeys.MinusSign, minusSign)
+        .build())
+    ))
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithAlters, "").cache()
+    logDataFrameContent(std)
+
+    val exp = List(
+      ("00-Null"             , null   , 0 , None      , None       , 7651   , Array.fill(2)(ErrorMessage.stdNullErr(srcField)).toList),
+      ("01-Binary"           , "+1101", 13, Some(393) , Some(4353) , 20413  , Seq.empty),
+      ("02-Binary negative"  , "§1001", -9, Some(-344), Some(-4097), -19684 , Seq.empty),
+      ("03-Septary"          , "35"   , 0 , Some(26)  , Some(53)   , 86     , err("35", 1)),
+      ("04-Septary negative" , "§103" , 0 , Some(-52) , Some(-259) , -732   , err("§103", 1)),
+      ("05-Hex"              , "FF"   , 0 , Some(-10) , Some(255)  , 420    , err("FF", 2)),
+      ("06-Hex negative"     , "§A1"  , 0 , Some(-10) , Some(-161) , -271   , err("§A1", 2)),
+      ("07-Hex 0x"           , "+0xB6", 0 , Some(-10) , Some(182)  , 7651   , err("+0xB6", 3)),
+      ("08-Hex 0x negative"  , "§0x3c", 0 , Some(-10) , Some(-60)  , 7651   , err("§0x3c", 3)),
+      ("09-Radix 27"         , "Hello" , 0, Some(-10) , None       , 9325959, err("Hello", 3)),
+      ("10-Radix 27 negative", "§Mail", 0 , Some(-10) , None       , -440823, err("§Mail", 3)),
+      ("11-Wrong for all"    , "0XoXo", 0 , Some(-10) , None       , 7651   , err("0XoXo", 4))
+    )
+
+    assertResult(exp)(std.as[(String, String, Byte, Option[Short], Option[Int], Long, Seq[ErrorMessage])].collect().toList)
+  }
 }

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuite.scala
@@ -15,20 +15,14 @@
 
 package za.co.absa.enceladus.standardization.interpreter.stages
 
-import java.io.ObjectOutputStream
-
-import org.apache.commons.io.output.ByteArrayOutputStream
-import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.standardization.interpreter.stages.TypeParser.IntegralParser
 import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 import za.co.absa.enceladus.utils.types.TypedStructField.TypedStructFieldTagged
 import za.co.absa.enceladus.utils.types.parsers.NumericParser
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFResult
-
 import scala.util.Success
 
 class TypeParserSuite extends FunSuite with SparkTestBase {

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuite.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuite.scala
@@ -19,10 +19,12 @@ import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 
 class TypeParserSuite extends FunSuite with SparkTestBase {
 
   private implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+  private implicit val defaults: Defaults = GlobalDefaults
 
   test("Test standardize with sourcecolumn metadata") {
     val structFieldNoMetadata = StructField("a", StringType)

--- a/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuiteTemplate.scala
+++ b/standardization/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuiteTemplate.scala
@@ -22,7 +22,7 @@ import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.standardization.interpreter.dataTypes.ParseOutput
-import za.co.absa.enceladus.utils.types.TypedStructField
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate._
 import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
@@ -31,6 +31,7 @@ import za.co.absa.enceladus.utils.time.DateTimePattern
 trait TypeParserSuiteTemplate extends FunSuite with SparkTestBase {
 
   private implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+  private implicit val defaults: Defaults = GlobalDefaults
 
   protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String
   protected def createErrorCondition(srcField: String, target: StructField, castS: String):String

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/error/UDFLibrary.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/error/UDFLibrary.scala
@@ -59,7 +59,7 @@ case class UDFLibrary()(implicit val spark: SparkSession) {
     }
   }
 
-  spark.udf.register("cleanErrCol", cleanErrCol, ArrayType.apply(ErrorMessage.errorColSchema, false))
+  spark.udf.register("cleanErrCol", cleanErrCol, ArrayType.apply(ErrorMessage.errorColSchema, containsNull = false))
 
   private val errorColumnAppend = new UDF2[Seq[Row], Row, Seq[Row]] {
     override def call(t1: Seq[Row], t2: Row) : Seq[Row] = {
@@ -67,6 +67,6 @@ case class UDFLibrary()(implicit val spark: SparkSession) {
     }
   }
 
-  spark.udf.register("errorColumnAppend", errorColumnAppend, ArrayType.apply(ErrorMessage.errorColSchema, false))
+  spark.udf.register("errorColumnAppend", errorColumnAppend, ArrayType.apply(ErrorMessage.errorColSchema, containsNull = false))
 
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/OptionImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/OptionImplicits.scala
@@ -13,15 +13,14 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.utils.validation.field
-import za.co.absa.enceladus.utils.schema.MetadataKeys
-import za.co.absa.enceladus.utils.types.TypedStructField
-import za.co.absa.enceladus.utils.validation.ValidationIssue
+package za.co.absa.enceladus.utils.implicits
 
-object FractionalFieldValidator extends NumericFieldValidator {
-  override def validate(field: TypedStructField): Seq[ValidationIssue] = {
-    super.validate(field) ++
-      this.checkMetadataKey[Boolean](field, MetadataKeys.AllowInfinity)
+import scala.util.{Failure, Success, Try}
+
+object OptionImplicits {
+  implicit class OptionEnhancements[T](option: Option[T]) {
+    def toTry(failure: Exception): Try[T] = {
+      option.fold[Try[T]](Failure(failure))(Success(_))
+    }
   }
 }
-

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StringImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StringImplicits.scala
@@ -16,7 +16,6 @@
 package za.co.absa.enceladus.utils.implicits
 
 import java.security.InvalidParameterException
-
 import scala.annotation.tailrec
 
 object StringImplicits {
@@ -31,7 +30,7 @@ object StringImplicits {
       if (replacements.isEmpty) {
        string
       } else {
-        val result = new StringBuffer(string.length)
+        val result = new StringBuilder(string.length)
         string.foreach(char => result.append(replacements.getOrElse(char, char)))
         result.toString
       }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StringImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StringImplicits.scala
@@ -21,6 +21,22 @@ import scala.annotation.tailrec
 
 object StringImplicits {
   implicit class StringEnhancements(string: String) {
+
+    /**
+      * Replaces all occurrences of the provided characters with their mapped values
+      * @param replacements the map of replacements where key's are chars to search for and values are their replacements
+      * @return             a string with characters replaced
+      */
+    def replaceChars(replacements: Map[Char, Char]): String = {
+      if (replacements.isEmpty) {
+       string
+      } else {
+        val result = new StringBuffer(string.length)
+        string.foreach(char => result.append(replacements.getOrElse(char, char)))
+        result.toString
+      }
+    }
+
     /**
       * Function to find the first occurrence of any of the characters from the charsToFind in the string. The
       * occurrence is not considered if the character is part of a sequence within a pair of quote characters specified

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StructFieldImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/StructFieldImplicits.scala
@@ -24,9 +24,21 @@ object StructFieldImplicits {
       Try(structField.metadata.getString(key)).toOption
     }
 
+    def getMetadataChar(key: String): Option[Char] = {
+      val resultString = Try(structField.metadata.getString(key)).toOption
+      resultString.flatMap { s =>
+        if (s.length == 1) {
+          Option(s(0))
+        } else {
+          None
+        }
+      }
+    }
+
     def getMetadataStringAsBoolean(key: String): Option[Boolean] = {
       Try(structField.metadata.getString(key).toBoolean).toOption
     }
+
 
     def hasMetadataKey(key: String): Boolean = {
       structField.metadata.contains(key)

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/DecimalSymbols.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/DecimalSymbols.scala
@@ -39,8 +39,7 @@ case class DecimalSymbols(
                            permillSign: Char,
                            exponentSeparator: String,
                            infinityValue: String,
-                           naNValue: String
-) extends Serializable {
+                           naNValue: String) {
   val negativeInfinityValue = s"$minusSign$infinityValue"
 
   def toDecimalFormatSymbols: DecimalFormatSymbols = {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/DecimalSymbols.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/DecimalSymbols.scala
@@ -40,7 +40,7 @@ case class DecimalSymbols(
                            exponentSeparator: String,
                            infinityValue: String,
                            naNValue: String
-) {
+) extends Serializable {
   val negativeInfinityValue = s"$minusSign$infinityValue"
 
   def toDecimalFormatSymbols: DecimalFormatSymbols = {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/DecimalSymbols.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/DecimalSymbols.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.numeric
+
+import java.text.DecimalFormatSymbols
+import java.util.Locale
+
+/**
+  * It's an immutable wrapper of Java's DecimalFormatSymbols
+  * @param decimalSeparator   the character used for decimal sign
+  * @param groupingSeparator  the character used for thousands separator
+  * @param minusSign          the character used to represent minus sign
+  * @param patternSeparator   the character used to separate positive and negative subpatterns in a pattern
+  * @param percentSign        the character used for percent sign
+  * @param permillSign        the character used for per mille sign
+  * @param exponentSeparator  the string used to separate the mantissa from the exponent
+  * @param infinityValue      the string used to represent infinity
+  * @param naNValue           the string used to represent "not a number"
+  */
+case class DecimalSymbols(
+                           decimalSeparator: Char,
+                           groupingSeparator: Char,
+                           minusSign: Char,
+                           patternSeparator: Char,
+                           percentSign: Char,
+                           permillSign: Char,
+                           exponentSeparator: String,
+                           infinityValue: String,
+                           naNValue: String
+) {
+  val negativeInfinityValue = s"$minusSign$infinityValue"
+
+  def toDecimalFormatSymbols: DecimalFormatSymbols = {
+    val result = new DecimalFormatSymbols(Locale.US)
+    result.setDecimalSeparator(decimalSeparator)
+    result.setGroupingSeparator(groupingSeparator)
+    result.setMinusSign(minusSign)
+    result.setPatternSeparator(patternSeparator)
+    result.setPercent(percentSign)
+    result.setPerMill(permillSign)
+    result.setExponentSeparator(exponentSeparator)
+    result.setInfinity(infinityValue)
+    result.setNaN(naNValue)
+    result
+  }
+
+  def charSymbolsDifference(from: DecimalSymbols): Map[Char, Char] = {
+    Map(
+      from.decimalSeparator -> decimalSeparator,
+      from.minusSign -> minusSign,
+      from.patternSeparator -> patternSeparator,
+      from.percentSign -> percentSign,
+      from.permillSign -> permillSign,
+      from.groupingSeparator -> groupingSeparator
+    ).filter(charsDiffer)
+  }
+
+  def basicSymbolsDifference(from: DecimalSymbols): Map[Char, Char] = {
+    Map(
+      from.decimalSeparator -> decimalSeparator,
+      from.minusSign -> minusSign,
+      // replace the standard symbols to "invalidate" them
+      decimalSeparator -> from.decimalSeparator,
+      minusSign -> from.minusSign
+    ).filter(charsDiffer)
+  }
+
+  private def charsDiffer(chars: (Char, Char)): Boolean = {
+    chars._1 != chars._2
+  }
+
+}
+
+object DecimalSymbols {
+  def apply(locale: Locale): DecimalSymbols = {
+    DecimalSymbols(new DecimalFormatSymbols(locale))
+  }
+
+  def apply(dfs: DecimalFormatSymbols): DecimalSymbols = {
+    DecimalSymbols(
+      decimalSeparator = dfs.getDecimalSeparator,
+      minusSign = dfs.getMinusSign,
+      patternSeparator = dfs.getPatternSeparator,
+      percentSign = dfs.getPercent,
+      permillSign = dfs.getPerMill,
+      infinityValue = dfs.getInfinity,
+      exponentSeparator = dfs.getExponentSeparator,
+      naNValue = dfs.getNaN,
+      groupingSeparator = dfs.getGroupingSeparator
+    )
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/NumericPattern.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/NumericPattern.scala
@@ -13,15 +13,25 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.utils.validation.field
-import za.co.absa.enceladus.utils.schema.MetadataKeys
-import za.co.absa.enceladus.utils.types.TypedStructField
-import za.co.absa.enceladus.utils.validation.ValidationIssue
+package za.co.absa.enceladus.utils.numeric
 
-object FractionalFieldValidator extends NumericFieldValidator {
-  override def validate(field: TypedStructField): Seq[ValidationIssue] = {
-    super.validate(field) ++
-      this.checkMetadataKey[Boolean](field, MetadataKeys.AllowInfinity)
+import za.co.absa.enceladus.utils.types.TypePattern
+import NumericPattern._
+
+case class NumericPattern (override val pattern: String, val decimalSymbols: DecimalSymbols)
+  extends TypePattern(pattern, isDefault = (pattern == DefaultPatternValue)) {
+
+  def specifiedPattern: Option[String] = {
+    if (isDefault) {
+      None
+    } else {
+      Option(pattern)
+    }
   }
 }
 
+object NumericPattern {
+  val DefaultPatternValue = ""
+
+  def apply(decimalSymbols: DecimalSymbols): NumericPattern = NumericPattern(DefaultPatternValue, decimalSymbols)
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/Radix.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/numeric/Radix.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.numeric
+
+class Radix(val value: Int) extends AnyVal {
+  override def toString: String = {
+    s"Radix($value)"
+  }
+}
+
+object Radix {
+
+  implicit object RadixOrdering extends Ordering[Radix] {
+    override def compare(a: Radix, b: Radix): Int = a.value compare b.value
+  }
+
+  // scalastyle:off magic.number
+  val MaxSupportedRadix = Radix(36)
+  val DefaultRadix = Radix(10)
+  // scalastyle:on magic.number
+
+
+  def apply(value: Int): Radix = new Radix(value)
+  def apply(string: String): Radix = {
+    // scalastyle:off magic.number obvious meaning
+    val value = string.toLowerCase() match {
+      case "" | "dec" | "decimal" => 10
+      case "hex" | "hexadecimal"  => 16
+      case "bin" | "binary"       => 2
+      case "oct" | "octal"        => 8
+      case x                      => x.toInt
+    }
+    // scalastyle:on magic.number
+    Radix(value)
+  }
+
+  def unapply(arg: Radix): Option[Int] = Some(arg.value)
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/MetadataKeys.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/MetadataKeys.scala
@@ -20,8 +20,15 @@ object MetadataKeys {
   val SourceColumn = "sourcecolumn"
   val DefaultValue = "default"
   // date & timestamp
-  val Pattern = "pattern"
   val DefaultTimeZone = "timezone"
+  // date & timestamp & all numeric
+  val Pattern = "pattern"
+  // all numeric
+  val MinusSign = "minus_sign"
   // float and double
-  val allowInfinity = "allowinfinity"
+  val AllowInfinity = "allow_infinity"
+  val DecimalSeparator = "decimal_separator"
+  val GroupingSeparator = "grouping_separator"
+  // integral types
+  val Radix = "Radix"
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/MetadataKeys.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/MetadataKeys.scala
@@ -24,11 +24,11 @@ object MetadataKeys {
   // date & timestamp & all numeric
   val Pattern = "pattern"
   // all numeric
+  val DecimalSeparator = "decimal_separator"
+  val GroupingSeparator = "grouping_separator"
   val MinusSign = "minus_sign"
   // float and double
   val AllowInfinity = "allow_infinity"
-  val DecimalSeparator = "decimal_separator"
-  val GroupingSeparator = "grouping_separator"
   // integral types
-  val Radix = "Radix"
+  val Radix = "radix"
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/typeClasses/DoubleLike.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/typeClasses/DoubleLike.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.typeClasses
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("No member of type class DoubleLike in scope for ${T}")
+trait DoubleLike[T] extends Ordering[T]{
+  def toDouble(x: T): Double
+  def toT(d: Double): T
+}
+
+object DoubleLike {
+
+  implicit object DoubleLikeForDouble extends DoubleLike[Double] {
+    override def toDouble(x: Double): Double = x
+    override def toT(d: Double): Double = d
+    override def compare(x: Double, y: Double): Int = x.compare(y)
+  }
+
+  implicit object DoubleLikeForFloat extends DoubleLike[Float] {
+    override def toDouble(x: Float): Double = x.toDouble
+    override def toT(d: Double): Float = d.toFloat
+    override def compare(x: Float, y: Float): Int = x.compare(y)
+  }
+}
+

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/typeClasses/LongLike.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/typeClasses/LongLike.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.typeClasses
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("No member of type class LongLike in scope for ${T}")
+trait LongLike[T] extends Ordering[T]{
+  val MinValue: Long
+  val MaxValue: Long
+  def toLong(x: T): Long
+  def toT(l: Long): T
+  def stringToT(s: String): T
+}
+
+object LongLike {
+
+  implicit object LongLikeForLong extends LongLike[Long] {
+    override val MinValue: Long = Long.MinValue
+    override val MaxValue: Long = Long.MaxValue
+    override def toLong(x: Long): Long = x
+    override def toT(l: Long): Long = l
+    override def stringToT(s: String): Long = s.toLong
+    override def compare(x: Long, y: Long): Int = x.compare(y)
+  }
+
+  implicit object LongLikeForInt extends LongLike[Int] {
+    override val MinValue: Long = Int.MinValue
+    override val MaxValue: Long = Int.MaxValue
+    override def toLong(x: Int): Long = x.toLong
+    override def toT(l: Long): Int = l.toInt
+    override def stringToT(s: String): Int = s.toInt
+    override def compare(x: Int, y: Int): Int = x.compare(y)
+  }
+
+  implicit object LongLikeForShort extends LongLike[Short] {
+    override val MinValue: Long = Short.MinValue
+    override val MaxValue: Long = Short.MaxValue
+    override def toLong(x: Short): Long = x.toLong
+    override def toT(l: Long): Short = l.toShort
+    override def stringToT(s: String): Short = s.toShort
+    override def compare(x: Short, y: Short): Int = x.compare(y)
+  }
+
+  implicit object LongLikeForByte extends LongLike[Byte] {
+    override val MinValue: Long = Byte.MinValue
+    override val MaxValue: Long = Byte.MaxValue
+    override def toLong(x: Byte): Long = x.toLong
+    override def toT(l: Long): Byte = l.toByte
+    override def stringToT(s: String): Byte = s.toByte
+    override def compare(x: Byte, y: Byte): Int = x.compare(y)
+  }
+}
+

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
@@ -25,7 +25,7 @@ import za.co.absa.enceladus.utils.numeric.DecimalSymbols
 
 import scala.util.{Success, Try}
 
-abstract class Defaults {
+abstract class Defaults extends Serializable {
   /** A function which defines default values for primitive types */
   def getDataTypeDefaultValue(dt: DataType): Any
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
@@ -17,7 +17,6 @@ package za.co.absa.enceladus.utils.types
 
 import java.sql.Date
 import java.sql.Timestamp
-import java.text.DecimalFormatSymbols
 import java.util.{Locale, TimeZone}
 
 import org.apache.spark.sql.types._

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
@@ -25,7 +25,7 @@ import za.co.absa.enceladus.utils.numeric.DecimalSymbols
 
 import scala.util.{Success, Try}
 
-abstract class Defaults extends Serializable {
+abstract class Defaults {
   /** A function which defines default values for primitive types */
   def getDataTypeDefaultValue(dt: DataType): Any
 
@@ -57,7 +57,7 @@ object GlobalDefaults extends Defaults {
       case _: BooleanType   => false
       case t: DecimalType   =>
         val rest = t.precision - t.scale
-        new java.math.BigDecimal(("0" * rest) + "." + ("0" * t.scale))
+        BigDecimal(("0" * rest) + "." + ("0" * t.scale))
       case _                => throw new IllegalStateException(s"No default value defined for data type ${dt.typeName}")
     }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypePattern.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypePattern.scala
@@ -22,7 +22,7 @@ import scala.language.implicitConversions
   * @param pattern  actual pattern to format the type conversion
   * @param isDefault  marks if the pattern is actually an assigned value or taken for global defaults
   */
-abstract class TypePattern(val pattern: String, val isDefault: Boolean = false)
+abstract class TypePattern(val pattern: String, val isDefault: Boolean = false) extends Serializable
 
 object TypePattern {
   implicit def patternToString(pattern: TypePattern): String = pattern.pattern

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -213,7 +213,7 @@ object TypedStructField {
 
     private def readNumericPatternFromMetadata: Option[NumericPattern] = {
       val stringPatternOpt = getMetadataString(MetadataKeys.Pattern)
-      val decimalSymbolsOpt = readDecimalSymbolsFromMetadata
+      val decimalSymbolsOpt = readDecimalSymbolsFromMetadata()
 
       if (stringPatternOpt.nonEmpty) {
         stringPatternOpt.map(NumericPattern(_, decimalSymbolsOpt.getOrElse(defaults.getDecimalSymbols)))
@@ -222,7 +222,7 @@ object TypedStructField {
       }
     }
 
-    private def readDecimalSymbolsFromMetadata: Option[DecimalSymbols] = {
+    private def readDecimalSymbolsFromMetadata(): Option[DecimalSymbols] = {
       val ds = defaults.getDecimalSymbols
       val minusSign = getMetadataChar(MetadataKeys.MinusSign).getOrElse(ds.minusSign)
       val decimalSeparator = getMetadataChar(MetadataKeys.DecimalSeparator).getOrElse(ds.decimalSeparator)
@@ -243,13 +243,13 @@ object TypedStructField {
                                                                                       (implicit defaults: Defaults)
     extends NumericTypeStructField[L](structField, typeMin, typeMax) {
 
-    val base: Radix = readRadixFromMetadata
+    private val radix: Radix = readRadixFromMetadata
 
     override val parser: Try[IntegralParser[L]] = {
       pattern.flatMap { patternForParser =>
-      if (base != Radix.DefaultRadix) {
+      if (radix != Radix.DefaultRadix) {
         val decimalSymbols = patternForParser.map(_.decimalSymbols).getOrElse(defaults.getDecimalSymbols)
-        Try(IntegralParser.ofRadix(base, decimalSymbols, Option(typeMin), Option(typeMax)))
+        Try(IntegralParser.ofRadix(radix, decimalSymbols, Option(typeMin), Option(typeMax)))
       } else {
         Success(IntegralParser(patternForParser
           .getOrElse(NumericPattern(defaults.getDecimalSymbols)), Option(typeMin), Option(typeMax)))
@@ -261,7 +261,7 @@ object TypedStructField {
     }
 
     override def needsUdfParsing: Boolean = {
-      (base != Radix.DefaultRadix) || super.needsUdfParsing
+      (radix != Radix.DefaultRadix) || super.needsUdfParsing
     }
 
     private def readRadixFromMetadata:Radix = {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -29,7 +29,7 @@ import za.co.absa.enceladus.utils.validation.field._
 import scala.util.{Failure, Success, Try}
 
 sealed abstract class TypedStructField(structField: StructField)(implicit defaults: Defaults)
-  extends StructFieldEnhancements(structField) {
+  extends StructFieldEnhancements(structField) with Serializable {
 
   type BaseType
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -15,22 +15,29 @@
 
 package za.co.absa.enceladus.utils.types
 
+import java.sql.{Date, Timestamp}
 import org.apache.spark.sql.types._
 import za.co.absa.enceladus.utils.implicits.StructFieldImplicits.StructFieldEnhancements
+import za.co.absa.enceladus.utils.numeric._
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.time.DateTimePattern
+import za.co.absa.enceladus.utils.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.enceladus.utils.types.parsers._
 import za.co.absa.enceladus.utils.validation.ValidationIssue
-import za.co.absa.enceladus.utils.validation.field.{DateFieldValidator, DateTimeFieldValidator, FieldValidator, FractionalFieldValidator, ScalarFieldValidator, TimestampFieldValidator}
+import za.co.absa.enceladus.utils.validation.field._
 
 import scala.util.{Failure, Success, Try}
 
-sealed abstract class TypedStructField(structField: StructField) extends StructFieldEnhancements(structField) {
-  protected def convertString(string: String): Try[Any]
+sealed abstract class TypedStructField(structField: StructField)(implicit defaults: Defaults)
+  extends StructFieldEnhancements(structField) {
+
+  type BaseType
+
+  protected def convertString(string: String): Try[BaseType]
 
   def validate(): Seq[ValidationIssue]
 
-  def stringToTyped(string: String): Try[Option[Any]] = {
+  def stringToTyped(string: String): Try[Option[BaseType]] = {
     def errMsg: String = {
       s"'$string' cannot be cast to ${dataType.typeName}"
     }
@@ -66,7 +73,7 @@ sealed abstract class TypedStructField(structField: StructField) extends StructF
    *          outer Option - None means no default was defined within the metadata of the field
    *          inner Option - the actual default value or None in case the default is null
    */
-  def ownDefaultValue: Try[Option[Option[Any]]] = {
+  def ownDefaultValue: Try[Option[Option[BaseType]]] = {
     if (hasMetadataKey(MetadataKeys.DefaultValue)) {
       for {
         defaultValueString <- Try{structField.metadata.getString(MetadataKeys.DefaultValue)}
@@ -82,19 +89,18 @@ sealed abstract class TypedStructField(structField: StructField) extends StructF
    * @return Try - because the gathering of local default  may fail in conversion between types
    *         Option - the actual default value or None in case the default is null
    */
-  def defaultValueWithGlobal: Try[Option[Any]] = {
+  def defaultValueWithGlobal: Try[Option[BaseType]] = {
     for {
       localDefault <- ownDefaultValue
       result <- localDefault match {
         case Some(value) => Success(value)
-        case None => Defaults.getGlobalDefaultWithNull(dataType, nullable)
+        case None => defaults.getDataTypeDefaultValueWithNull(dataType, nullable).map(_.map(_.asInstanceOf[BaseType]))
       }
     } yield result
   }
 
-  def pattern: Try[Option[TypePattern]] = {
-    Success(None)
-  }
+  def pattern: Try[Option[TypePattern]] = Success(None)
+  def needsUdfParsing: Boolean = false
 
   def name: String = structField.name
   def nullable: Boolean = structField.nullable
@@ -125,38 +131,45 @@ object TypedStructField {
    * @param structField the structField to wrap TypedStructField around
    * @return            the object of non-abstract TypedStructField successor class relevant to the StructField dataType
    */
-  def apply(structField: StructField): TypedStructField = {
+  def apply(structField: StructField)(implicit defaults: Defaults): TypedStructField = {
     structField.dataType match {
       case _: StringType    => new StringTypeStructField(structField)
       case _: BooleanType   => new BooleanTypeStructField(structField)
-      case _: ByteType      => new IntegralTypeStructField(structField)
-      case _: ShortType     => new IntegralTypeStructField(structField)
-      case _: IntegerType   => new IntegralTypeStructField(structField)
-      case _: LongType      => new IntegralTypeStructField(structField)
-      case _: FloatType     => new FractionalTypeStructField(structField)
-      case _: DoubleType    => new FractionalTypeStructField(structField)
+      case _: ByteType      => new ByteTypeStructField(structField)
+      case _: ShortType     => new ShortTypeStructField(structField)
+      case _: IntegerType   => new IntTypeStructField(structField)
+      case _: LongType      => new LongTypeStructField(structField)
+      case _: FloatType     => new FloatTypeStructField(structField)
+      case _: DoubleType    => new DoubleTypeStructField(structField)
       case dt: DecimalType  => new DecimalTypeStructField(structField, dt)
-      case _: TimestampType => new DateTimeTypeStructField(structField, TimestampFieldValidator)
-      case _: DateType      => new DateTimeTypeStructField(structField, DateFieldValidator)
+      case _: TimestampType => new TimestampTypeStructField(structField)
+      case _: DateType      => new DateTypeStructField(structField)
       case at: ArrayType    => new ArrayTypeStructField(structField, at)
       case st: StructType   => new StructTypeStructField(structField, st)
       case _                => new GeneralTypeStructField(structField)
     }
   }
 
-  def asStringTypedStructField(structField: StructField): StringTypeStructField = TypedStructField(structField).asInstanceOf[StringTypeStructField]
-  def asBooleanTypeStructField(structField: StructField): BooleanTypeStructField = TypedStructField(structField).asInstanceOf[BooleanTypeStructField]
-  def asIntegralTypeStructField(structField: StructField): IntegralTypeStructField = TypedStructField(structField).asInstanceOf[IntegralTypeStructField]
-  def asFractionalTypeStructField(structField: StructField): FractionalTypeStructField = TypedStructField(structField).asInstanceOf[FractionalTypeStructField]
-  def asDecimalTypeStructField(structField: StructField): DecimalTypeStructField = TypedStructField(structField).asInstanceOf[DecimalTypeStructField]
-  def asDateTimeTypeStructField(structField: StructField): DateTimeTypeStructField = TypedStructField(structField).asInstanceOf[DateTimeTypeStructField]
-  def asArrayTypeStructField(structField: StructField): ArrayTypeStructField = TypedStructField(structField).asInstanceOf[ArrayTypeStructField]
-  def asStructTypeStructField(structField: StructField): StructTypeStructField = TypedStructField(structField).asInstanceOf[StructTypeStructField]
+  def asNumericTypeStructField[N](structField: StructField)(implicit defaults: Defaults): NumericTypeStructField[N] =
+    TypedStructField(structField).asInstanceOf[NumericTypeStructField[N]]
+  def asDateTimeTypeStructField[T](structField: StructField)(implicit defaults: Defaults): DateTimeTypeStructField[T] =
+    TypedStructField(structField).asInstanceOf[DateTimeTypeStructField[T]]
+  def asArrayTypeStructField(structField: StructField)(implicit defaults: Defaults): ArrayTypeStructField =
+    TypedStructField(structField).asInstanceOf[ArrayTypeStructField]
+  def asStructTypeStructField(structField: StructField)(implicit defaults: Defaults): StructTypeStructField =
+    TypedStructField(structField).asInstanceOf[StructTypeStructField]
 
-  def unapply(typedStructField: TypedStructField): Option[StructField] = Some(typedStructField.structField)
+  def unapply[T](typedStructField: TypedStructField): Option[StructField] = Some(typedStructField.structField)
 
-  final class StringTypeStructField private[TypedStructField] (structField: StructField) extends TypedStructField(structField) {
-    override protected def convertString(string: String): Try[Any] = {
+  abstract class TypedStructFieldTagged[T](structField: StructField)(implicit defaults: Defaults)
+    extends TypedStructField(structField) {
+    override type BaseType = T
+  }
+  // StringTypeStructField
+  final class StringTypeStructField private[TypedStructField](structField: StructField)
+                                                              (implicit defaults: Defaults)
+    extends TypedStructFieldTagged[String](structField) {
+    override protected def convertString(string: String): Try[String] = {
       Success(string)
     }
 
@@ -165,8 +178,11 @@ object TypedStructField {
     }
   }
 
-  final class BooleanTypeStructField private[TypedStructField] (structField: StructField) extends TypedStructField(structField) {
-    override protected def convertString(string: String): Try[Any] = {
+  // BooleanTypeStructField
+  final class BooleanTypeStructField private[TypedStructField](structField: StructField)
+                                                               (implicit defaults: Defaults)
+    extends TypedStructFieldTagged[Boolean](structField) {
+    override protected def convertString(string: String): Try[Boolean] = {
       Try{string.toBoolean}
     }
 
@@ -175,36 +191,112 @@ object TypedStructField {
     }
   }
 
-  final class IntegralTypeStructField private[TypedStructField] (structField: StructField) extends TypedStructField(structField) {
-    val parser: IntegralParser = IntegralParser
+  // NumericTypeStructField
+  sealed abstract class NumericTypeStructField[N](structField: StructField, val typeMin: N, val typeMax: N)
+                                                 (implicit defaults: Defaults)
+    extends TypedStructFieldTagged[N](structField) {
+    val allowInfinity: Boolean = false
+    val parser: Try[NumericParser[N]]
 
-    override protected def convertString(string: String): Try[Any] = {
-      Try{
-        dataType match {
-          case ByteType => parser.parseByte(string)
-          case ShortType => parser.parseShort(string)
-          case IntegerType => parser.parseInt(string)
-          case LongType => parser.parseLong(string)
-        }
+    override def pattern: Try[Option[NumericPattern]] = Success(readNumericPatternFromMetadata)
+
+    override def needsUdfParsing: Boolean = {
+      pattern.toOption.flatten.exists(!_.isDefault)
+    }
+
+    override protected def convertString(string: String): Try[N] = {
+      for {
+        parserToUse <- parser
+        parsed <- parserToUse.parse(string)
+      } yield parsed
+    }
+
+    private def readNumericPatternFromMetadata: Option[NumericPattern] = {
+      val stringPatternOpt = getMetadataString(MetadataKeys.Pattern)
+      val decimalSymbolsOpt = readDecimalSymbolsFromMetadata
+
+      if (stringPatternOpt.nonEmpty) {
+        stringPatternOpt.map(NumericPattern(_, decimalSymbolsOpt.getOrElse(defaults.getDecimalSymbols)))
+      } else {
+        decimalSymbolsOpt.map(NumericPattern(_))
       }
     }
 
-    override def validate(): Seq[ValidationIssue] = {
-      ScalarFieldValidator.validate(this)
+    private def readDecimalSymbolsFromMetadata: Option[DecimalSymbols] = {
+      val ds = defaults.getDecimalSymbols
+      val minusSign = getMetadataChar(MetadataKeys.MinusSign).getOrElse(ds.minusSign)
+      val decimalSeparator = getMetadataChar(MetadataKeys.DecimalSeparator).getOrElse(ds.decimalSeparator)
+      val groupingSeparator = getMetadataChar(MetadataKeys.GroupingSeparator).getOrElse(ds.groupingSeparator)
+
+      if ((ds.minusSign != minusSign) || (ds.decimalSeparator != decimalSeparator) || (ds.groupingSeparator != groupingSeparator)) {
+        Option(ds.copy(minusSign = minusSign, decimalSeparator = decimalSeparator, groupingSeparator = groupingSeparator))
+      } else {
+        None
+      }
     }
   }
 
-  final class FractionalTypeStructField private[TypedStructField] (structField: StructField) extends TypedStructField(structField) {
+  // IntegralTypeStructField
+  sealed abstract class IntegralTypeStructField[L: LongLike] private[TypedStructField](structField: StructField,
+                                                                                       override val typeMin: L,
+                                                                                       override val typeMax: L)
+                                                                                      (implicit defaults: Defaults)
+    extends NumericTypeStructField[L](structField, typeMin, typeMax) {
 
-    val allowInfinity: Boolean = getMetadataStringAsBoolean(MetadataKeys.allowInfinity).getOrElse(false)
+    val base: Radix = readRadixFromMetadata
 
-    val parser: FractionalParser = FractionalParser(allowInfinity)
+    override val parser: Try[IntegralParser[L]] = {
+      pattern.flatMap { patternForParser =>
+      if (base != Radix.DefaultRadix) {
+        val decimalSymbols = patternForParser.map(_.decimalSymbols).getOrElse(defaults.getDecimalSymbols)
+        Try(IntegralParser.ofRadix(base, decimalSymbols, Option(typeMin), Option(typeMax)))
+      } else {
+        Success(IntegralParser(patternForParser
+          .getOrElse(NumericPattern(defaults.getDecimalSymbols)), Option(typeMin), Option(typeMax)))
+      }}
+    }
 
-    override protected def convertString(string: String): Try[Any] = {
-      Try{
-        dataType match {
-          case FloatType => parser.parseFloat(string)
-          case DoubleType => parser.parseDouble(string)
+    override def validate(): Seq[ValidationIssue] = {
+      IntegralFieldValidator.validate(this)
+    }
+
+    override def needsUdfParsing: Boolean = {
+      (base != Radix.DefaultRadix) || super.needsUdfParsing
+    }
+
+    private def readRadixFromMetadata:Radix = {
+      Try(getMetadataString(MetadataKeys.Radix).map(Radix(_))).toOption.flatten.getOrElse(Radix.DefaultRadix)
+    }
+  }
+
+  final class ByteTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends IntegralTypeStructField(structField, Byte.MinValue, Byte.MaxValue)
+
+  final class ShortTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends IntegralTypeStructField(structField, Short.MinValue, Short.MaxValue)
+
+  final class IntTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends IntegralTypeStructField(structField, Int.MinValue, Int.MaxValue)
+
+  final class LongTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends IntegralTypeStructField(structField, Long.MinValue, Long.MaxValue)
+
+  // FractionalTypeStructField
+  sealed abstract class FractionalTypeStructField[D: DoubleLike] private[TypedStructField](structField: StructField,
+                                                                                           override val typeMin: D,
+                                                                                           override val typeMax: D)
+                                                                                          (implicit defaults: Defaults)
+    extends NumericTypeStructField[D](structField, typeMin, typeMax) {
+
+    override val allowInfinity: Boolean = getMetadataStringAsBoolean(MetadataKeys.AllowInfinity).getOrElse(false)
+
+    override val parser: Try[NumericParser[D]] = {
+      pattern.map {patternOpt =>
+        val patternForParser = patternOpt.getOrElse(NumericPattern(defaults.getDecimalSymbols))
+        if (allowInfinity) {
+          FractionalParser.withInfinity(patternForParser)
+        } else {
+          FractionalParser(patternForParser, typeMin, typeMax)
         }
       }
     }
@@ -214,60 +306,106 @@ object TypedStructField {
     }
   }
 
-  final class DecimalTypeStructField private[TypedStructField] (structField: StructField, override val dataType: DecimalType) extends TypedStructField(structField) {
-    val parser = DecimalParser(precision, scale)
+  // FloatTypeStructField
+  final class FloatTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends FractionalTypeStructField(structField, Float.MinValue, Float.MaxValue)
 
-    override protected def convertString(string: String): Try[Any] = {
-      Try{parser.parseDecimal(string)}
-    }
+  // DoubleTypeStructField
+  final class DoubleTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends FractionalTypeStructField(structField, Double.MinValue, Double.MaxValue)
+
+  // DecimalTypeStructField
+  final class DecimalTypeStructField private[TypedStructField](structField: StructField,
+                                                               override val dataType: DecimalType)
+                                                              (implicit defaults: Defaults)
+    extends NumericTypeStructField[BigDecimal](
+      structField,
+      DecimalTypeStructField.minPossible(dataType),
+      DecimalTypeStructField.maxPossible(dataType)
+    ){
+
+    override val parser: Try[DecimalParser] =
+      pattern.map { patternOpt =>
+        DecimalParser(patternOpt.getOrElse(NumericPattern(defaults.getDecimalSymbols)), Option(typeMin), Option(typeMax))
+      }
 
     override def validate(): Seq[ValidationIssue] = {
-      ScalarFieldValidator.validate(this)
+      NumericFieldValidator.validate(this)
     }
 
     def precision: Int = dataType.precision
     def scale: Int = dataType.scale
   }
 
-  final class DateTimeTypeStructField private[TypedStructField] (structField: StructField, validator: DateTimeFieldValidator)
-    extends TypedStructField(structField) {
+  object DecimalTypeStructField {
+    def maxPossible(decimalType: DecimalType): BigDecimal = {
+      val precision: Int = decimalType.precision
+      val scale: Int = decimalType.scale
+      val postDecimalString = "9" * scale
+      val preDecimalString = "9" * (precision - scale)
+      BigDecimal(s"$preDecimalString.$postDecimalString")
+    }
+
+    def minPossible(decimalType: DecimalType): BigDecimal = {
+      -maxPossible(decimalType)
+    }
+  }
+
+  // DateTimeTypeStructField
+  sealed abstract class DateTimeTypeStructField[T] private[TypedStructField](structField: StructField, validator: DateTimeFieldValidator)
+                                                                         (implicit defaults: Defaults)
+    extends TypedStructFieldTagged[T](structField) {
 
     override def pattern: Try[Option[DateTimePattern]] = {
       parser.map(x => Some(x.pattern))
     }
 
     lazy val parser: Try[DateTimeParser] = {
-      val patternOpt: Option[String] = getMetadataString(MetadataKeys.Pattern)
-      val patternToUse = patternOpt match {
-        case Some(pattern) =>
-          val timeZoneOpt = getMetadataString(MetadataKeys.DefaultTimeZone)
-          DateTimePattern(pattern, timeZoneOpt)
-        case None =>
-          DateTimePattern.asDefault(Defaults.getGlobalFormat(dataType), None)
-      }
+      val patternToUse = readDateTimePattern
       Try{
         DateTimeParser(patternToUse)
-      }
-    }
-
-    override protected def convertString(string: String): Try[Any] = {
-      dataType match {
-        case TimestampType => parser.map(_.parseTimestamp(string))
-        case DateType => parser.map(_.parseDate(string))
       }
     }
 
     override def validate(): Seq[ValidationIssue] = {
       validator.validate(this)
     }
+
+    private def readDateTimePattern: DateTimePattern = {
+      getMetadataString(MetadataKeys.Pattern).map { pattern =>
+        val timeZoneOpt = getMetadataString(MetadataKeys.DefaultTimeZone)
+        DateTimePattern(pattern, timeZoneOpt)
+      }.getOrElse(
+        DateTimePattern.asDefault(defaults.getStringPattern(structField.dataType), None)
+      )
+    }
   }
 
-  sealed trait WeakSupport {
-    this: TypedStructField =>
+  // TimestampTypeStructField
+  final class TimestampTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends DateTimeTypeStructField[Timestamp](structField, TimestampFieldValidator) {
+
+    override protected def convertString(string: String): Try[Timestamp] = {
+      parser.map(_.parseTimestamp(string))
+    }
+
+  }
+
+  // DateTypeStructField
+  final class DateTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends DateTimeTypeStructField[Date](structField, DateFieldValidator) {
+
+    override protected def convertString(string: String): Try[Date] = {
+      parser.map(_.parseDate(string))
+    }
+  }
+
+  sealed trait WeakSupport[T] {
+    this: TypedStructFieldTagged[T] =>
 
     def structField: StructField
 
-    def convertString(string: String): Try[Any] = {
+    def convertString(string: String): Try[T] = {
       Failure(new IllegalStateException(s"No converter defined for data type ${structField.dataType.typeName}"))
     }
 
@@ -276,14 +414,13 @@ object TypedStructField {
     }
   }
 
-  final class ArrayTypeStructField private[TypedStructField] (structField: StructField, override val dataType: ArrayType)
-    extends TypedStructField(structField)
-    with WeakSupport
+  final class ArrayTypeStructField private[TypedStructField](structField: StructField, override val dataType: ArrayType)
+                                                            (implicit defaults: Defaults)
+    extends TypedStructFieldTagged[Any](structField) with WeakSupport[Any]
 
-  final class StructTypeStructField(structField: StructField, override val dataType: StructType)
-    extends TypedStructField(structField)
-    with WeakSupport
+  final class StructTypeStructField(structField: StructField, override val dataType: StructType)(implicit defaults: Defaults)
+    extends TypedStructFieldTagged[Any](structField) with WeakSupport[Any]
 
-  final class GeneralTypeStructField private[TypedStructField] (structField: StructField) extends TypedStructField(structField) with WeakSupport
-
+  final class GeneralTypeStructField private[TypedStructField](structField: StructField)(implicit defaults: Defaults)
+    extends TypedStructFieldTagged[Any](structField) with WeakSupport[Any]
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/DecimalParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/DecimalParser.scala
@@ -27,9 +27,9 @@ class DecimalParser(override val pattern: NumericPattern,
   override protected val numberConversion: Number => BigDecimal = {n => BigDecimal(n.asInstanceOf[java.math.BigDecimal])}
 
   protected val decimalFormat: Option[DecimalFormat] = pattern.specifiedPattern.map (s => {
-    val df = new DecimalFormat(s, pattern.decimalSymbols.toDecimalFormatSymbols)
-    df.setParseBigDecimal(true)
-    df
+    val format = new DecimalFormat(s, pattern.decimalSymbols.toDecimalFormatSymbols)
+    format.setParseBigDecimal(true)
+    format
   })
 }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/FractionalParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/FractionalParser.scala
@@ -15,35 +15,54 @@
 
 package za.co.absa.enceladus.utils.types.parsers
 
-class FractionalParser (val allowInfinity: Boolean) {
+import java.text.DecimalFormat
 
-  def parseFloat(value: String): Float = {
-    val result = value.toFloat
-    if (result == Float.NaN) {
-      throw new NumberFormatException(s"The Float value '$value' is NaN")
-    }
-    if (result.isInfinity && (!allowInfinity)) {
-      throw new NumberFormatException(s"The Float value '$value' is infinite or out of range")
-    }
-    result
-  }
+import za.co.absa.enceladus.utils.numeric.NumericPattern
+import za.co.absa.enceladus.utils.typeClasses.DoubleLike
+import za.co.absa.enceladus.utils.types.parsers.NumericParser.NumericParserException
 
-  def parseDouble(value: String): Double = {
-    val result = value.toDouble
-    if (result == Double.NaN) {
-      throw new NumberFormatException(s"The Double value '$value' is NaN")
-    }
-    if (result.isInfinity && (!allowInfinity)) {
-      throw new NumberFormatException(s"The Double value '$value' is infinite or out of range")
-    }
-    result
-  }
+class FractionalParser[D: DoubleLike] private(override val pattern: NumericPattern,
+                                              override val min: Option[D],
+                                              override val max: Option[D])
+  extends NumericParser(pattern, min, max) with ParseViaDecimalFormat[D] {
 
-  def format(value: Double): String = {
-    value.toString
+  private val ev = implicitly[DoubleLike[D]]
+
+  override protected val stringConversion: String => D = stringToDWithoutPattern
+  override protected val numberConversion: Number => D = {number => ev.toT(number.doubleValue())}
+
+  protected val decimalFormat: Option[DecimalFormat] = pattern
+    .specifiedPattern
+    .map(new DecimalFormat(_, pattern.decimalSymbols.toDecimalFormatSymbols))
+
+  private def stringToDWithoutPattern(string: String): D = {
+    val resultAsDouble = string match {
+      case pattern.decimalSymbols.naNValue => Double.NaN
+      case pattern.decimalSymbols.infinityValue => Double.PositiveInfinity
+      case pattern.decimalSymbols.negativeInfinityValue => Double.NegativeInfinity
+      case _ => string.toDouble
+    }
+    ev.toT(resultAsDouble)
   }
 }
 
-object FractionalParser extends FractionalParser(allowInfinity = true) {
-  def apply(allowInfinity: Boolean): FractionalParser = new FractionalParser(allowInfinity)
+object FractionalParser {
+  def apply(pattern: NumericPattern,
+            min: Double = Double.MinValue,
+            max: Double = Double.MaxValue): FractionalParser[Double] = {
+    new FractionalParser(pattern, Option(min), Option(max))
+  }
+
+  def apply[D: DoubleLike](pattern: NumericPattern,
+                           min: D,
+                           max: D): FractionalParser[D] = {
+    new FractionalParser[D](pattern, Option(min), Option(max))
+  }
+
+  def withInfinity[D: DoubleLike](pattern: NumericPattern): FractionalParser[D] = {
+    val ev = implicitly[DoubleLike[D]]
+    val negativeInfinity = ev.toT(Double.NegativeInfinity)
+    val positiveInfinity = ev.toT(Double.PositiveInfinity)
+    new FractionalParser(pattern, Option(negativeInfinity), Option(positiveInfinity))
+  }
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser.scala
@@ -78,10 +78,10 @@ object IntegralParser {
     Try(Radix(string))
   }
 
-  private class RadixIntegralParser[N: LongLike] (override val radix: Radix,
-                                                  decimalSymbols: DecimalSymbols,
-                                    override val min: Option[N],
-                                    override val max: Option[N])
+  final class RadixIntegralParser[N: LongLike] (override val radix: Radix,
+                                                decimalSymbols: DecimalSymbols,
+                                                override val min: Option[N],
+                                                override val max: Option[N])
     extends IntegralParser(NumericPattern(decimalSymbols), min, max) {
 
     private val minBI = BigInteger.valueOf(min.map(ev.toLong).getOrElse(Long.MinValue))
@@ -148,9 +148,9 @@ object IntegralParser {
 
   }
 
-  private class PatternIntegralParser[N: LongLike](override val pattern: NumericPattern,
-                                                   override val min: Option[N],
-                                                   override val max: Option[N])
+  final class PatternIntegralParser[N: LongLike](override val pattern: NumericPattern,
+                                                 override val min: Option[N],
+                                                 override val max: Option[N])
     extends IntegralParser(pattern, min, max) with ParseViaDecimalFormat[N] {
     override val radix: Radix = Radix.DefaultRadix
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser.scala
@@ -19,10 +19,8 @@ import java.math.BigInteger
 import java.text.DecimalFormat
 
 import scala.util.{Failure, Success, Try}
-import za.co.absa.enceladus.utils.numeric.Radix.RadixOrdering._
 import za.co.absa.enceladus.utils.numeric.{DecimalSymbols, NumericPattern, Radix}
 import za.co.absa.enceladus.utils.typeClasses.LongLike
-import za.co.absa.enceladus.utils.types.parsers.NumericParser.NumericParserException
 
 abstract class IntegralParser[N: LongLike] private(override val pattern: NumericPattern,
                                                    override val min: Option[N],
@@ -85,12 +83,6 @@ object IntegralParser {
                                     override val min: Option[N],
                                     override val max: Option[N])
     extends IntegralParser(NumericPattern(decimalSymbols), min, max) {
-    if (radix.value <= 0) {
-      throw new NumericParserException(s"Radix has to be greater then 0, $radix was entered")
-    }
-    if (radix > Radix.MaxSupportedRadix) {
-      throw new NumericParserException(s"Maximum supported radix is ${Radix.MaxSupportedRadix.value}, $radix was entered")
-    }
 
     private val minBI = BigInteger.valueOf(min.map(ev.toLong).getOrElse(Long.MinValue))
     private val maxBI = BigInteger.valueOf(max.map(ev.toLong).getOrElse(Long.MaxValue))
@@ -165,7 +157,7 @@ object IntegralParser {
     override protected val numberConversion: Number => N = {number =>
       val longValue = number.longValue()
       if ((longValue > ev.MaxValue) || (longValue < ev.MinValue)) {
-        throw this.outOfBoundsException(number.toString)
+        throw outOfBoundsException(number.toString)
       }
       ev.toT(longValue)
     }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser.scala
@@ -15,26 +15,164 @@
 
 package za.co.absa.enceladus.utils.types.parsers
 
-class IntegralParser {
-  def parseByte(value: String): Byte = {
-    value.toByte
-  }
+import java.math.BigInteger
+import java.text.DecimalFormat
 
-  def parseShort(value: String): Short = {
-    value.toShort
-  }
+import scala.util.{Failure, Success, Try}
+import za.co.absa.enceladus.utils.numeric.Radix.RadixOrdering._
+import za.co.absa.enceladus.utils.numeric.{DecimalSymbols, NumericPattern, Radix}
+import za.co.absa.enceladus.utils.typeClasses.LongLike
+import za.co.absa.enceladus.utils.types.parsers.NumericParser.NumericParserException
 
-  def parseInt(value: String): Int = {
-    value.toInt
-  }
+abstract class IntegralParser[N: LongLike] private(override val pattern: NumericPattern,
+                                                   override val min: Option[N],
+                                                   override val max: Option[N])
+  extends NumericParser[N](pattern, min, max) {
+  protected val ev: LongLike[N] = implicitly[LongLike[N]]
 
-  def parseLong(value: String): Long = {
-    value.toLong
-  }
+  val radix: Radix
 
-  def format(value: Long): String = {
-    value.toString
-  }
+  override protected val stringConversion: String => N = {string => ev.stringToT(string)}
 }
 
-object IntegralParser extends IntegralParser
+object IntegralParser {
+  def apply(pattern: NumericPattern,
+            min: Long = Long.MinValue,
+            max: Long = Long.MaxValue): IntegralParser[Long] = {
+    new PatternIntegralParser(pattern, Option(min), Option(max))
+  }
+
+  def apply[N: LongLike](pattern: NumericPattern,
+                         min: Option[N],
+                         max: Option[N]): IntegralParser[N] = {
+    new PatternIntegralParser(pattern, min, max)
+  }
+
+  def ofRadix(radix: Radix,
+              decimalSymbols: DecimalSymbols = NumericParser.defaultDecimalSymbols,
+              min: Long = Long.MinValue,
+              max: Long = Long.MaxValue): IntegralParser[Long] = {
+    new RadixIntegralParser(radix, decimalSymbols, Option(min), Option(max))
+  }
+
+  def ofRadix[N: LongLike](radix: Radix,
+                           decimalSymbols: DecimalSymbols,
+                           min: Option[N],
+                           max: Option[N]): IntegralParser[N] = {
+    new RadixIntegralParser[N](radix, decimalSymbols, min, max)
+  }
+
+  def ofStringRadix(stringRadix: String,
+                    decimalSymbols: DecimalSymbols = NumericParser.defaultDecimalSymbols,
+                    min: Long = Long.MinValue,
+                    max: Long = Long.MaxValue): IntegralParser[Long] = {
+    ofRadix(Radix(stringRadix), decimalSymbols, min, max)
+  }
+
+  def ofStringRadix[N: LongLike](stringRadix: String,
+                                 decimalSymbols: DecimalSymbols,
+                                 min: Option[N],
+                                 max: Option[N]): IntegralParser[N] = {
+    ofRadix(Radix(stringRadix), decimalSymbols, min, max)
+  }
+
+  def tryStringToBase(string: String): Try[Radix] = {
+    Try(Radix(string))
+  }
+
+  private class RadixIntegralParser[N: LongLike] (override val radix: Radix,
+                                                  decimalSymbols: DecimalSymbols,
+                                    override val min: Option[N],
+                                    override val max: Option[N])
+    extends IntegralParser(NumericPattern(decimalSymbols), min, max) {
+    if (radix.value <= 0) {
+      throw new NumericParserException(s"Radix has to be greater then 0, $radix was entered")
+    }
+    if (radix > Radix.MaxSupportedRadix) {
+      throw new NumericParserException(s"Maximum supported radix is ${Radix.MaxSupportedRadix.value}, $radix was entered")
+    }
+
+    private val minBI = BigInteger.valueOf(min.map(ev.toLong).getOrElse(Long.MinValue))
+    private val maxBI = BigInteger.valueOf(max.map(ev.toLong).getOrElse(Long.MaxValue))
+
+    override def parse(string: String): Try[N] = {
+      val preprocessed = normalizeBasicSymbols(string)
+      radix match {
+        case Radix.DefaultRadix => Try{ev.stringToT(preprocessed)}.flatMap(valueWithinBounds(_, string))
+        case Radix(16) => toNWithBoundCheck(clearHexString(preprocessed), string)// scalastyle:ignore magic.number obvious meaning
+        case _ => toNWithBoundCheck(preprocessed, string)
+      }
+    }
+
+    override def format(value: N): String = {
+      // scalastyle:off magic.number obvious meaning
+      val longValue = ev.toLong(value)
+      val result = radix match {
+        case Radix(10) => longValue.toString
+        case Radix(16) => longValue.toHexString
+        case Radix(2)  => longValue.toBinaryString
+        case Radix(8)  => longValue.toOctalString
+        case Radix(b)  =>
+          val bigValue = BigInteger.valueOf(longValue)
+          bigValue.toString(b)
+      }
+      // scalastyle:on magic.number
+      denormalizeBasicSymbols(result)
+    }
+
+    private def toNWithBoundCheck(string: String, originalInput: String): Try[N] = {
+      val bigIntegerTry = Try{new BigInteger(string, radix.value)}
+      bigIntegerTry.flatMap(bigValue => {
+        if (bigValue.compareTo(maxBI) > 0) { // too big
+          Failure(outOfBoundsException(originalInput))
+        } else if (bigValue.compareTo(minBI) < 0) { // too small
+          Failure(outOfBoundsException(originalInput))
+        } else {
+          Success(ev.toT(bigValue.longValue()))
+        }
+      })
+    }
+
+    private def clearHexString(string: String): String = {
+      // supporting 0xFF style format of hexadecimals
+      val longEnoughString = string + "   "
+      val prefix2 = longEnoughString.substring(0, 2).toLowerCase
+      if (prefix2 == "0x") {
+        string.substring(2)
+      } else {
+        val prefix3 = longEnoughString.substring(0, 3).toLowerCase
+        if (prefix3 == "-0x") {
+          "-" + string.substring(3)
+        } else if (prefix3 == "+0x") {
+          string.substring(3)
+        } else {
+          string
+        }
+      }
+    }
+
+    protected def parseUsingPattern(stringToParse: String):Try[N] = parse(stringToParse)
+    protected def formatUsingPattern(value: N): String = format(value)
+
+  }
+
+  private class PatternIntegralParser[N: LongLike](override val pattern: NumericPattern,
+                                                   override val min: Option[N],
+                                                   override val max: Option[N])
+    extends IntegralParser(pattern, min, max) with ParseViaDecimalFormat[N] {
+    override val radix: Radix = Radix.DefaultRadix
+
+    override protected val numberConversion: Number => N = {number =>
+      val longValue = number.longValue()
+      if ((longValue > ev.MaxValue) || (longValue < ev.MinValue)) {
+        throw this.outOfBoundsException(number.toString)
+      }
+      ev.toT(longValue)
+    }
+    override protected val decimalFormat: Option[DecimalFormat] = pattern.specifiedPattern.map(s => {
+      val df = new DecimalFormat(s, pattern.decimalSymbols.toDecimalFormatSymbols)
+      df.setParseIntegerOnly(true)
+      df
+    })
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/NumericParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/NumericParser.scala
@@ -31,7 +31,11 @@ abstract class NumericParser[N: Ordering](val pattern: NumericPattern,
 
   def parse(string: String): Try[N] = {
     for {
-      parsed <- pattern.specifiedPattern.map(_ => parseUsingPattern(string)).getOrElse(parseWithoutPattern(string))
+      parsed <- if (pattern.specifiedPattern.isDefined) {
+          parseUsingPattern(string)
+        } else {
+          parseWithoutPattern(string)
+        }
       result <- valueWithinBounds(parsed)
     } yield result
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/NumericParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/NumericParser.scala
@@ -22,7 +22,8 @@ import scala.util.{Failure, Success, Try}
 
 abstract class NumericParser[N: Ordering](val pattern: NumericPattern,
                                           val min: Option[N],
-                                          val max: Option[N]) {
+                                          val max: Option[N])
+  extends Serializable {
 
   protected val stringConversion: String => N
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/NumericParser.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/NumericParser.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.types.parsers
+
+import java.util.Locale
+import za.co.absa.enceladus.utils.numeric.{DecimalSymbols, NumericPattern}
+import za.co.absa.enceladus.utils.types.parsers.NumericParser.NumericParserException
+import scala.util.{Failure, Success, Try}
+
+abstract class NumericParser[N: Ordering](val pattern: NumericPattern,
+                                          val min: Option[N],
+                                          val max: Option[N]) {
+
+  protected val stringConversion: String => N
+
+  protected def parseUsingPattern(stringToParse: String):Try[N]
+  protected def formatUsingPattern(value: N): String
+
+  def parse(string: String): Try[N] = {
+    for {
+      parsed <- pattern.specifiedPattern.map(_ => parseUsingPattern(string)).getOrElse(parseWithoutPattern(string))
+      result <- valueWithinBounds(parsed)
+    } yield result
+  }
+
+  def format(value: N): String = {
+    if (pattern.isDefault) {
+      formatWithoutPattern(value)
+    } else {
+      formatUsingPattern(value)
+    }
+  }
+
+  protected def outOfBoundsException(originalInput: String): NumericParserException = {
+    new NumericParserException(s"The number '$originalInput' is out of range <$min, $max>")
+  }
+
+  protected def valueWithinBounds(value: N): Try[N] = {
+    valueWithinBounds(value, value.toString)
+  }
+
+  protected def valueWithinBounds(value: N, originalInput: String): Try[N] = {
+    // to be abe to use comparison on N type
+    val ordering = implicitly[Ordering[N]]
+    import ordering._
+
+    (this.min, this.max) match { // using this because of ambiguity with imports from ordering
+      case (Some(minDefined), _) if value < minDefined => Failure(outOfBoundsException(originalInput))
+      case (_, Some(maxDefined)) if value > maxDefined => Failure(outOfBoundsException(originalInput))
+      case _                                           => Success(value)
+    }
+  }
+
+  protected def parseWithoutPattern(stringToParse: String):Try[N] = {
+    Try(stringConversion(normalizeBasicSymbols(stringToParse)))
+  }
+
+  protected def formatWithoutPattern(value: N): String = {
+    denormalizeBasicSymbols(value.toString)
+  }
+
+  protected def normalizeBasicSymbols(string: String): String = {
+    import za.co.absa.enceladus.utils.implicits.StringImplicits.StringEnhancements
+    val replacements = NumericParser.defaultDecimalSymbols.basicSymbolsDifference(pattern.decimalSymbols)
+    if (replacements.nonEmpty) {
+      string.replaceChars(replacements)
+    } else {
+      string
+    }
+  }
+
+  protected def denormalizeBasicSymbols(string: String): String = {
+    import za.co.absa.enceladus.utils.implicits.StringImplicits.StringEnhancements
+    val replacements = pattern.decimalSymbols.basicSymbolsDifference(NumericParser.defaultDecimalSymbols)
+    if (replacements.nonEmpty) {
+      string.replaceChars(replacements)
+    } else {
+      string
+    }
+  }
+}
+
+object NumericParser {
+  val defaultDecimalSymbols: DecimalSymbols = DecimalSymbols(Locale.US)
+
+  class NumericParserException(s: String = "") extends NumberFormatException(s)
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/ParseViaDecimalFormat.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/ParseViaDecimalFormat.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.types.parsers
+
+import java.text.{DecimalFormat, ParsePosition}
+
+import za.co.absa.enceladus.utils.types.parsers.NumericParser.NumericParserException
+
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Trait to implement the common logic of parsing and formatting using DecimalFormat object
+ *
+  * @tparam N a numeric types
+  */
+trait ParseViaDecimalFormat[N] {
+  protected val decimalFormat: Option[DecimalFormat]
+  protected val numberConversion: Number => N
+
+  protected def parseUsingPattern(stringToParse: String):Try[N] = {
+    import za.co.absa.enceladus.utils.implicits.OptionImplicits.OptionEnhancements
+
+    def checkPosAtEnd(pos: ParsePosition): Try[Unit] = {
+      if (pos.getIndex < stringToParse.length) {
+        Failure(new NumericParserException(s"Parsing of '$stringToParse' failed."))
+      } else {
+        Success(Unit)
+      }
+    }
+
+    for {
+      df     <- decimalFormat.toTry(new NumericParserException("No pattern provided"))
+      pos     = new ParsePosition(0)
+      parsed <- Try(df.parse(stringToParse, pos))
+      _      <- checkPosAtEnd(pos)
+      result <- Try(numberConversion(parsed))
+    } yield result
+  }
+
+  protected def formatUsingPattern(value: N): String = {
+    decimalFormat.map(_.format(value).trim).getOrElse(value.toString)
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/ParseViaDecimalFormat.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/parsers/ParseViaDecimalFormat.scala
@@ -42,11 +42,11 @@ trait ParseViaDecimalFormat[N] {
     }
 
     for {
-      df     <- decimalFormat.toTry(new NumericParserException("No pattern provided"))
-      pos     = new ParsePosition(0)
-      parsed <- Try(df.parse(stringToParse, pos))
-      _      <- checkPosAtEnd(pos)
-      result <- Try(numberConversion(parsed))
+      formatter <- decimalFormat.toTry(new NumericParserException("No pattern provided"))
+      pos       = new ParsePosition(0)
+      parsed    <- Try(formatter.parse(stringToParse, pos))
+      _         <- checkPosAtEnd(pos)
+      result    <- Try(numberConversion(parsed))
     } yield result
   }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFBuilder.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFBuilder.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.udf
+
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.udf
+import za.co.absa.enceladus.utils.types.parsers.NumericParser
+import za.co.absa.enceladus.utils.types.parsers.NumericParser.NumericParserException
+import scala.reflect.runtime.universe._
+import scala.util.{Failure, Success}
+
+object UDFBuilder {
+  /* TODO Make UDFBuilder work with TypedStructField #1047
+  def stringUdfViaTypedStructField[T: TypeTag](field: TypedStructFieldTagged[T],
+                                               columnNameForError: String,
+                                               defaultValue: Option[T]): UserDefinedFunction = {
+    // ensuring all values sent to the UDFBuilder are instantiated
+    val vField = field
+    val vColumnNameForError = columnNameForError
+    val vDefaultValue = defaultValue
+
+    udf[UDFResult[T], String](fieldStringToTyped(_, vField, vColumnNameForError, vDefaultValue))
+  }
+  */
+
+  def stringUdfViaNumericParser[T: TypeTag](parser: NumericParser[T],
+                                            columnNullable: Boolean,
+                                            columnNameForError: String,
+                                            defaultValue: Option[T]
+                                           ): UserDefinedFunction = {
+    // ensuring all values sent to the UDFBuilder are instantiated
+    val vParser = parser
+    val vColumnNameForError = columnNameForError
+    val vDefaultValue = defaultValue
+    val vColumnNullable = columnNullable
+
+    udf[UDFResult[T], String](numericParserToTyped(_, vParser, vColumnNullable,  vColumnNameForError, vDefaultValue))
+  }
+
+  /* TODO Make UDFBuilder work with TypedStructField #1047
+  private def fieldStringToTyped[T](input: String,
+                                    field: TypedStructFieldTagged[T],
+                                    columnNameForError: String,
+                                    defaultValue: Option[T]): UDFResult[T] = {
+    val result = field.stringToTyped(input)
+    UDFResult.fromTry(result, columnNameForError, input, defaultValue)
+  }
+  */
+
+  private def numericParserToTyped[T](input: String,
+                                      parser: NumericParser[T],
+                                      columnNullable: Boolean,
+                                      columnNameForError: String,
+                                      defaultValue: Option[T]): UDFResult[T] = {
+    val result = Option(input) match {
+      case Some(string) => parser.parse(string).map(Some(_))
+      case None if columnNullable => Success(None)
+      case None => Failure(nullException)
+    }
+    UDFResult.fromTry(result, columnNameForError, input, defaultValue)
+  }
+
+private val nullException = new NumericParserException("Null value on input for non-nullable field")
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFBuilder.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFBuilder.scala
@@ -23,19 +23,6 @@ import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success}
 
 object UDFBuilder {
-  /* TODO Make UDFBuilder work with TypedStructField #1047
-  def stringUdfViaTypedStructField[T: TypeTag](field: TypedStructFieldTagged[T],
-                                               columnNameForError: String,
-                                               defaultValue: Option[T]): UserDefinedFunction = {
-    // ensuring all values sent to the UDFBuilder are instantiated
-    val vField = field
-    val vColumnNameForError = columnNameForError
-    val vDefaultValue = defaultValue
-
-    udf[UDFResult[T], String](fieldStringToTyped(_, vField, vColumnNameForError, vDefaultValue))
-  }
-  */
-
   def stringUdfViaNumericParser[T: TypeTag](parser: NumericParser[T],
                                             columnNullable: Boolean,
                                             columnNameForError: String,
@@ -50,16 +37,6 @@ object UDFBuilder {
     udf[UDFResult[T], String](numericParserToTyped(_, vParser, vColumnNullable,  vColumnNameForError, vDefaultValue))
   }
 
-  /* TODO Make UDFBuilder work with TypedStructField #1047
-  private def fieldStringToTyped[T](input: String,
-                                    field: TypedStructFieldTagged[T],
-                                    columnNameForError: String,
-                                    defaultValue: Option[T]): UDFResult[T] = {
-    val result = field.stringToTyped(input)
-    UDFResult.fromTry(result, columnNameForError, input, defaultValue)
-  }
-  */
-
   private def numericParserToTyped[T](input: String,
                                       parser: NumericParser[T],
                                       columnNullable: Boolean,
@@ -73,5 +50,5 @@ object UDFBuilder {
     UDFResult.fromTry(result, columnNameForError, input, defaultValue)
   }
 
-private val nullException = new NumericParserException("Null value on input for non-nullable field")
+  private val nullException = new NumericParserException("Null value on input for non-nullable field")
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFResult.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFResult.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.udf
+
+import za.co.absa.enceladus.utils.error.ErrorMessage
+
+import scala.util.{Failure, Success, Try}
+
+case class UDFResult[T] (
+                         result: Option[T],
+                         error: Seq[ErrorMessage]
+                       )
+
+object UDFResult {
+  def success[T](result: Option[T]): UDFResult[T] = {
+    UDFResult(result, Seq.empty)
+  }
+
+  def fromTry[T](result: Try[Option[T]], columnName: String, rawValue: String, defaultValue: Option[T] = None): UDFResult[T] = {
+    result match {
+      case Success(success)                       => UDFResult.success(success)
+      case Failure(_) if Option(rawValue).isEmpty => UDFResult(defaultValue, Seq(ErrorMessage.stdNullErr(columnName)))
+      case Failure(_)                             => UDFResult(defaultValue, Seq(ErrorMessage.stdCastErr(columnName, rawValue)))
+    }
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/SchemaValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/SchemaValidator.scala
@@ -18,7 +18,7 @@ package za.co.absa.enceladus.utils.validation
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
 import za.co.absa.enceladus.utils.error.ErrorMessage
-import za.co.absa.enceladus.utils.types.TypedStructField
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
 import za.co.absa.enceladus.utils.validation.field.FieldValidationFailure
 
 import scala.collection.mutable.ListBuffer
@@ -27,6 +27,8 @@ import scala.collection.mutable.ListBuffer
   * Object responsible for Spark schema validation against self inconsistencies (not against the actual data)
   */
 object SchemaValidator {
+  private implicit val defaults: Defaults = GlobalDefaults
+
   /**
     * Validate a schema
     *

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/DateTimeFieldValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/DateTimeFieldValidator.scala
@@ -30,13 +30,14 @@ import scala.util.control.NonFatal
 
 abstract class DateTimeFieldValidator extends FieldValidator {
   override def validate(field: TypedStructField): Seq[ValidationIssue] = {
+    super.validate(field) ++ (
     field match {
-      case dateTimeField: DateTimeTypeStructField => validateDateTimeTypeStructField(dateTimeField)
+      case dateTimeField: DateTimeTypeStructField[_] => validateDateTimeTypeStructField(dateTimeField)
       case _ => Seq(ValidationError("DateTimeFieldValidator can validate only fields of type Date or Timestamp"))
-    }
+    })
   }
 
-  private def validateDateTimeTypeStructField(field: DateTimeTypeStructField): Seq[ValidationIssue] = {
+  private def validateDateTimeTypeStructField(field: DateTimeTypeStructField[_]): Seq[ValidationIssue] = {
     val result = for {
       parser <- field.parser
       defaultValue: Option[String] = field.getMetadataString(MetadataKeys.DefaultValue)
@@ -48,7 +49,7 @@ abstract class DateTimeFieldValidator extends FieldValidator {
     tryToValidationIssues(result)
   }
 
-  private def patternConversionIssues(field: DateTimeTypeStructField, parser: DateTimeParser): Option[ValidationIssue] = {
+  private def patternConversionIssues(field: DateTimeTypeStructField[_], parser: DateTimeParser): Option[ValidationIssue] = {
 
     try {
       implicit val implicitParser: DateTimeParser = parser

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/IntegralFieldValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/IntegralFieldValidator.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.validation.field
+import za.co.absa.enceladus.utils.numeric.Radix
+import za.co.absa.enceladus.utils.schema.MetadataKeys
+import za.co.absa.enceladus.utils.types.TypedStructField
+import za.co.absa.enceladus.utils.validation.{ValidationIssue, ValidationWarning}
+
+import scala.util.Try
+
+object IntegralFieldValidator extends NumericFieldValidator {
+
+  private def radixIssues(field: TypedStructField): Seq[ValidationIssue] = {
+    field.getMetadataString(MetadataKeys.Radix).map { radixString =>
+      val result = for {
+        radix <- Try(Radix(radixString))
+        pattern <- field.pattern
+        conflict = if ((radix != Radix.DefaultRadix) && (pattern.exists(!_.isDefault))) {
+          ValidationWarning(
+            s"Both Radix and Pattern defined for field ${field.name}, for Radix different from ${Radix.DefaultRadix} Pattern is ignored"
+          )
+        }
+      } yield conflict
+      tryToValidationIssues(result)
+    }.getOrElse(Nil)
+  }
+
+  override def validate(field: TypedStructField): Seq[ValidationIssue] = {
+    super.validate(field) ++
+      checkMetadataKey[String](field, MetadataKeys.Radix) ++
+      radixIssues(field)
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/NumericFieldValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/NumericFieldValidator.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.validation.field
+
+import za.co.absa.enceladus.utils.schema.MetadataKeys
+import za.co.absa.enceladus.utils.types.TypedStructField
+import za.co.absa.enceladus.utils.types.TypedStructField.NumericTypeStructField
+import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue}
+
+object NumericFieldValidator extends NumericFieldValidator
+
+class NumericFieldValidator  extends ScalarFieldValidator {
+  private def validateNumericTypeStructField(field: NumericTypeStructField[_]): Seq[ValidationIssue] = {
+    tryToValidationIssues(field.parser)
+  }
+
+  override def validate(field: TypedStructField): Seq[ValidationIssue] = {
+    super.validate(field) ++
+      checkMetadataKey[String](field, MetadataKeys.Pattern) ++
+      checkMetadataKey[Char](field, MetadataKeys.DecimalSeparator) ++
+      checkMetadataKey[Char](field, MetadataKeys.MinusSign) ++
+      checkMetadataKey[Char](field, MetadataKeys.GroupingSeparator) ++ (
+      field match {
+        case numericField: NumericTypeStructField[_] => validateNumericTypeStructField(numericField)
+        case _ => Seq(ValidationError("NumericFieldValidator can validate only fields of numeric types"))
+      })
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/ScalarFieldValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/ScalarFieldValidator.scala
@@ -33,6 +33,6 @@ class ScalarFieldValidator extends FieldValidator {
   }
 
   override def validate(field: TypedStructField): Seq[ValidationIssue] = {
-    tryToValidationIssues(validateDefaultValue(field))
+    super.validate(field) ++ tryToValidationIssues(validateDefaultValue(field))
   }
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/SchemaValidationSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/SchemaValidationSuite.scala
@@ -85,7 +85,7 @@ class SchemaValidationSuite extends FunSuite with LoggerTestBase{
         StructField("float_bad", FloatType, nullable = false, Metadata.fromJson(""" { "default": "1e40" } """)),
         StructField("double_good", DoubleType, nullable = false, Metadata.fromJson(""" { "default": "1000000.5544" } """)),
         StructField("double_bad", DoubleType, nullable = false, Metadata.fromJson(""" { "default": "1e310" } """)),
-        StructField("decimal_good", DecimalType(20,10), nullable = false, Metadata.fromJson(""" { "default": "314159265351.31415926"}""")),
+        StructField("decimal_good", DecimalType(20,10), nullable = false, Metadata.fromJson(""" { "default": "-9999999999.9999999999"}""")),
         StructField("decimal_bad", DecimalType(20,10), nullable = false, Metadata.fromJson(""" { "default": "123456789012345678901.12345678901"}"""))
       )
     )

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/StringImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/StringImplicitsSuite.scala
@@ -21,7 +21,30 @@ import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.implicits.StringImplicits.StringEnhancements
 
 class StringImplicitsSuite extends FunSuite {
-  test("StringImprovements.findFirstUnquoted - empty string") {
+  test("StringEnhancements.replaceChars - empty replacements") {
+    val s = "supercalifragilisticexpialidocious"
+    assert(s.replaceChars(Map.empty) == s)
+  }
+
+  test("StringEnhancements.replaceChars - no hits") {
+    val s = "supercalifragilisticexpialidocious"
+    val map = Map('1' -> '5', '2' -> '6', '3' -> '7')
+    assert(s.replaceChars(map) == s)
+  }
+
+  test("StringEnhancements.replaceChars - replace all to same char") {
+    val s: String = "abcba"
+    val map = Map('a' -> 'x', 'b' -> 'x', 'c' -> 'x', 'd' -> 'x')
+    assert(s.replaceChars(map) == "xxxxx")
+  }
+
+  test("StringEnhancements.replaceChars - swap characters") {
+    val s: String = "abcba"
+    val map = Map('a' -> 'b', 'b' -> 'a')
+    assert(s.replaceChars(map) == "bacab")
+  }
+
+  test("StringEnhancements.findFirstUnquoted - empty string") {
     var result = "".findFirstUnquoted(Set.empty, Set.empty)
     assert(result.isEmpty)
     result = "".findFirstUnquoted(Set('a'), Set.empty)
@@ -32,7 +55,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.isEmpty)
   }
 
-  test("StringImprovements.findFirstUnquoted - no quotes") {
+  test("StringEnhancements.findFirstUnquoted - no quotes") {
     var result = "Hello world".findFirstUnquoted(Set('x', 'y', 'z'), Set.empty)
     assert(result.isEmpty)
     result = "Hello world".findFirstUnquoted(Set('w'), Set.empty)
@@ -41,7 +64,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.contains(1))
   }
 
-  test("StringImprovements.findFirstUnquoted - simple quotes") {
+  test("StringEnhancements.findFirstUnquoted - simple quotes") {
     val quotes = Set(''')
     var result = "Hello 'world'".findFirstUnquoted(Set('w'), quotes)
     assert(result.isEmpty)
@@ -51,7 +74,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.contains(8))
   }
 
-  test("StringImprovements.findFirstUnquoted - multiple quotes") {
+  test("StringEnhancements.findFirstUnquoted - multiple quotes") {
     val charsToFind = Set('w', 'e', 'l')
     val quotes = Set(''', '`')
     var result = "`Hello` 'world'".findFirstUnquoted(charsToFind, quotes)
@@ -62,7 +85,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.contains(14))
   }
 
-  test("StringImprovements.findFirstUnquoted - using escape character") {
+  test("StringEnhancements.findFirstUnquoted - using escape character") {
     val charsToFind = Set('w', 'e', 'l')
     val quotes = Set(''', '`')
     var result = "`Hello` \\'world".findFirstUnquoted(charsToFind, quotes) //hasn't started
@@ -77,7 +100,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.isEmpty)
   }
 
-  test("StringImprovements.findFirstUnquoted - quote between search characters") {
+  test("StringEnhancements.findFirstUnquoted - quote between search characters") {
     val charsToFind = Set('w', 'e', 'l', ''')
     val quotes = Set(''', '`')
     var result = "Hello \\'world".findFirstUnquoted(charsToFind, quotes) //simple
@@ -92,7 +115,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.isEmpty)
   }
 
-  test("StringImprovements.findFirstUnquoted - custom escape character") {
+  test("StringEnhancements.findFirstUnquoted - custom escape character") {
     val charsToFind = Set('w', 'e', 'l')
     val quotes = Set(''', '`')
     val escapeChar = '~'
@@ -108,7 +131,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.contains(16))
   }
 
-  test("StringImprovements.findFirstUnquoted - many escapes") { //better to do with other then \
+  test("StringEnhancements.findFirstUnquoted - many escapes") { //better to do with other then \
     val charsToFind = Set('w')
     val quotes = Set(''')
     val escapeChar = '~'
@@ -124,7 +147,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.isEmpty)
   }
 
-  test("StringImprovements.findFirstUnquoted - escape in search chars") { //better to do with other then \
+  test("StringEnhancements.findFirstUnquoted - escape in search chars") { //better to do with other then \
     val escapeChar = '~'
     val quotes = Set(''')
     val charsToFind = Set('w', escapeChar)
@@ -138,7 +161,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.contains(13))
   }
 
-  test("StringImprovements.findFirstUnquoted - escape in quote chars") { //better to do with other then \
+  test("StringEnhancements.findFirstUnquoted - escape in quote chars") { //better to do with other then \
     val escapeChar = '~'
     val quotes = Set(''', escapeChar)
     val charsToFind = Set('w', 'e', 'l')
@@ -154,7 +177,7 @@ class StringImplicitsSuite extends FunSuite {
     assert(result.contains(14))
   }
 
-  test("StringImprovements.findFirstUnquoted - escape in search and quote chars") { //better to do with other then \
+  test("StringEnhancements.findFirstUnquoted - escape in search and quote chars") { //better to do with other then \
     val escapeChar = '!'
     val quotes = Set(''', escapeChar)
     val charsToFind = Set('w', 'e', 'l', escapeChar)
@@ -165,14 +188,14 @@ class StringImplicitsSuite extends FunSuite {
     assert(caught.getMessage == expectedMessage)
   }
 
-  test("StringImprovements.hasUnquoted") {
+  test("StringEnhancements.hasUnquoted") {
     assert(!"".hasUnquoted(Set.empty, Set.empty))
     assert(!"Hello world".hasUnquoted(Set('x'), Set.empty))
     assert("Hello world".hasUnquoted(Set('w', 'e', 'l'), Set('`')))
     assert(!"`Hello world`".hasUnquoted(Set('w', 'e', 'l'), Set('`')))
   }
 
-  test("StringImprovements.countUnquoted: empty variants") {
+  test("StringEnhancements.countUnquoted: empty variants") {
     val expected = Map(
       'x'->0,
       'y'->0,
@@ -185,7 +208,7 @@ class StringImplicitsSuite extends FunSuite {
     assert("Hello world".countUnquoted(empty, Set('|')) == Map.empty)
   }
 
-  test("StringImprovements.countUnquoted: simple test") {
+  test("StringEnhancements.countUnquoted: simple test") {
     val charsToFind = Set('x', 'y', 'z')
     val expected1 = Map(
       'x'->0,
@@ -208,7 +231,7 @@ class StringImplicitsSuite extends FunSuite {
     assert("x-xxy-yyzzz|zyyy|zz".countUnquoted(charsToFind, Set('-', '|')) == expected3)
   }
 
-  test("StringImprovements.countUnquoted: escape involved") {
+  test("StringEnhancements.countUnquoted: escape involved") {
     val charsToFind = Set('x', 'y', 'z')
     val expected = Map(
       'x'->3,
@@ -218,7 +241,7 @@ class StringImplicitsSuite extends FunSuite {
     assert("x~yz~'xxyyzz 'xxxx~'zzzz'~''yyyy".countUnquoted(charsToFind, Set('''),'~') == expected)
   }
 
-  test("StringImprovements.countUnquoted: search and quote chars overlap") {
+  test("StringEnhancements.countUnquoted: search and quote chars overlap") {
     val charsToFind = Set('a', '#', '$', '%')
     val quoteChars = Set('$', '%', '^')
     val expected = Map(
@@ -230,7 +253,7 @@ class StringImplicitsSuite extends FunSuite {
     assert("#^##^|$%%%%".countUnquoted(charsToFind, quoteChars, '|') == expected)
   }
 
-  test("StringImprovements.countUnquoted: escape in search for chars") {
+  test("StringEnhancements.countUnquoted: escape in search for chars") {
     val charsToFind = Set('a', 'b', 'c', 'd', '|')
     val quoteChars = Set('%', '^')
     val expected = Map(
@@ -243,7 +266,7 @@ class StringImplicitsSuite extends FunSuite {
     assert("aa||%bb%|^cc^a|cd||d|^b^".countUnquoted(charsToFind, quoteChars, '|') == expected)
   }
 
-  test("StringImprovements.countUnquoted: escape in quote chars") {
+  test("StringEnhancements.countUnquoted: escape in quote chars") {
     val charsToFind = Set('a', 'b', 'c')
     val quoteChars = Set('$', '%', '^')
     val expected = Map(

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/DefaultsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/DefaultsSuite.scala
@@ -27,52 +27,52 @@ class DefaultsSuite extends FunSuite {
   TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
 
   test("ByteType") {
-    assert(Defaults.getGlobalDefaultWithNull(ByteType, nullable = false) === Success(Some(0.toByte)))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(ByteType, nullable = false) === Success(Some(0.toByte)))
   }
 
   test("ShortType") {
-    assert(Defaults.getGlobalDefaultWithNull(ShortType, nullable = false) === Success(Some(0.toShort)))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(ShortType, nullable = false) === Success(Some(0.toShort)))
   }
 
   test("IntegerType") {
-    assert(Defaults.getGlobalDefaultWithNull(IntegerType, nullable = false) === Success(Some(0)))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(IntegerType, nullable = false) === Success(Some(0)))
   }
 
   test("LongType") {
-    assert(Defaults.getGlobalDefaultWithNull(LongType, nullable = false) === Success(Some(0L)))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(LongType, nullable = false) === Success(Some(0L)))
   }
 
   test("FloatType") {
-    assert(Defaults.getGlobalDefaultWithNull(FloatType, nullable = false) === Success(Some(0F)))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(FloatType, nullable = false) === Success(Some(0F)))
   }
 
   test("DoubleType") {
-    assert(Defaults.getGlobalDefaultWithNull(DoubleType, nullable = false) === Success(Some(0D)))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(DoubleType, nullable = false) === Success(Some(0D)))
   }
 
   test("StringType") {
-    assert(Defaults.getGlobalDefaultWithNull(StringType, nullable = false) === Success(Some("")))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(StringType, nullable = false) === Success(Some("")))
   }
 
   test("DateType") {
-    assert(Defaults.getGlobalDefaultWithNull(DateType, nullable = false) === Success(Some(new Date(0))))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(DateType, nullable = false) === Success(Some(new Date(0))))
   }
 
   test("TimestampType") {
-    assert(Defaults.getGlobalDefaultWithNull(TimestampType, nullable = false) === Success(Some(new Timestamp(0))))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(TimestampType, nullable = false) === Success(Some(new Timestamp(0))))
   }
 
   test("BooleanType") {
-    assert(Defaults.getGlobalDefaultWithNull(BooleanType, nullable = false) === (Success(Some(false))))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(BooleanType, nullable = false) === (Success(Some(false))))
   }
 
   test("DecimalType") {
-    assert(Defaults.getGlobalDefaultWithNull(DecimalType(6, 3), nullable = false) === Success(Some(new java.math.BigDecimal("000.000"))))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(DecimalType(6, 3), nullable = false) === Success(Some(new java.math.BigDecimal("000.000"))))
   }
 
   test("ArrayType") {
     val dataType = ArrayType(StringType)
-    val result = Defaults.getGlobalDefaultWithNull(dataType, nullable = false)
+    val result = GlobalDefaults.getDataTypeDefaultValueWithNull(dataType, nullable = false)
     val e = intercept[IllegalStateException] {
       result.get
     }
@@ -80,7 +80,7 @@ class DefaultsSuite extends FunSuite {
   }
 
   test("Nullable default is None") {
-    assert(Defaults.getGlobalDefaultWithNull(BooleanType, nullable = true) === Success(None))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(BooleanType, nullable = true) === Success(None))
   }
 }
 

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/DefaultsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/DefaultsSuite.scala
@@ -67,7 +67,7 @@ class DefaultsSuite extends FunSuite {
   }
 
   test("DecimalType") {
-    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(DecimalType(6, 3), nullable = false) === Success(Some(new java.math.BigDecimal("000.000"))))
+    assert(GlobalDefaults.getDataTypeDefaultValueWithNull(DecimalType(6, 3), nullable = false) === Success(Some(BigDecimal("000.000"))))
   }
 
   test("ArrayType") {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/DecimalParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/DecimalParserSuite.scala
@@ -1,0 +1,105 @@
+package za.co.absa.enceladus.utils.types.parsers
+
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.numeric.{DecimalSymbols, NumericPattern}
+import za.co.absa.enceladus.utils.types.GlobalDefaults
+
+import scala.util.Success
+
+class DecimalParserSuite extends FunSuite {
+  test("No pattern, no limitations") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern(decimalSymbols)
+    val parser = DecimalParser(pattern)
+    assert(parser.parse("3.14") == Success(BigDecimal("3.14")))
+    assert(parser.parse("1.") == Success(BigDecimal.valueOf(1)))
+    assert(parser.parse("-7") == Success(BigDecimal.valueOf(-7)))
+    assert(parser.parse(".271E1") == Success(BigDecimal("2.71")))
+    assert(parser.parse("271E-2") == Success(BigDecimal("2.71")))
+  }
+
+  test("No pattern, no limitations, minus sign and decimal separator altered") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols.copy(minusSign = 'N', decimalSeparator = ',')
+    val pattern = NumericPattern(decimalSymbols)
+    val parser = DecimalParser(pattern)
+    assert(parser.parse("3,14") == Success(BigDecimal("3.14")))
+    assert(parser.parse("1,") == Success(BigDecimal.valueOf(1)))
+    assert(parser.parse("N7") == Success(BigDecimal.valueOf(-7)))
+    assert(parser.parse(",271E1") == Success(BigDecimal("2.71")))
+    assert(parser.parse("271EN2") == Success(BigDecimal("2.71")))
+    assert(parser.parse("-11.1").isFailure)
+  }
+
+  test("Simple pattern, some limitations") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("0.#", decimalSymbols)
+    val parser = DecimalParser(pattern, Some(BigDecimal.valueOf(-1000)), Some(BigDecimal.valueOf(1000)))
+    assert(parser.parse("3.14") == Success(BigDecimal("3.14"))) //NB! number of hashes and 0 in pattern is not reliable
+    assert(parser.parse("1.") == Success(BigDecimal.valueOf(1)))
+    assert(parser.parse("-7") == Success(BigDecimal.valueOf(-7)))
+    assert(parser.parse(".271E1") == Success(BigDecimal("2.71"))) //NB! number of hashes and 0 in pattern is not reliable
+    assert(parser.parse("271E-2") == Success(BigDecimal("2.71")))
+    assert(parser.parse("1000.0000000000000000000000000000000000000000000000000001").isFailure)
+    assert(parser.parse("-1000.0000000000000000000000000000000000000000000000000001").isFailure)
+  }
+
+  test("pattern with altered decimal symbols") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols.copy(
+      decimalSeparator = ',',
+      groupingSeparator = ' ',
+      minusSign = '~'
+    )
+    val pattern = NumericPattern("#,##0.000",decimalSymbols) //NB! that the standard grouping and decimal separators are used
+    val parser = DecimalParser(pattern)
+
+    assert(parser.parse("100") == Success(BigDecimal.valueOf(100)))
+    assert(parser.parse("~1") == Success(BigDecimal.valueOf(-1)))
+    assert(parser.parse("1 000,3") == Success(BigDecimal("1000.3")))
+    assert(parser.parse("~2 000,003") == Success(BigDecimal("-2000.003")))
+    assert(parser.parse("3 0000,000001") == Success(BigDecimal("30000.000001"))) // grouping size is not reliable for parsing
+    assert(parser.parse("31,4E4") == Success(BigDecimal.valueOf(314000)))
+    assert(parser.parse("-4").isFailure)
+    assert(parser.parse("3,14E3") == Success(BigDecimal("3140")))
+    assert(parser.parse("0.000 1").isFailure) // NB! grouping separator is not supported
+    assert(parser.parse("3.14E3").isFailure)
+    assert(parser.parse("~1 ").isFailure)
+    assert(parser.parse(" ~1 ").isFailure)
+  }
+
+  test("grouping separator is not supported in decimal places") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern1 = NumericPattern("0.000,#",decimalSymbols)
+    val exception = intercept[IllegalArgumentException] {
+      DecimalParser(pattern1)
+    }
+    assert(exception.getMessage == """Malformed pattern "0.000,#"""")
+
+    val pattern2 = NumericPattern("0.000#",decimalSymbols)
+    val parser2 = DecimalParser(pattern2)
+    assert(parser2.parse("0.000,1").isFailure)
+  }
+
+  test("Prefix, suffix and different negative pattern") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("Alt: 0.#Feet;Alt: (0.#)Feet",decimalSymbols)
+    val parser = DecimalParser(pattern)
+
+    assert(parser.parse("Alt: 10000.5Feet") == Success(BigDecimal("10000.5")))
+    assert(parser.parse("Alt: (100)Feet") == Success(BigDecimal.valueOf(-100)))
+    assert(parser.parse("Alt: 612E-2Feet") == Success(BigDecimal("6.12")))
+    assert(parser.parse("Alt: 10,000Feet").isFailure)
+    assert(parser.parse("100").isFailure)
+  }
+
+  test("Percent") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("#,##0.#%",decimalSymbols)
+    val parser = DecimalParser(pattern)
+
+    assert(parser.parse("113.8%") == Success(BigDecimal("1.138")))
+    assert(parser.parse("-5,000.1%") == Success(BigDecimal("-50.001")))
+    assert(parser.parse("113.8").isFailure)
+
+    println(s"=${decimalSymbols.permillSign}=")
+  }
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/FractionalParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/FractionalParserSuite.scala
@@ -1,0 +1,168 @@
+package za.co.absa.enceladus.utils.types.parsers
+
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.numeric.{DecimalSymbols, NumericPattern}
+import za.co.absa.enceladus.utils.types.GlobalDefaults
+
+import scala.util.Success
+
+class FractionalParserSuite extends FunSuite {
+  private val reallyBigNumberString = "12345678901234567890123456789012345678901234567890123456789012345678901234567890" +
+    "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890" +
+    "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890" +
+    "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+  private val reallySmallNumberString = s"-$reallyBigNumberString"
+
+  test("No pattern") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern(decimalSymbols)
+    val parserFloat = FractionalParser[Float](pattern, Float.MinValue, Float.MaxValue)
+    val parserDouble = FractionalParser[Double](pattern, Double.MinValue, Double.MaxValue)
+    assert(parserFloat.parse("3.14") == Success(3.14F))
+    assert(parserDouble.parse("3.14") == Success(3.14D))
+    assert(parserFloat.parse("+1.") == Success(1F))
+    assert(parserDouble.parse("1.") == Success(1D))
+    assert(parserFloat.parse("-7") == Success(-7F))
+    assert(parserDouble.parse("-7") == Success(-7D))
+    assert(parserFloat.parse(".271E1") == Success(2.71F))
+    assert(parserDouble.parse(".271E1") == Success(2.71D))
+    assert(parserFloat.parse("271E-2") == Success(2.71F))
+    assert(parserDouble.parse("+271E-2") == Success(2.71D))
+    assert(parserFloat.parse("1E40").isFailure)
+    assert(parserDouble.parse("1E40") == Success(1.0E40))
+    assert(parserDouble.parse("1E360").isFailure)
+  }
+
+  test("Simple pattern, some limitations") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("0.#", decimalSymbols)
+    val parserFloat = FractionalParser[Float](pattern, Float.MinValue, Float.MaxValue)
+    val parserDouble = FractionalParser[Double](pattern, Double.MinValue, Double.MaxValue)
+    assert(parserFloat.parse("3.14") == Success(3.14F))
+    assert(parserDouble.parse("3.14") == Success(3.14D))
+    assert(parserFloat.parse("1.") == Success(1F))
+    assert(parserDouble.parse("1.") == Success(1D))
+    assert(parserFloat.parse("-7") == Success(-7F))
+    assert(parserDouble.parse("-7") == Success(-7D))
+    assert(parserFloat.parse(".271E1") == Success(2.71F)) //NB! number of hashes and 0 in pattern is not reliable
+    assert(parserDouble.parse(".271E1") == Success(2.71D)) //NB! number of hashes and 0 in pattern is not reliable
+    assert(parserFloat.parse("271E-2") == Success(2.71F))
+    assert(parserDouble.parse("271E-2") == Success(2.71D))
+    assert(parserFloat.parse("1E40").isFailure)
+    assert(parserDouble.parse("1E40") == Success(1.0E40))
+    assert(parserDouble.parse("1E360").isFailure)
+  }
+
+  test("plus doesn't work if pattern is specified") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("0", decimalSymbols)
+    val parserFloat = FractionalParser[Float](pattern, Float.MinValue, Float.MaxValue)
+    val parserDouble = FractionalParser[Double](pattern, Double.MinValue, Double.MaxValue)
+    assert(parserFloat.parse("+2.71").isFailure)
+    assert(parserDouble.parse("+2.71").isFailure)
+  }
+
+  test("infinities") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern1 = NumericPattern(decimalSymbols)
+    val pattern2 = NumericPattern("0.#", decimalSymbols)
+    val parserFloatStd1 = FractionalParser.withInfinity[Float](pattern1)
+    val parserDoubleStd1 = FractionalParser.withInfinity[Double](pattern1)
+    val parserFloatStd2 = FractionalParser.withInfinity[Float](pattern2)
+    val parserDoubleStd2 = FractionalParser.withInfinity[Double](pattern2)
+    assert(parserFloatStd1.parse("∞") == Success(Float.PositiveInfinity))
+    assert(parserFloatStd1.parse("-∞") == Success(Float.NegativeInfinity))
+    assert(parserDoubleStd1.parse("∞") == Success(Double.PositiveInfinity))
+    assert(parserDoubleStd1.parse("-∞") == Success(Double.NegativeInfinity))
+    assert(parserFloatStd2.parse("∞") == Success(Float.PositiveInfinity))
+    assert(parserFloatStd2.parse("-∞") == Success(Float.NegativeInfinity))
+    assert(parserDoubleStd2.parse("∞") == Success(Double.PositiveInfinity))
+    assert(parserDoubleStd2.parse("-∞") == Success(Double.NegativeInfinity))
+    assert(parserFloatStd1.parse("3E40") == Success(Float.PositiveInfinity))
+    assert(parserFloatStd1.parse("-7699980973893499984399399999999999999998976876999") == Success(Float.NegativeInfinity))
+    assert(parserDoubleStd1.parse(reallyBigNumberString) == Success(Double.PositiveInfinity))
+    assert(parserDoubleStd1.parse(reallySmallNumberString) == Success(Double.NegativeInfinity))
+    assert(parserDoubleStd1.parse("2E308") == Success(Double.PositiveInfinity))
+    assert(parserDoubleStd1.parse("-6.6E666") == Success(Double.NegativeInfinity))
+    assert(parserFloatStd2.parse("1276493809384398420983098239843298980977679008") == Success(Float.PositiveInfinity))
+    assert(parserFloatStd2.parse("-2.71E55") == Success(Float.NegativeInfinity))
+    assert(parserDoubleStd2.parse(reallyBigNumberString) == Success(Double.PositiveInfinity))
+    assert(parserDoubleStd2.parse(reallySmallNumberString) == Success(Double.NegativeInfinity))
+    assert(parserDoubleStd2.parse("2E308") == Success(Double.PositiveInfinity))
+    assert(parserDoubleStd2.parse("-1E1000") == Success(Double.NegativeInfinity))
+  }
+
+  test("infinities redefined") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols.copy(minusSign = '&', infinityValue = "Infinity")
+    val pattern1 = NumericPattern(decimalSymbols)
+    val pattern2 = NumericPattern("#", decimalSymbols)
+    val pattern3 = NumericPattern("#;Negative#", decimalSymbols)
+    val parser1 = FractionalParser.withInfinity[Double](pattern1)
+    val parser2 = FractionalParser.withInfinity[Float](pattern2)
+    val parser3 = FractionalParser.withInfinity[Double](pattern3)
+    assert(parser1.parse("Infinity") == Success(Double.PositiveInfinity))
+    assert(parser1.parse("&Infinity") == Success(Double.NegativeInfinity))
+    assert(parser2.parse("Infinity") == Success(Float.PositiveInfinity))
+    assert(parser2.parse("&Infinity") == Success(Float.NegativeInfinity))
+    assert(parser3.parse("Infinity") == Success(Double.PositiveInfinity))
+    assert(parser3.parse("NegativeInfinity") == Success(Double.NegativeInfinity))
+    assert(parser3.parse("&Infinity").isFailure)
+  }
+
+  test("No pattern, no limitations, minus sign and decimal separator altered") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols.copy(minusSign = 'N', decimalSeparator = ',')
+    val pattern = NumericPattern(decimalSymbols)
+    val parser = FractionalParser(pattern)
+    assert(parser.parse("6,28") == Success(6.28D))
+    assert(parser.parse("10000,") == Success(10000D))
+    assert(parser.parse("N7") == Success(-7D))
+    assert(parser.parse(",271E1") == Success(2.71D))
+    assert(parser.parse("271EN2") == Success(2.71D))
+    assert(parser.parse("-11.1").isFailure)
+  }
+
+  test("pattern with altered decimal symbols") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols.copy(
+      decimalSeparator = ',',
+      groupingSeparator = ''',
+      minusSign = '@'
+    )
+    val pattern = NumericPattern("#,##0",decimalSymbols) //NB! that the standard grouping separator is used
+    val parser = FractionalParser(pattern)
+
+    assert(parser.parse("100") == Success(100))
+    assert(parser.parse("@,1") == Success(-0.1D))
+    assert(parser.parse("1'032,") == Success(1032D))
+    assert(parser.parse("@2'000,55") == Success(-2000.55D))
+    assert(parser.parse("3'0000,001") == Success(30000.001D)) // grouping size is not reliable for parsing
+    assert(parser.parse("314E@2") == Success(3.14D))
+    assert(parser.parse("-4").isFailure)
+    assert(parser.parse("3.14E3").isFailure)
+    assert(parser.parse("@1 ").isFailure)
+    assert(parser.parse(" @1 ").isFailure)
+  }
+
+  test("Prefix, suffix and different negative pattern") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("Temperature #,##0C;Freezing -0",decimalSymbols)
+    val parser = FractionalParser(pattern)
+
+    assert(parser.parse("Temperature 100C") == Success(100D))
+    assert(parser.parse("Temperature 36.8C") == Success(36.8D))
+    assert(parser.parse("Freezing -12") == Success(-12D))
+    assert(parser.parse("Temperature 1,234C") == Success(1234))
+    assert(parser.parse("Freezing 300.0C").isFailure)
+    assert(parser.parse("100.2").isFailure)
+  }
+
+  test("Percent") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("#,##0.#%",decimalSymbols)
+    val parser = FractionalParser(pattern)
+
+    assert(parser.parse("113.8%") == Success(1.138D))
+    assert(parser.parse("-5,000.1%") == Success(-5000.1D / 100)) // -5000.1D / 100 = -50.001000000000005
+    assert(parser.parse("113.8").isFailure)
+  }
+
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser_BaseIntegralParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser_BaseIntegralParserSuite.scala
@@ -1,0 +1,147 @@
+package za.co.absa.enceladus.utils.types.parsers
+
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.numeric.Radix
+import za.co.absa.enceladus.utils.types.parsers.NumericParser.NumericParserException
+
+import scala.util.Success
+
+class IntegralParser_BaseIntegralParserSuite extends FunSuite {
+
+  test("base 10 parsing succeeds") {
+    val parser = IntegralParser.ofRadix(Radix(10))
+    assert(parser.parse("1111") == Success(1111))
+    assert(parser.parse("-1") == Success(-1))
+  }
+
+  test("base 10 parsing fails on too big number") {
+    val parser = IntegralParser.ofRadix(Radix(10))
+    val tooBig = "45455782147845454874654658875324"
+    val fail = parser.parse(tooBig).failed.get
+    assert(fail.isInstanceOf[NumberFormatException])
+    assert(fail.getMessage == """For input string: """" + tooBig + """"""")
+  }
+
+  test("base 10 parsing fails on wrong input") {
+    val parser = IntegralParser.ofRadix(Radix(10))
+    val wrong = "Hello"
+    val fail = parser.parse(wrong).failed.get
+    assert(fail.isInstanceOf[NumberFormatException])
+    assert(fail.getMessage == """For input string: """" + wrong + """"""")
+  }
+
+  test("base 16 parsing succeeds") {
+    val parser = IntegralParser.ofRadix(Radix(16))
+    assert(parser.parse("CAFE") == Success(51966))
+    assert(parser.parse("-a") == Success(-10))
+    assert(parser.parse("0xFFFfF") == Success(1048575))
+    assert(parser.parse("+0X1A") == Success(26))
+    assert(parser.parse("-0X1") == Success(-1))
+    assert(parser.parse("7FFFFFFFFFFFFFFF") == Success(9223372036854775807L))
+  }
+
+  test("base 16 parsing fails on incomplete input") {
+    val parser = IntegralParser.ofRadix(Radix(16))
+    val fail1 = parser.parse("").failed.get
+    assert(fail1.isInstanceOf[NumberFormatException])
+    assert(fail1.getMessage == "Zero length BigInteger")
+    val fail2 = parser.parse("0x").failed.get
+    assert(fail2.isInstanceOf[NumberFormatException])
+    assert(fail2.getMessage == "Zero length BigInteger")
+  }
+
+  test("base 16 parsing fails on too big input") {
+    val parser = IntegralParser.ofRadix(Radix(16))
+    val tooBig = "8FFFFFFFFFFFFFFF"
+    val fail = parser.parse(tooBig).failed.get
+    assert(fail.isInstanceOf[NumericParserException])
+    assert(fail.getMessage == s"The number '$tooBig' is out of range <Some(-9223372036854775808), Some(9223372036854775807)>")
+  }
+
+  test("base 16 parsing fails on bad input") {
+    val parser = IntegralParser.ofRadix(Radix(16))
+    val wrong = "g"
+    val fail = parser.parse(wrong).failed.get
+    assert(fail.isInstanceOf[NumberFormatException])
+    assert(fail.getMessage == """For input string: "g"""")
+  }
+
+  test("base 2 parsing succeeds") {
+    val parser = IntegralParser.ofRadix(Radix(2))
+    assert(parser.parse("1" * 63) == Success(Long.MaxValue))
+    assert(parser.parse("-10101") == Success(-21))
+  }
+
+  test("base 2 parsing fails on too big number") {
+    val parser = IntegralParser.ofRadix(Radix(2))
+    val tooBig = "1" * 64
+    val result = parser.parse(tooBig)
+    val fail = result.failed.get
+    assert(fail.isInstanceOf[NumericParserException])
+    assert(fail.getMessage == s"The number '$tooBig' is out of range <Some(-9223372036854775808), Some(9223372036854775807)>")
+  }
+
+  test("base 2 parsing fails on wrong input") {
+    val parser = IntegralParser.ofRadix(Radix(2))
+    val wrong = "3"
+    val fail = parser.parse(wrong).failed.get
+    assert(fail.isInstanceOf[NumberFormatException])
+    assert(fail.getMessage == """For input string: """" + wrong + """"""")
+  }
+
+
+  test("base 36 parsing succeeds") {
+    val parser = IntegralParser.ofRadix(Radix(36))
+    assert(parser.parse("Zardoz1") == Success(76838032045L))
+    assert(parser.parse("-Wick3") == Success(-54603795))
+  }
+
+  test("base 36 parsing fails on too big number") {
+    val parser = IntegralParser.ofRadix(Radix(36))
+    val tooBig = "DowningStreet10"
+    val result = parser.parse(tooBig)
+    val fail = result.failed.get
+    assert(fail.isInstanceOf[NumericParserException])
+    assert(fail.getMessage == s"The number '$tooBig' is out of range <Some(-9223372036854775808), Some(9223372036854775807)>")
+  }
+
+  test("base 36 parsing fails on wrong input") {
+    val parser = IntegralParser.ofRadix(Radix(36))
+    val wrong = "__"
+    val fail = parser.parse(wrong).failed.get
+    assert(fail.isInstanceOf[NumberFormatException])
+    assert(fail.getMessage == """For input string: """" + wrong + """"""")
+  }
+
+  test("string base inputs") {
+    assert(IntegralParser.ofStringRadix("").radix.value == 10)
+    assert(IntegralParser.ofStringRadix("DEC").radix.value == 10)
+    assert(IntegralParser.ofStringRadix("decImal").radix.value == 10)
+    assert(IntegralParser.ofStringRadix("Hex").radix.value == 16)
+    assert(IntegralParser.ofStringRadix("HexaDecimal").radix.value == 16)
+    assert(IntegralParser.ofStringRadix("bin").radix.value == 2)
+    assert(IntegralParser.ofStringRadix("binarY").radix.value == 2)
+    assert(IntegralParser.ofStringRadix("oct").radix.value == 8)
+    assert(IntegralParser.ofStringRadix("OCTAL").radix.value == 8)
+    assert(IntegralParser.ofStringRadix("23").radix.value == 23)
+  }
+
+  test("base out of range") {
+    val exception1 = intercept[NumericParserException] {
+      IntegralParser.ofRadix(Radix(0))
+    }
+    assert(exception1.getMessage == "Radix has to be greater then 0, Radix(0) was entered")
+    val exception2 = intercept[NumericParserException] {
+      IntegralParser.ofRadix(Radix(37))
+    }
+    assert(exception2.getMessage == "Maximum supported radix is 36, Radix(37) was entered")
+  }
+
+  test("base not recognized") {
+    val exception = intercept[NumberFormatException] {
+      IntegralParser.ofStringRadix("hello")
+    }
+    assert(exception.getMessage == """For input string: "hello"""")
+  }
+
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser_PatternIntegralParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser_PatternIntegralParserSuite.scala
@@ -1,0 +1,113 @@
+package za.co.absa.enceladus.utils.types.parsers
+
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.numeric.{DecimalSymbols, NumericPattern}
+import za.co.absa.enceladus.utils.types.GlobalDefaults
+import scala.util.Success
+
+class IntegralParser_PatternIntegralParserSuite extends FunSuite {
+  test("No pattern, no limitations") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern(decimalSymbols)
+    val ipLong = IntegralParser[Long](pattern, None, None)
+    val ipInt = IntegralParser[Int](pattern, None, None)
+    val ipShort = IntegralParser[Short](pattern, None, None)
+    val ipByte = IntegralParser[Byte](pattern, None, None)
+    assert(ipLong.parse("98987565664") == Success(98987565664L))
+    assert(ipLong.parse("-31225927393149") == Success(-31225927393149L))
+    assert(ipInt.parse("2100000") == Success(2100000))
+    assert(ipInt.parse("-1000") == Success(-1000))
+    assert(ipShort.parse("16000") == Success(16000))
+    assert(ipShort.parse("-16000") == Success(-16000))
+    assert(ipByte.parse("127") == Success(127))
+    assert(ipByte.parse("-17") == Success(-17))
+  }
+
+  test("No pattern, no limitations, minus sign altered") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols.copy(minusSign = 'N')
+    val pattern = NumericPattern(decimalSymbols)
+    val ipLong = IntegralParser[Long](pattern, None, None)
+    val ipInt = IntegralParser[Int](pattern, None, None)
+    val ipShort = IntegralParser[Short](pattern, None, None)
+    val ipByte = IntegralParser[Byte](pattern, None, None)
+    assert(ipLong.parse("98987565664") == Success(98987565664L))
+    assert(ipLong.parse("N31225927393149") == Success(-31225927393149L))
+    assert(ipLong.parse("-31225927393149").isFailure)
+    assert(ipInt.parse("2100000") == Success(2100000))
+    assert(ipInt.parse("N1000") == Success(-1000))
+    assert(ipInt.parse("-1000").isFailure)
+    assert(ipShort.parse("16000") == Success(16000))
+    assert(ipShort.parse("N16000") == Success(-16000))
+    assert(ipShort.parse("-16000").isFailure)
+    assert(ipByte.parse("127") == Success(127))
+    assert(ipByte.parse("N17") == Success(-17))
+    assert(ipByte.parse("-17").isFailure)
+  }
+
+  test("Limit breaches") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern(decimalSymbols)
+    val ipLong = IntegralParser[Long](pattern, Some(10000000000L), Some(10000000010L))
+    val ipInt = IntegralParser[Int](pattern, Some(-700000), None)
+    val ipShort = IntegralParser[Short](pattern, None, Some(5000))
+    val ipByte = IntegralParser[Byte](pattern, None, None)
+    assert(ipLong.parse("10000000011").isFailure)
+    assert(ipLong.parse("9999999999").isFailure)
+    assert(ipInt.parse("2147483648").isFailure)
+    assert(ipInt.parse("-800000").isFailure)
+    assert(ipShort.parse("5001").isFailure)
+    assert(ipShort.parse("-32769").isFailure)
+    assert(ipByte.parse("128").isFailure)
+    assert(ipByte.parse("-129").isFailure)
+  }
+
+  test("pattern with standard decimal symbols") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("0,000",decimalSymbols)
+    val parser = IntegralParser(pattern)
+
+    assert(parser.parse("100") == Success(100))
+    assert(parser.parse("-1") == Success(-1))
+    assert(parser.parse("1,000") == Success(1000))
+    assert(parser.parse("-2000") == Success(-2000))
+    assert(parser.parse("3,0000") == Success(30000)) // grouping size is not reliable for parsing
+    assert(parser.parse("314E3") == Success(314000))
+    assert(parser.parse("3.14E3").isFailure)
+    assert(parser.parse("-1 ").isFailure)
+    assert(parser.parse(" -1 ").isFailure)
+  }
+
+  test("pattern with altered decimal symbols") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols.copy(
+      decimalSeparator = ',',
+      groupingSeparator = ' ',
+      minusSign = '~'
+    )
+    val pattern = NumericPattern("#,##0",decimalSymbols) //NB! that the standard grouping separator is used
+    val parser = IntegralParser(pattern)
+
+    assert(parser.parse("100") == Success(100))
+    assert(parser.parse("~1") == Success(-1))
+    assert(parser.parse("1 000") == Success(1000))
+    assert(parser.parse("~2 000") == Success(-2000))
+    assert(parser.parse("3 0000") == Success(30000)) // grouping size is not reliable for parsing
+    assert(parser.parse("314E3") == Success(314000))
+    assert(parser.parse("-4").isFailure)
+    assert(parser.parse("3,14E3").isFailure)
+    assert(parser.parse("3.14E3").isFailure)
+    assert(parser.parse("~1 ").isFailure)
+    assert(parser.parse(" ~1 ").isFailure)
+  }
+
+  test("Prefix, suffix and different negative pattern") {
+    val decimalSymbols: DecimalSymbols = GlobalDefaults.getDecimalSymbols
+    val pattern = NumericPattern("Price: 0'EUR';Price: -0'EUR'",decimalSymbols)
+    val parser = IntegralParser(pattern)
+
+    assert(parser.parse("Price: 100EUR") == Success(100))
+    assert(parser.parse("Price: -12EUR") == Success(-12))
+    assert(parser.parse("Price: 1,234EUR").isFailure)
+    assert(parser.parse("Price: 100.0EUR").isFailure)
+    assert(parser.parse("100").isFailure)
+  }
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser_RadixIntegralParserSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/parsers/IntegralParser_RadixIntegralParserSuite.scala
@@ -2,11 +2,12 @@ package za.co.absa.enceladus.utils.types.parsers
 
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.numeric.Radix
+import za.co.absa.enceladus.utils.numeric.Radix.RadixFormatException
 import za.co.absa.enceladus.utils.types.parsers.NumericParser.NumericParserException
 
 import scala.util.Success
 
-class IntegralParser_BaseIntegralParserSuite extends FunSuite {
+class IntegralParser_RadixIntegralParserSuite extends FunSuite {
 
   test("base 10 parsing succeeds") {
     val parser = IntegralParser.ofRadix(Radix(10))
@@ -127,21 +128,30 @@ class IntegralParser_BaseIntegralParserSuite extends FunSuite {
   }
 
   test("base out of range") {
-    val exception1 = intercept[NumericParserException] {
+    val exception1 = intercept[RadixFormatException] {
       IntegralParser.ofRadix(Radix(0))
     }
-    assert(exception1.getMessage == "Radix has to be greater then 0, Radix(0) was entered")
-    val exception2 = intercept[NumericParserException] {
+    assert(exception1.getMessage == "Radix has to be greater then 0, 0 was entered")
+    val exception2 = intercept[RadixFormatException] {
       IntegralParser.ofRadix(Radix(37))
     }
-    assert(exception2.getMessage == "Maximum supported radix is 36, Radix(37) was entered")
+    assert(exception2.getMessage == "Maximum supported radix is 36, 37 was entered")
   }
 
   test("base not recognized") {
-    val exception = intercept[NumberFormatException] {
+    val exception = intercept[RadixFormatException] {
       IntegralParser.ofStringRadix("hello")
     }
-    assert(exception.getMessage == """For input string: "hello"""")
+    assert(exception.getMessage == "'hello' was not recognized as a Radix value")
+  }
+
+  test("base is smaller then 10 and minus is a higher digit") {
+    val decimalSymbols =  NumericParser.defaultDecimalSymbols.copy(minusSign = '5')
+
+    val parser = IntegralParser.ofRadix(Radix(5), decimalSymbols)
+    assert(parser.parse("4321") == Success(586))
+    assert(parser.parse("54321") == Success(-586))
+    assert(parser.parse("-4321").isFailure)
   }
 
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/udf/UDFBuilderSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/udf/UDFBuilderSuite.scala
@@ -1,0 +1,57 @@
+package za.co.absa.enceladus.utils.udf
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.{DoubleType, StructField}
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.types.TypedStructField._
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
+
+class UDFBuilderSuite extends FunSuite {
+  private implicit val defaults: Defaults = GlobalDefaults
+
+  /* TODO Make UDFBuilder work with TypedStructField #1047
+  test("Serialization and deserialization of stringUdfViaTypedStructField") {
+    val fieldName = "test"
+    val field: StructField = StructField(fieldName, LongType, nullable = false)
+    val typedField = TypedStructField(field)
+
+
+    val taggedTypedField = typedField.asInstanceOf[TypedStructFieldTagged[Long]]
+    val defaultValue: Option[Long] = typedField.defaultValueWithGlobal.get.map(_.asInstanceOf[Long])
+    val udfFnc = UDFBuilder.stringUdfViaTypedStructField(taggedTypedField, fieldName, defaultValue)
+    //write
+    val bos = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(bos)
+    out.writeObject(udfFnc)
+    out.flush()
+    val serialized = bos.toByteArray
+    assert(serialized.nonEmpty)
+    //read
+    val ois = new ObjectInputStream(new ByteArrayInputStream(serialized))
+    (ois readObject ()).asInstanceOf[UserDefinedFunction]
+  }
+  */
+
+  test("Serialization and deserialization of stringUdfViaNumericParser") {
+    val fieldName = "test"
+    val field: StructField = StructField(fieldName, DoubleType, nullable = false)
+    val typedField = TypedStructField(field)
+
+
+    val numericTypeField = typedField.asInstanceOf[NumericTypeStructField[Double]]
+    val defaultValue: Option[Double] = typedField.defaultValueWithGlobal.get.map(_.asInstanceOf[Double])
+    val udfFnc = UDFBuilder.stringUdfViaNumericParser(numericTypeField.parser.get, numericTypeField.nullable, fieldName, defaultValue)
+    //write
+    val bos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(bos)
+    oos.writeObject(udfFnc)
+    oos.flush()
+    val serialized = bos.toByteArray
+    assert(serialized.nonEmpty)
+    //read
+    val ois = new ObjectInputStream(new ByteArrayInputStream(serialized))
+    (ois readObject ()).asInstanceOf[UserDefinedFunction]
+  }
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/udf/UDFBuilderSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/udf/UDFBuilderSuite.scala
@@ -3,38 +3,18 @@ package za.co.absa.enceladus.utils.udf
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.types.{DoubleType, StructField}
+import org.apache.spark.sql.types.{DecimalType, DoubleType, LongType, MetadataBuilder, ShortType, StructField}
 import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.types.TypedStructField._
+import za.co.absa.enceladus.utils.types.parsers.{DecimalParser, FractionalParser}
+import za.co.absa.enceladus.utils.types.parsers.IntegralParser.{PatternIntegralParser, RadixIntegralParser}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
 
 class UDFBuilderSuite extends FunSuite {
   private implicit val defaults: Defaults = GlobalDefaults
 
-  /* TODO Make UDFBuilder work with TypedStructField #1047
-  test("Serialization and deserialization of stringUdfViaTypedStructField") {
-    val fieldName = "test"
-    val field: StructField = StructField(fieldName, LongType, nullable = false)
-    val typedField = TypedStructField(field)
-
-
-    val taggedTypedField = typedField.asInstanceOf[TypedStructFieldTagged[Long]]
-    val defaultValue: Option[Long] = typedField.defaultValueWithGlobal.get.map(_.asInstanceOf[Long])
-    val udfFnc = UDFBuilder.stringUdfViaTypedStructField(taggedTypedField, fieldName, defaultValue)
-    //write
-    val bos = new ByteArrayOutputStream
-    val out = new ObjectOutputStream(bos)
-    out.writeObject(udfFnc)
-    out.flush()
-    val serialized = bos.toByteArray
-    assert(serialized.nonEmpty)
-    //read
-    val ois = new ObjectInputStream(new ByteArrayInputStream(serialized))
-    (ois readObject ()).asInstanceOf[UserDefinedFunction]
-  }
-  */
-
-  test("Serialization and deserialization of stringUdfViaNumericParser") {
+  test("Serialization and deserialization of stringUdfViaNumericParser (FractionalParser)") {
     val fieldName = "test"
     val field: StructField = StructField(fieldName, DoubleType, nullable = false)
     val typedField = TypedStructField(field)
@@ -42,16 +22,89 @@ class UDFBuilderSuite extends FunSuite {
 
     val numericTypeField = typedField.asInstanceOf[NumericTypeStructField[Double]]
     val defaultValue: Option[Double] = typedField.defaultValueWithGlobal.get.map(_.asInstanceOf[Double])
-    val udfFnc = UDFBuilder.stringUdfViaNumericParser(numericTypeField.parser.get, numericTypeField.nullable, fieldName, defaultValue)
+    val parser = numericTypeField.parser.get.asInstanceOf[FractionalParser[Double]]
+    val udfFnc = UDFBuilder.stringUdfViaNumericParser(parser, numericTypeField.nullable, fieldName, defaultValue)
     //write
-    val bos = new ByteArrayOutputStream
-    val oos = new ObjectOutputStream(bos)
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
     oos.writeObject(udfFnc)
     oos.flush()
-    val serialized = bos.toByteArray
+    val serialized = baos.toByteArray
     assert(serialized.nonEmpty)
     //read
     val ois = new ObjectInputStream(new ByteArrayInputStream(serialized))
     (ois readObject ()).asInstanceOf[UserDefinedFunction]
   }
+
+  test("Serialization and deserialization of stringUdfViaNumericParser (DecimalParser)") {
+    val fieldName = "test"
+    val field: StructField = StructField(fieldName, DecimalType(20,5), nullable = false)
+    val typedField = TypedStructField(field)
+
+
+    val numericTypeField = typedField.asInstanceOf[NumericTypeStructField[BigDecimal]]
+    val defaultValue = typedField.defaultValueWithGlobal.get.map(_.asInstanceOf[BigDecimal])
+    val parser = numericTypeField.parser.get.asInstanceOf[DecimalParser]
+    val udfFnc = UDFBuilder.stringUdfViaNumericParser(parser, numericTypeField.nullable, fieldName, defaultValue)
+    //write
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(udfFnc)
+    oos.flush()
+    val serialized = baos.toByteArray
+    assert(serialized.nonEmpty)
+    //read
+    val ois = new ObjectInputStream(new ByteArrayInputStream(serialized))
+    (ois readObject ()).asInstanceOf[UserDefinedFunction]
+  }
+
+  test("Serialization and deserialization of stringUdfViaNumericParser (RadixIntegralParser)") {
+    val fieldName = "test"
+    val field: StructField = StructField(fieldName, LongType, nullable = false, new MetadataBuilder()
+      .putString(MetadataKeys.Radix, "hex")
+      .putString(MetadataKeys.DefaultValue, "FF")
+      .build)
+    val typedField = TypedStructField(field)
+
+
+    val numericTypeField = typedField.asInstanceOf[NumericTypeStructField[Long]]
+    val defaultValue: Option[Long] = typedField.defaultValueWithGlobal.get.map(_.asInstanceOf[Long])
+    val parser = numericTypeField.parser.get.asInstanceOf[RadixIntegralParser[Long]]
+    val udfFnc = UDFBuilder.stringUdfViaNumericParser(parser, numericTypeField.nullable, fieldName, defaultValue)
+    //write
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(udfFnc)
+    oos.flush()
+    val serialized = baos.toByteArray
+    assert(serialized.nonEmpty)
+    //read
+    val ois = new ObjectInputStream(new ByteArrayInputStream(serialized))
+    (ois readObject ()).asInstanceOf[UserDefinedFunction]
+  }
+
+  test("Serialization and deserialization of stringUdfViaNumericParser (PatternIntegralParser)") {
+    val fieldName = "test"
+    val field: StructField = StructField(fieldName, ShortType, nullable = true, new MetadataBuilder()
+      .putString(MetadataKeys.Pattern, "0 feet")
+      .build)
+    val typedField = TypedStructField(field)
+
+
+    val numericTypeField = typedField.asInstanceOf[NumericTypeStructField[Short]]
+    val defaultValue: Option[Short] = typedField.defaultValueWithGlobal.get.map(_.asInstanceOf[Short])
+    val parser = numericTypeField.parser.get.asInstanceOf[PatternIntegralParser[Short]]
+    val udfFnc = UDFBuilder.stringUdfViaNumericParser(parser, numericTypeField.nullable, fieldName, defaultValue)
+    //write
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(udfFnc)
+    oos.flush()
+    val serialized = baos.toByteArray
+    assert(serialized.nonEmpty)
+    //read
+    val ois = new ObjectInputStream(new ByteArrayInputStream(serialized))
+    (ois readObject ()).asInstanceOf[UserDefinedFunction]
+  }
+
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/DateFieldValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/DateFieldValidatorSuite.scala
@@ -17,19 +17,21 @@ package za.co.absa.enceladus.utils.validation.field
 
 import org.apache.spark.sql.types.{DateType, MetadataBuilder, StructField}
 import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
-import za.co.absa.enceladus.utils.types.TypedStructField
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
 import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue, ValidationWarning}
 
 class DateFieldValidatorSuite extends FunSuite  {
   TimeZoneNormalizer.normalizeJVMTimeZone()
+  private implicit val defaults: Defaults = GlobalDefaults
 
   private def field(pattern: String, defaultValue: Option[String] = None, defaultTimeZone: Option[String] = None): TypedStructField = {
-    val builder = new MetadataBuilder().putString("pattern",pattern)
-    val builder2 = defaultValue.map(builder.putString("default", _)).getOrElse(builder)
-    val builder3 = defaultTimeZone.map(builder2.putString("timezone", _)).getOrElse(builder2)
+    val builder = new MetadataBuilder().putString(MetadataKeys.Pattern, pattern)
+    val builder2 = defaultValue.map(builder.putString(MetadataKeys.DefaultValue, _)).getOrElse(builder)
+    val builder3 = defaultTimeZone.map(builder2.putString(MetadataKeys.DefaultTimeZone, _)).getOrElse(builder2)
     val result = StructField("test_field", DateType,  nullable = false, builder3.build())
-    TypedStructField(result)
+    TypedStructField.asDateTimeTypeStructField(result)
   }
 
   test("epoch pattern") {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/DateFieldValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/DateFieldValidatorSuite.scala
@@ -31,7 +31,7 @@ class DateFieldValidatorSuite extends FunSuite  {
     val builder2 = defaultValue.map(builder.putString(MetadataKeys.DefaultValue, _)).getOrElse(builder)
     val builder3 = defaultTimeZone.map(builder2.putString(MetadataKeys.DefaultTimeZone, _)).getOrElse(builder2)
     val result = StructField("test_field", DateType,  nullable = false, builder3.build())
-    TypedStructField.asDateTimeTypeStructField(result)
+    TypedStructField(result)
   }
 
   test("epoch pattern") {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FractionalFieldValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/FractionalFieldValidatorSuite.scala
@@ -1,0 +1,75 @@
+package za.co.absa.enceladus.utils.validation.field
+
+import org.apache.spark.sql.types.{DataType, DoubleType, FloatType, MetadataBuilder, StructField}
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.schema.MetadataKeys
+import za.co.absa.enceladus.utils.types.TypedStructField.FractionalTypeStructField
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
+import za.co.absa.enceladus.utils.validation.ValidationError
+
+class FractionalFieldValidatorSuite extends FunSuite {
+  private implicit val defaults: Defaults = GlobalDefaults
+
+  private def field(dataType: DataType, metadataBuilder: MetadataBuilder): FractionalTypeStructField[_] = {
+    val result = StructField("test_field", dataType,  nullable = false, metadataBuilder.build())
+    TypedStructField(result).asInstanceOf[FractionalTypeStructField[_]]
+  }
+
+  test("No allow_infinity metadata") {
+    val builder = new MetadataBuilder
+    val f = field(FloatType, builder)
+    assert(FractionalFieldValidator.validate(f).isEmpty)
+  }
+
+  test("allow_infinity metadata defined") {
+    val builder1 = new MetadataBuilder().putString(MetadataKeys.AllowInfinity, "false")
+    val f1 = field(FloatType, builder1)
+    assert(FractionalFieldValidator.validate(f1).isEmpty)
+    val builder2 = new MetadataBuilder().putString(MetadataKeys.AllowInfinity, "True")
+    val f2 = field(DoubleType, builder2)
+    assert(FractionalFieldValidator.validate(f2).isEmpty)
+  }
+
+  test("allow_infinity not boolean") {
+    val builder = new MetadataBuilder().putString(MetadataKeys.AllowInfinity, "23")
+    val f = field(FloatType, builder)
+    assert(FractionalFieldValidator.validate(f) == Seq(
+      ValidationError(s"${MetadataKeys.AllowInfinity} metadata value of field 'test_field' is not Boolean in String format")
+    ))
+  }
+
+  test("allow_infinity boolean in binary form") {
+    val builder = new MetadataBuilder().putBoolean(MetadataKeys.AllowInfinity, value = true)
+    val f = field(FloatType, builder)
+    assert(FractionalFieldValidator.validate(f) == Seq(
+      ValidationError(s"${MetadataKeys.AllowInfinity} metadata value of field 'test_field' is not Boolean in String format")
+    ))
+  }
+
+  test("Decimal symbols redefined wrongly, invalid pattern") {
+    val builder = new MetadataBuilder()
+      .putString(MetadataKeys.GroupingSeparator, "")
+      .putString(MetadataKeys.DecimalSeparator, "xxx")
+      .putLong(MetadataKeys.MinusSign, 1)
+      .putString(MetadataKeys.Pattern, "0.###,#")
+    val f = field(DoubleType, builder)
+    val exp = Set(
+      ValidationError(s"${MetadataKeys.GroupingSeparator} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError(s"${MetadataKeys.DecimalSeparator} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError(s"${MetadataKeys.MinusSign} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError("""Malformed pattern "0.###,#"""")
+    )
+    assert(NumericFieldValidator.validate(f).toSet == exp)
+  }
+
+  test("Pattern defined, default value doesn't adhere to it") {
+    val builder = new MetadataBuilder()
+      .putString(MetadataKeys.Pattern, "0.#MPH")
+      .putString(MetadataKeys.DefaultValue, "0.0")
+    val f = field(FloatType, builder)
+    assert(NumericFieldValidator.validate(f) == Seq(
+      ValidationError("Parsing of '0.0' failed.")
+    ))
+  }
+
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/IntegralFieldValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/IntegralFieldValidatorSuite.scala
@@ -1,0 +1,73 @@
+package za.co.absa.enceladus.utils.validation.field
+
+import org.apache.spark.sql.types.{ByteType, DataType, IntegerType, LongType, MetadataBuilder, ShortType, StructField}
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.numeric.Radix
+import za.co.absa.enceladus.utils.schema.MetadataKeys
+import za.co.absa.enceladus.utils.types.TypedStructField.IntegralTypeStructField
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
+import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationWarning}
+
+class IntegralFieldValidatorSuite extends FunSuite {
+  private implicit val defaults: Defaults = GlobalDefaults
+
+  private def field(dataType: DataType, metadataBuilder: MetadataBuilder): IntegralTypeStructField[_] = {
+    val result = StructField("test_field", dataType,  nullable = false, metadataBuilder.build())
+    TypedStructField(result).asInstanceOf[IntegralTypeStructField[_]]
+  }
+
+  private def field(dataType: DataType, pattern: Option[String], radix: Option[Radix]): IntegralTypeStructField[_] = {
+    val builder = new MetadataBuilder()
+    val builder2 = pattern.map(builder.putString(MetadataKeys.Pattern, _)).getOrElse(builder)
+    val builder3 = radix.map(r => builder2.putString(MetadataKeys.Radix, r.value.toString)).getOrElse(builder2)
+    field(dataType, builder3)
+  }
+
+  test("No Radix nor Pattern defined") {
+    val f = field(LongType, None, None)
+    assert(IntegralFieldValidator.validate(f).isEmpty)
+  }
+
+  test("Radix and Pattern collide") {
+    val f = field(IntegerType, Option("##0"), Option(Radix(3)))
+    assert(IntegralFieldValidator.validate(f) == Seq(
+      ValidationWarning("Both Radix and Pattern defined for field test_field, for Radix different from Radix(10) Pattern is ignored"))
+    )
+  }
+
+  test("Radix defined as default, Pattern defined non-default") {
+    val f = field(ByteType, Option("##0"), Option(Radix(10)))
+    assert(IntegralFieldValidator.validate(f).isEmpty)
+  }
+
+  test("Radix defined is non-default, Pattern defined as default") {
+    val f = field(ShortType, Option(""), Option(Radix(16)))
+    assert(IntegralFieldValidator.validate(f).isEmpty)
+  }
+
+  test("Decimal symbols redefined wrongly, invalid pattern") {
+    val builder = new MetadataBuilder()
+      .putString(MetadataKeys.GroupingSeparator, "Hello")
+      .putLong(MetadataKeys.DecimalSeparator, 789)
+      .putString(MetadataKeys.MinusSign, "")
+      .putString(MetadataKeys.Pattern, "%0.###,#")
+    val f = field(LongType, builder)
+    val exp = Set(
+      ValidationError(s"${MetadataKeys.GroupingSeparator} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError(s"${MetadataKeys.DecimalSeparator} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError(s"${MetadataKeys.MinusSign} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError("""Malformed pattern "%0.###,#"""")
+    )
+    assert(NumericFieldValidator.validate(f).toSet == exp)
+  }
+
+  test("Pattern defined, default value doesn't adhere to it") {
+    val builder = new MetadataBuilder()
+      .putString(MetadataKeys.Pattern, "0XP")
+      .putString(MetadataKeys.DefaultValue, "0.0XP")
+    val f = field(IntegerType, builder)
+    assert(NumericFieldValidator.validate(f) == Seq(
+      ValidationError("Parsing of '0.0XP' failed.")
+    ))
+  }
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/NumericFieldValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/NumericFieldValidatorSuite.scala
@@ -1,0 +1,76 @@
+package za.co.absa.enceladus.utils.validation.field
+
+import org.apache.spark.sql.types.{DataType, DecimalType, MetadataBuilder, StructField}
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.schema.MetadataKeys
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
+import za.co.absa.enceladus.utils.types.TypedStructField.NumericTypeStructField
+import za.co.absa.enceladus.utils.validation.ValidationError
+
+class NumericFieldValidatorSuite extends FunSuite {
+  private implicit val defaults: Defaults = GlobalDefaults
+
+  private def field(metadataBuilder: MetadataBuilder): NumericTypeStructField[_] = {
+    val result = StructField("test_field", DecimalType(15, 5),  nullable = false, metadataBuilder.build())
+    TypedStructField(result).asInstanceOf[NumericTypeStructField[_]]
+  }
+
+
+  test("No extra metadata") {
+    val builder = new MetadataBuilder
+    val f = field(builder)
+    assert(NumericFieldValidator.validate(f).isEmpty)
+  }
+
+  test("Decimal symbols redefined") {
+    val builder = new MetadataBuilder()
+      .putString(MetadataKeys.GroupingSeparator, " ")
+      .putString(MetadataKeys.DecimalSeparator, ",")
+      .putString(MetadataKeys.MinusSign, "N")
+    val f = field(builder)
+    assert(NumericFieldValidator.validate(f).isEmpty)
+  }
+
+  test("Pattern defined") {
+    val builder = new MetadataBuilder()
+      .putString(MetadataKeys.Pattern, "#,##0.#%")
+      .putString(MetadataKeys.DefaultValue, "100%")
+    val f = field(builder)
+    assert(NumericFieldValidator.validate(f).isEmpty)
+  }
+
+  test("Pattern not string") {
+    val builder = new MetadataBuilder()
+      .putLong(MetadataKeys.Pattern, 0)
+    val f = field(builder)
+    assert(NumericFieldValidator.validate(f) == Seq(
+      ValidationError(s"${MetadataKeys.Pattern} metadata value of field 'test_field' is not String in String format")
+    ))
+  }
+
+  test("Decimal symbols redefined wrongly, invalid pattern") {
+    val builder = new MetadataBuilder()
+      .putBoolean(MetadataKeys.GroupingSeparator, value = false)
+      .putString(MetadataKeys.DecimalSeparator, "")
+      .putString(MetadataKeys.MinusSign, "xyz")
+      .putString(MetadataKeys.Pattern, "0.0.0.0")
+    val f = field(builder)
+    val exp = Set(
+      ValidationError(s"${MetadataKeys.GroupingSeparator} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError(s"${MetadataKeys.DecimalSeparator} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError(s"${MetadataKeys.MinusSign} metadata value of field 'test_field' is not Char in String format"),
+      ValidationError("""Multiple decimal separators in pattern "0.0.0.0"""")
+    )
+    assert(NumericFieldValidator.validate(f).toSet == exp)
+  }
+
+  test("Pattern defined, default value doesn't adhere to it") {
+    val builder = new MetadataBuilder()
+      .putString(MetadataKeys.Pattern, "#,##0.#%")
+      .putString(MetadataKeys.DefaultValue, "100")
+    val f = field(builder)
+    assert(NumericFieldValidator.validate(f) == Seq(
+      ValidationError("Parsing of '100' failed.")
+    ))
+  }
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/TimestampFieldValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/TimestampFieldValidatorSuite.scala
@@ -17,17 +17,19 @@ package za.co.absa.enceladus.utils.validation.field
 
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, TimestampType}
 import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
-import za.co.absa.enceladus.utils.types.TypedStructField
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
 import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue, ValidationWarning}
 
 class TimestampFieldValidatorSuite extends FunSuite  {
   TimeZoneNormalizer.normalizeJVMTimeZone()
+  private implicit val defaults: Defaults = GlobalDefaults
 
   private def field(pattern: String, defaultValue: Option[String] = None, defaultTimeZone: Option[String] = None): TypedStructField = {
-    val builder = new MetadataBuilder().putString("pattern",pattern)
-    val builder2 = defaultValue.map(builder.putString("default", _)).getOrElse(builder)
-    val builder3 = defaultTimeZone.map(builder2.putString("timezone", _)).getOrElse(builder2)
+    val builder = new MetadataBuilder().putString(MetadataKeys.Pattern, pattern)
+    val builder2 = defaultValue.map(builder.putString(MetadataKeys.DefaultValue, _)).getOrElse(builder)
+    val builder3 = defaultTimeZone.map(builder2.putString(MetadataKeys.DefaultTimeZone, _)).getOrElse(builder2)
     val result = StructField("test_field", TimestampType,  nullable = false, builder3.build())
     TypedStructField(result)
   }


### PR DESCRIPTION
* Numeric fields in schema definition now support patterns (using classes bellow)
* Pattern parsing classes for numeric types (`IntegralParser`, `FractionalParser`,` DecimalParser`)
* `NumericPattern` class to represent pattern for numbers
* `Radix` class for integers radix representation
* `TypeStructField` subclasses have bigger granularity
* TypeClasses: `LongLike`, `DoubleLike`
* Metadata key change "allowifinity" -> "allow_infinity"
* type parser now switches to UDF if pattern or radix is used for numbers
* `UDFResult` class to represent a result from UDF call
* Schema validations enhanced to cover new metadata
* Defaults is now an implicit class wherever used
* Defaults now returns `DecimalSymbols` case class too
* `StringImplicits`->`replaceChars`
* `OptionImplicits`->`toTry`
* `StructFieldImplicits`->`getMetadataChar`
* Bunch of UTs