### PR TITLE
#1067: Remove Usage chapter from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,34 +11,33 @@ ___
 
 <!-- toc -->
 - [What is Enceladus?](#what-is-enceladus)
-    - [Menas](#wie-menas)
-    - [Standardization](#wie-standardization)
-    - [Conformance](#wie-conformance)
-- [How to build](#build)
-- [How to run](#run)
-- [How to contribute](#contribute)
-- [How to use](#use)
-    - [Standardization](#use-standardization)
+    - [Menas](#menas)
+    - [Standardization](#standardization)
+    - [Conformance](#conformance)
+- [How to build](#how-to-build)
+- [How to run](#how-to-run)
+- [How to contribute](#how-to-contribute)
+- [Documentation](#documentation)
 <!-- tocstop -->
 
-## <a name="what-is-enceladus"/>What is Enceladus?
+## What is Enceladus?
 **Enceladus** is a **Dynamic Conformance Engine** which allows data from different formats to be standardized to parquet and conformed to group-accepted common reference (e.g. data for country designation which are **DE** in one source system and **Deutschland** in another, can be conformed to **Germany**).
 
 The project is comprised of three main components:
-### <a name="wie-menas"/>Menas
+### Menas
 This is the user-facing web client, used to **specify the standardization schema**, and **define the steps required to conform** a dataset.  
 There are three models used to do this:
  - **Dataset**: Specifies where the dataset will be read from on HDFS (**RAW**), the conformance rules that will be applied to it, and where it will land on HDFS once it is conformed (**PUBLISH**)
  - **Schema**: Specifies the schema towards which the dataset will be standardized
  - **Mapping Table**: Specifies where tables with master reference data can be found (parquet on HDFS), which are used when applying Mapping conformance rules (e.g. the dataset uses **Germany**, which maps to the master reference **DE** in the mapping table)
 
-### <a name="wie-standardization"/>Standardization
+### Standardization
 This is a Spark job which reads an input dataset in any of the supported formats and **produces a parquet dataset with the Menas-specified schema** as output. 
 
-### <a name="wie-conformance"/>Conformance
+### Conformance
 This is a Spark job which **applies the Menas-specified conformance rules to the standardized dataset**.
 
-## <a name="build"/>How to build
+## How to build
 #### Build requirements:
  - **Maven 3.5.4+**
  - **Java 8**
@@ -59,7 +58,7 @@ Ensure the properties there fit your environment.
 
 The coverage reports are written in each module's `target` directory and aggregated in the root `target` directory.
 
-## <a name="run"/>How to run
+## How to run
 #### Menas requirements:
 - [**Tomcat 8.5/9.0** installation](https://tomcat.apache.org/download-90.cgi)
 - [**MongoDB 4.0** installation](https://docs.mongodb.com/manual/administration/install-community/)
@@ -180,17 +179,17 @@ The basic command to run Conformance becomes:
 
 The list of options for configuring Spark deployment mode in Yarn and resource specification:
 
-|            Option          |                           Description |
-| -------------------------- |:----------------------------------------------------------------------------- |
-| --deploy-mode **cluster/client**  | Specifies a Spark Application deployment mode when Spark runs on Yarn. Can be either `client` or `cluster`. |
-| --num-executors **n**      | Specifies the number of executors to use. |
-| --executor-memory **mem**  | Specifies an amount of memory to request for each executor. See memory specification syntax in Spark. Examples: `4g`, `8g`. |
-| --executor-cores **mem**   | Specifies a number of cores to request for each executor (default=1). |
-| --driver-cores **n**       | Specifies a number of CPU cores to allocate for the driver process. |
-| --driver-memory **mem**    | Specifies an amount of memory to request for the driver process. See memory specification syntax in Spark. Examples: `4g`, `8g`. |
-| --persist-storage-level **level** | **Advanced** Specifies the storage level to use for persisting intermediate results. Can be one of `NONE`, `DISK_ONLY`, `MEMORY_ONLY`, `MEMORY_ONLY_SER`, `MEMORY_AND_DISK` (default), `MEMORY_AND_DISK_SER`, etc. See more [here](https://spark.apache.org/docs/2.4.4/api/java/index.html?org/apache/spark/storage/StorageLevel.html). |
-| --conf-spark-executor-memoryOverhead **mem** | **Adnavced**. The amount of off-heap memory to be allocated per executor, in MiB unless otherwise specified. Sets `spark.executor.memoryOverhead` Spark configuration parameter. See the detailed description [here](http://spark.apache.org/docs/latest/configuration.html#available-properties). See memory specification syntax in Spark. Examples: `4g`, `8g`. |
-| --conf-spark-memory-fraction **value** | **Adnavced**. Fraction of (heap space - 300MB) used for execution and storage (default=`0.6`). Sets `spark.memory.fraction` Spark configuration parameter. See the detailed description [here](http://spark.apache.org/docs/latest/configuration.html#memory-management). |
+|            Option                            |                           Description                                                                       |
+|----------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| --deploy-mode **cluster/client**             | Specifies a Spark Application deployment mode when Spark runs on Yarn. Can be either `client` or `cluster`. |
+| --num-executors **n**                        | Specifies the number of executors to use. |
+| --executor-memory **mem**                    | Specifies an amount of memory to request for each executor. See memory specification syntax in Spark. Examples: `4g`, `8g`. |
+| --executor-cores **mem**                     | Specifies a number of cores to request for each executor (default=1). |
+| --driver-cores **n**                         | Specifies a number of CPU cores to allocate for the driver process. |
+| --driver-memory **mem**                      | Specifies an amount of memory to request for the driver process. See memory specification syntax in Spark. Examples: `4g`, `8g`. |
+| --persist-storage-level **level**            | **Advanced** Specifies the storage level to use for persisting intermediate results. Can be one of `NONE`, `DISK_ONLY`, `MEMORY_ONLY`, `MEMORY_ONLY_SER`, `MEMORY_AND_DISK` (default), `MEMORY_AND_DISK_SER`, etc. See more [here](https://spark.apache.org/docs/2.4.4/api/java/index.html?org/apache/spark/storage/StorageLevel.html). |
+| --conf-spark-executor-memoryOverhead **mem** | **Advanced**. The amount of off-heap memory to be allocated per executor, in MiB unless otherwise specified. Sets `spark.executor.memoryOverhead` Spark configuration parameter. See the detailed description [here](http://spark.apache.org/docs/latest/configuration.html#available-properties). See memory specification syntax in Spark. Examples: `4g`, `8g`. |
+| --conf-spark-memory-fraction **value**       | **Advanced**. Fraction of (heap space - 300MB) used for execution and storage (default=`0.6`). Sets `spark.memory.fraction` Spark configuration parameter. See the detailed description [here](http://spark.apache.org/docs/latest/configuration.html#memory-management). |
 
 
 For more information on these options see the official documentation on running Spark on Yarn: 
@@ -198,157 +197,43 @@ For more information on these options see the official documentation on running 
 
 The list of all options for running both Standardization and Conformance:
 
-|            Option          |                           Description |
-| -------------------------- |:----------------------------------------------------------------------------- |
-| --menas-auth-keytab **filename** | A keytab file used for Kerberized authentication to Menas. Cannot be used together with `--menas-credentials-file`. |
-| --menas-credentials-file **filename** | A credentials file containing a login and a password used to authenticate to Menas. Cannot be used together with `--menas-auth-keytab`. |
-| --dataset-name **name** | A dataset name to be standardized or conformed. |
-| --dataset-version **version** | A version of a dataset to be standardized or conformed. |
-| --report-date **YYYY-mm-dd** | A date specifying a day for which a raw data is landed. |
-| --report-version **version** | A version of the data for a particular day. |
-| --std-hdfs-path **path**   | A path pattern where to put standardized data. The following tokens are expending in the pattern: `{0}` - dataset name, `{1}` - dataset verrsion, `{2}`- report date, `{3}`- report version. |
+|            Option                     |                           Description                                                                                                                                                       |
+|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --menas-auth-keytab **filename**      | A keytab file used for Kerberized authentication to Menas. Cannot be used together with `--menas-credentials-file`.                                                                         |
+| --menas-credentials-file **filename** | A credentials file containing a login and a password used to authenticate to Menas. Cannot be used together with `--menas-auth-keytab`.                                                     |
+| --dataset-name **name**               | A dataset name to be standardized or conformed.                                                                                                                                             |
+| --dataset-version **version**         | A version of a dataset to be standardized or conformed.                                                                                                                                     |
+| --report-date **YYYY-mm-dd**          | A date specifying a day for which a raw data is landed.                                                                                                                                     |
+| --report-version **version**          | A version of the data for a particular day.                                                                                                                                                 |
+| --std-hdfs-path **path**              | A path pattern where to put standardized data. The following tokens are expending in the pattern: `{0}` - dataset name, `{1}` - dataset version, `{2}`- report date, `{3}`- report version. |
 
 The list of additional options available for running Standardization:
 
-|            Option          |                           Description |
-| -------------------------- |:----------------------------------------------------------------------------- |
-| --raw-format **format**    | A format for input data. Can be one of `parquet`, `json`, `csv`, `xml`, `cobol`, `fixed-width`. |
-| --charset **charset**      | Specifies a charset to use for `csv`, `json` or `xml`. Default is `UTF-8`.    |
-| --row-tag **tag**          | A row tag if the input format is `xml`.                                       |
-| --header **true/false**    | Indicates if in the input CSV data has headers as the first row of each file. |
-| --delimiter **character**  | Specifies a delmiter character to use for CSV format. By default `,` is used. |
-| --csv-quote **character**  | Specifies a character to be used as a quote for creating fields that might contain delimiter character. By default `"` is used. |
-| --csv-escape **character** | Specifies a character to be used for escaping other characters. By default '&#92;' (backslash) is used. |
-| --trimValues **true/false** | Indicates if string fields of fixed with text data should be trimmed.        |
-| --is-xcom **true/false**   | If `true` a mainframe input file is expected to have XCOM RDW headers.        |
-| --folder-prefix **prefix** | Adds a folder prefix before the date tokens.                                  |
-| --debug-set-raw-path **path** | Override the path of the raw data (used for testing purposes).             |
+|            Option             |                           Description                                                                                           |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| --raw-format **format**       | A format for input data. Can be one of `parquet`, `json`, `csv`, `xml`, `cobol`, `fixed-width`.                                 |
+| --charset **charset**         | Specifies a charset to use for `csv`, `json` or `xml`. Default is `UTF-8`.                                                      |
+| --row-tag **tag**             | A row tag if the input format is `xml`.                                                                                         |
+| --header **true/false**       | Indicates if in the input CSV data has headers as the first row of each file.                                                   |
+| --delimiter **character**     | Specifies a delimiter character to use for CSV format. By default `,` is used.                                                  |
+| --csv-quote **character**     | Specifies a character to be used as a quote for creating fields that might contain delimiter character. By default `"` is used. |
+| --csv-escape **character**    | Specifies a character to be used for escaping other characters. By default '&#92;' (backslash) is used.                         |
+| --trimValues **true/false**   | Indicates if string fields of fixed with text data should be trimmed.                                                           |
+| --is-xcom **true/false**      | If `true` a mainframe input file is expected to have XCOM RDW headers.                                                          |
+| --folder-prefix **prefix**    | Adds a folder prefix before the date tokens.                                                                                    |
+| --debug-set-raw-path **path** | Override the path of the raw data (used for testing purposes).                                                                  |
 
 The list of additional options available for running Conformance:
 
-|            Option          |                           Description |
-| -------------------------- |:----------------------------------------------------------------------------- |
-| --mapping-table-pattern **pattern** | A pattern to look for mapping table for the specified date.<br>The list of possible substitutions: `{0}` - year, `{1}` - month, `{2}` - day of month. By default the pattern is `reportDate={0}-{1}-{2}`. Special symbols in the pattern need to be escaped. For example, an empty pattern can be be specified as `\'\'` (single quotes are escaped using a backslash character).|
+|            Option                          |                           Description                                        |
+|--------------------------------------------|------------------------------------------------------------------------------|
+| --mapping-table-pattern **pattern**        | A pattern to look for mapping table for the specified date.<br>The list of possible substitutions: `{0}` - year, `{1}` - month, `{2}` - day of month. By default the pattern is `reportDate={0}-{1}-{2}`. Special symbols in the pattern need to be escaped. For example, an empty pattern can be be specified as `\'\'` (single quotes are escaped using a backslash character).|
 | --experimental-mapping-rule **true/false** | If `true`, the experimental optimized mapping rule implementation is used. The default value is build-specific and is set in 'application.properties'. |
-| --catalyst-workaround **true/false** | Turns on (`true`) or off (`false`) workaround for Catalyst optimizer issue. It is `true` by default. Turn this off only is you encounter timing freeze issues when running Conformance. | 
-| --autoclean-std-folder **true/false** | If `true`, the standardized folder will be cleaned automatically after successful execution of a Conformance job. |
+| --catalyst-workaround **true/false**       | Turns on (`true`) or off (`false`) workaround for Catalyst optimizer issue. It is `true` by default. Turn this off only is you encounter timing freeze issues when running Conformance. | 
+| --autoclean-std-folder **true/false**      | If `true`, the standardized folder will be cleaned automatically after successful execution of a Conformance job. |
 
-## <a name="contribute"/>How to contribute
+## How to contribute
 Please see our [**Contribution Guidelines**](CONTRIBUTING.md).
 
-## <a name="use"/>How to use
-In this section some more complex and less obvious usage patterns are going to be described.
-
-### <a name="use-standardization"/>Standardization
-#### Adjusting Standardization Of Data
-_Standardization_ can be influenced by `metadata` in the schema of the data. These are the possible properties taken
-into account with the description of their purpose.
-
-| Property | Target data type | Description | Example |
-| --- | --- | --- | --- |
-| _sourcecolumn_ | any | The source column to provide data of the described column | _id_ |
-| _default_ | any atomic type| Default value to use in case data are missing | _0_ |
-| _pattern_ | date & timestamp | Pattern for the date or timestamp representation | _dd.MM.yy_ |
-| _timezone_ | timestamp (also date) | The time zone of the timestamp when that is not part of the pattern (NB! for date it can return unexpected results) | _US/Pacific_ |
-
-Schema entry example:
-```
-{
-    "name": "MODIFIEDTIMESTAMP",
-    "type": "timestamp",
-    "nullable": true,
-    "metadata": {    
-        "description": "Timestamp when the row was last changed.",
-        "sourcecolumn": "MODIFIED"
-        "default": "1970/01/01 01-00-00"
-        "pattern": "yyyy/MM/dd HH-mm-ss"
-        "timezone": "CET"
-    }
-}
-  ```
-
-#### Date & time
-Dates and especially timestamps (date + time) can be tricky. Currently Spark considers all time entries to be in the 
-current system time zone by default. (For more detailed explanation of possible issues with that see 
-[Consistent timestamp types in Hadoop SQL engines](https://docs.google.com/document/d/1gNRww9mZJcHvUDCXklzjFEQGpefsuR_akCDfWsdE35Q/edit#heading=h.n699ftkvhjlo).)
-
-To address this potential source of discrepancies the following has been implemented:
-1. All Enceladus components are set to run in UTC
-1. As part of **Standardization** all time related entries are normalized to UTC
-1. There are several methods how to ensure that a timestamp entry is normalized as expected
-1. We urge users, that all timestamp entries should include time zone information in one of the supported ways
-1. While this is all valid for date entries too, it should be noted that UTC normalization of a date can have unexpected 
-consequences - namely all dates west from UTC would be shifted to a day earlier
-
-##### Date & timestamp pattern
-To enable processing of time entries from other systems **Standardization** offers the possibility to convert 
-string and even numeric values to timestamp or date types. It's done using Spark's ability to convert strings to 
-timestamp/date with some enhancements. The pattern placeholders and usage is described in Java's 
-[`SimpleDateFormat` class description](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) with 
-the addition of recognizing some keywords (like `epoch` and `milliepoch` (case insensitive)) to denote the number of 
-seconds/milliseconds since epoch (1970/01/01 00:00:00.000 UTC) and some additional placeholders.
-It should be noted explicitly that `epoch` and `milliepoch` are considered a pattern including time zone.
- 
-Summary:
-
-| placeholder | Description | Example | Note |
-| --- | --- | --- | --- |
-| G | Era designator | AD | |
-| y | Year | 1996; 96 | |
-| Y | Week year | 2009; 09 | |
-| M | Month in year (context sensitive) |  July; Jul; 07 | |
-| L | Month in year (standalone form) | July; Jul; 07 | |
-| w | Week in year | 27 | |
-| W | Week in month | 2 | |
-| D | Day in year | 189 | |
-| d | Day in month |  10 | |
-| F | Day of week in month | 2 | |
-| E | Day name in week | Tuesday; Tue | |
-| u | Day number of week (1 = Monday, ..., 7 = Sunday) | 1 | |
-| a | Am/pm marker | PM | |
-| H | Hour in day (0-23) | 0 | |
-| k | Hour in day (1-24) | 24 | |
-| K | Hour in am/pm (0-11) |  0 | |
-| h | Hour in am/pm (1-12) | 12 | |
-| m | Minute in hour | 30 | |
-| s | Second in minute | 55 | |
-| S | Millisecond | 978 | |
-| z | General time zone | Pacific Standard Time; PST; GMT-08:00 | |
-| Z | RFC 822 time zone | -0800 | |
-| X | ISO 8601 time zone | -08; -0800; -08:00 | |
-| _epoch_ | Seconds since 1970/01/01 00:00:00 | 1557136493, 1557136493.136| |
-| _epochmilli_ | Milliseconds since 1970/01/01 00:00:00.0000| 1557136493128, 1557136493128.001 | |
-| _epochmicro_ | Microseconds since 1970/01/01 00:00:00.0000| 1557136493128789, 1557136493128789.999 | |
-| _epochnano_ | Nanoseconds since 1970/01/01 00:00:00.0000| 1557136493128789101 | Seen the remark bellow regarding the loss of precision in _nanoseconds_ |
-| i | Microsecond | 111, 321001 | |
-| n | Nanosecond | 999, 542113879 | Seen the remark bellow regarding the loss of precision in _nanoseconds_ |
-
-
-**NB!** Spark uses US Locale and because on-the-fly conversion would be complicated, at the moment we stick to this 
-hardcoded locale as well. E.g. `am/pm` for `a` placeholder, English names of days and months etc.
-
-**NB!** The keywords are case **insensitive**. Therefore, there is no difference between `epoch` and `EpoCH`.
-
-**NB!** While _nanoseconds_ designation is supported on input, it's not supported in storage or further usage. So any
-value behind microseconds precision will be truncated.
-   
-##### Time Zone support
-As it has been mentioned, it's highly recommended to use timestamps with the time zone. But it's not unlikely that the 
-source for standardization doesn't provide the time zone information. On the other hand, these times are usually within
-one time zone. To ensure proper standardization, the schema's _metadata_ can include the `timezone` value.
-All timestamps then will be standardized as belonging to the particular time zone.  
-
-E.g. _2019-05-04 11:31:10_ with `timzene` specified as _CET_ will be standardized to _2019-05-04 10:31:10_ (UTC of 
-course)
-
-In case the pattern already includes information to recognize the time zone, the `timezone` entry in _metadata_ will 
-be ignored. Namely if the pattern includes 'z', 'Z' or 'X' placeholder or `epoch`/`milliepoch` keywords.
-
-**NB!** Due to spark limitation, only time zone ids are accepted as valid values. To get the full list of supported time
- zone denominators see the output of Java's 
-[`TimeZone.getAvailableIDs()` function](https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getAvailableIDs--). 
-
-##### Default value
-Default value is used to handle **NULL** values in non-nullable columns when they are being standardized. This can be due to type mismatch or **NULL** entries.
-Date and timestamp default values, specifically, have to adhere to the provided `pattern`. If no pattern is 
-provided, the implicit pattern is used - `yyyy-MM-dd` for dates and `yyyy-MM-dd HH:mm:ss` for timestamps.
+## Documentation
+Please see the [documentation pages](https://absaoss.github.io/enceladus/).


### PR DESCRIPTION
* Removed *How to use* chapter
* Fixed some typos
* Links to headers changed to standard and removed anchor names
* some table alignments for better readability in text-only display