### PR TITLE
1053 Allow disk use for get all run summaries query

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/RunMongoRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/RunMongoRepository.scala
@@ -120,6 +120,7 @@ class RunMongoRepository @Autowired()(mongoDb: MongoDatabase)
     )
     collection
       .aggregate[RunSummary](pipeline)
+      .allowDiskUse(true)
       .toFuture()
   }
 


### PR DESCRIPTION
This is a workaround we won't need after #273. As it stands the current Runs Navigation is unusable. The only reason we should keep this endpoint alive is because people might be using it. We should mark it deprecated and remove it in version 2.0.0