### PR TITLE
1039 Add convinience scripts for gh pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ _site
 .sass-cache
 .jekyll-metadata
 
+utils/resources/*.conf

--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
+
+gem 'git', '~> 1.5'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Usage: ruby utils/get_release_notes.rb VERSION [options]
 Specific options:
         --github-token TOKEN         Github token. Can be specified using environment variable GITHUB_TOKEN
         --zenhub-token TOKEN         Zenhub token. This means we will use Release object for release notes. You don't have to use --use-zenhub in case you use this. Can be specified using environment variable ZENHUB_TOKEN
-    -z, --use-zenhub                 Run using zenhub. IT needs environment variable ZENHUB_TOKEN. If you use --zenhub-token option, you don't need to use this. This means we will use Release object for release notes.
+    -z, --use-zenhub                 Run using zenhub. It needs environment variable ZENHUB_TOKEN. If you use --zenhub-token option, you don't need to use this. This means we will use Release object for release notes.
         --organization ORGANIZATION  Github Organization
         --repository REPOSITORY      Github Repository name
         --repository-id REPOSITORYID Zenhub Repository ID

--- a/README.md
+++ b/README.md
@@ -22,18 +22,22 @@ ruby utils/create_docs.rb <version>
 ```
 
 #### Generate release notes
+A Ruby script to generate release notes. 
+
 ```bash
 Usage: ruby utils/get_release_notes.rb VERSION [options]
 
 Specific options:
-        --github-token TOKEN         Github token. Can be specified using environment variable GITHUB_TOKEN
-        --zenhub-token TOKEN         Zenhub token. This means we will use Release object for release notes. You don't have to use --use-zenhub in case you use this. Can be specified using environment variable ZENHUB_TOKEN
-    -z, --use-zenhub                 Run using zenhub. It needs environment variable ZENHUB_TOKEN. If you use --zenhub-token option, you don't need to use this. This means we will use Release object for release notes.
+        --github-token TOKEN         Github token. Can be specified using environment variable GITHUB_TOKEN or in get_release_notes.json in resources using github_token key
+        --zenhub-token TOKEN         Zenhub token. This means we will use Release object for release notes. You don't have to use --use-zenhub in case you do this. Can be specified using environment variable ZENHUB_TOKEN or in get_release_notes.json in resources using zenhub_token key
+    -z, --use-zenhub                 Run using zenhub. It needs zenhub token set. If you use --zenhub-token option, you don't need to use this. This means we will use Release object for release notes.
         --organization ORGANIZATION  Github Organization
         --repository REPOSITORY      Github Repository name
         --repository-id REPOSITORYID Zenhub Repository ID
         --zenhub-url ZENURL          Zenhub API URL
         --github-url GITURL          Github API URL
     -p, --[no-]print-empty           Should Issue with no release notes comment be included in the output file
+        --[no-]print-only-title      Should Issue with no release notes comment be preceeded with 'Couldn't find comment'
+    -s, --[no-]strict                Treats warnings as errors
     -h, --help                       Show this message
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Specific options:
         --github-token TOKEN         Github token. Can be specified using environment variable GITHUB_TOKEN
         --zenhub-token TOKEN         Zenhub token. This means we will use Release object for release notes. You don't have to use --use-zenhub in case you use this. Can be specified using environment variable ZENHUB_TOKEN
     -z, --use-zenhub                 Run using zenhub. IT needs environment variable ZENHUB_TOKEN. If you use --zenhub-token option, you don't need to use this. This means we will use Release object for release notes.
-    -v, --version VERSION            Version of release notes
         --organization ORGANIZATION  Github Organization
         --repository REPOSITORY      Github Repository name
         --repository-id REPOSITORYID Zenhub Repository ID

--- a/README.md
+++ b/README.md
@@ -13,3 +13,28 @@ $> bundle install
 $> bundle exec jekyll serve
 # => Now browse to http://localhost:4000
 ```
+
+### Run convinience scripts
+
+#### Generate new docs
+```ruby
+ruby create_docs.rb <version>
+```
+
+#### Generate release notes
+```bash
+Usage: ruby get_release_notes.rb [options]
+
+Specific options:
+        --github-token TOKEN         Github token.
+        --zenhub-token TOKEN         Zenhub token. This means we will use Release object for release notes.
+    -z, --use-zenhub                 Run using zenhub. IT needs environment variable ZENHUB_TOKEN. If you use --zenhub-token option, you don't need to use this. This means we will use Release object for release notes.
+    -v, --version VERSION            Version of release notes
+        --organization ORGANIZATION  Github Organization
+        --repository REPOSITORY      Github Repository name
+        --repository-id REPOSITORYID Zenhub Repository ID
+        --zenhub-url ZENURL          Zenhub API URL
+        --github-url GITURL          Github API URL
+    -p, --print_empty                Github API URL
+    -h, --help                       Show this message
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ruby utils/create_docs.rb <version>
 
 #### Generate release notes
 ```bash
-Usage: ruby utils/get_release_notes.rb [options]
+Usage: ruby utils/get_release_notes.rb VERSION [options]
 
 Specific options:
         --github-token TOKEN         Github token. Can be specified using environment variable GITHUB_TOKEN

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ ruby utils/create_docs.rb <version>
 Usage: ruby utils/get_release_notes.rb [options]
 
 Specific options:
-        --github-token TOKEN         Github token.
-        --zenhub-token TOKEN         Zenhub token. This means we will use Release object for release notes.
+        --github-token TOKEN         Github token. Can be specified using environment variable GITHUB_TOKEN
+        --zenhub-token TOKEN         Zenhub token. This means we will use Release object for release notes. You don't have to use --use-zenhub in case you use this. Can be specified using environment variable ZENHUB_TOKEN
     -z, --use-zenhub                 Run using zenhub. IT needs environment variable ZENHUB_TOKEN. If you use --zenhub-token option, you don't need to use this. This means we will use Release object for release notes.
     -v, --version VERSION            Version of release notes
         --organization ORGANIZATION  Github Organization
@@ -35,6 +35,6 @@ Specific options:
         --repository-id REPOSITORYID Zenhub Repository ID
         --zenhub-url ZENURL          Zenhub API URL
         --github-url GITURL          Github API URL
-    -p, --print_empty                Github API URL
+    -p, --[no-]print-empty           Should Issue with no release notes comment be included in the output file
     -h, --help                       Show this message
 ```

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ $> bundle exec jekyll serve
 
 #### Generate new docs
 ```ruby
-ruby create_docs.rb <version>
+ruby utils/create_docs.rb <version>
 ```
 
 #### Generate release notes
 ```bash
-Usage: ruby get_release_notes.rb [options]
+Usage: ruby utils/get_release_notes.rb [options]
 
 Specific options:
         --github-token TOKEN         Github token.

--- a/_docs/1.0.0/usage-schema.md
+++ b/_docs/1.0.0/usage-schema.md
@@ -63,8 +63,85 @@ fields within fields.
 
 You provide *Schema* to **Standardization** in a JSON file:
 
-{% gist 394d2fe3a23366c081af4aa54441fe8b %}
-
+```json
+{
+    "type": "struct",
+    "fields": [{
+        "name": "name",
+        "type": "string",
+        "nullable": false,
+        "metadata": {
+        }
+    },
+    {
+        "name": "surname",
+        "type": "string",
+        "nullable": false,
+        "metadata": {
+            "default": "Unknown Surname"
+        }
+    },
+    {
+        "name": "hoursWorked",
+        "type": {
+            "type": "array",
+            "elementType": "integer",
+            "containsNull": false
+        },
+        "nullable": false,
+        "metadata": {
+        }
+    },
+{
+        "name": "employeeNumbers",
+        "type": {
+            "type": "array",
+            "elementType": {
+                "type": "struct",
+                "fields": [{
+                    "name": "numberType",
+                    "type": "string",
+                    "nullable": true,
+                    "metadata": {
+                    }
+                },
+                {
+                    "name": "numbers",
+                    "type": {
+                        "type": "array",
+                        "elementType": "integer",
+                        "containsNull": true
+                    },
+                    "nullable": true,
+                    "metadata": {
+                    }
+                }]
+            },
+            "containsNull": true
+        },
+        "nullable": true,
+        "metadata": {
+        }
+    },
+        {
+        "name": "startDate",
+        "type": "date",
+        "nullable": false,
+        "metadata": {
+            "pattern": "yyyy-MM-dd"
+        }
+    },
+        {
+        "name": "updated",
+        "type": "timestamp",
+        "nullable": true,
+        "metadata": {
+            "pattern": "yyyyMMdd.HHmmss"
+        }
+    }
+    ]
+}
+```
 
 Example of data adhering to the above schema can be found [here](https://github.com/AbsaOSS/enceladus/blob/develop/standardization/src/test/scala/za/co/absa/enceladus/standardization/samples/TestSamples.scala).
 

--- a/_docs/1.0.0/usage-schema.md
+++ b/_docs/1.0.0/usage-schema.md
@@ -52,10 +52,8 @@ table. That means fields not mentioned in the schema won't be in the input. Ther
 automatically - [see bellow](#TODO). Fields are defined in the order they are to be in the output table and have three basic common properties:
 
 - `name` - the field (column) name
-
-- `type` - data type of the field 
-
-- `nullable` (optional) - flag indicating if the data can contain the value *null*, if not specified considered set to *false* 
+- `type` - data type of the field
+- `nullable` (optional) - flag indicating if the data can contain the value *null*, if not specified considered set to *false*
 
 Furthermore, some type can have additional properties. The details of each supported type, their meaning and additional
 properties will be described in the following chapters.
@@ -65,85 +63,8 @@ fields within fields.
 
 You provide *Schema* to **Standardization** in a JSON file:
 
-```json
-{
-    "type": "struct",
-    "fields": [{
-        "name": "name",
-        "type": "string",
-        "nullable": false,
-        "metadata": {
-        }
-    },
-    {
-        "name": "surname",
-        "type": "string",
-        "nullable": false,
-        "metadata": {
-            "default": "Unknown Surname"
-        }
-    },
-    {
-        "name": "hoursWorked",
-        "type": {
-            "type": "array",
-            "elementType": "integer",
-            "containsNull": false
-        },
-        "nullable": false,
-        "metadata": {
-        }
-    },
-{
-        "name": "employeeNumbers",
-        "type": {
-            "type": "array",
-            "elementType": {
-                "type": "struct",
-                "fields": [{
-                    "name": "numberType",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                    }
-                },
-                {
-                    "name": "numbers",
-                    "type": {
-                        "type": "array",
-                        "elementType": "integer",
-                        "containsNull": true
-                    },
-                    "nullable": true,
-                    "metadata": {
-                    }
-                }]
-            },
-            "containsNull": true
-        },
-        "nullable": true,
-        "metadata": {
-        }
-    },
-        {
-        "name": "startDate",
-        "type": "date",
-        "nullable": false,
-        "metadata": {
-            "pattern": "yyyy-MM-dd"
-        }
-    },
-        {
-        "name": "updated",
-        "type": "timestamp",
-        "nullable": true,
-        "metadata": {
-            "pattern": "yyyyMMdd.HHmmss"
-        }
-    }
-    ]
-}
-```
+{% gist 394d2fe3a23366c081af4aa54441fe8b %}
+
 
 Example of data adhering to the above schema can be found [here](https://github.com/AbsaOSS/enceladus/blob/develop/standardization/src/test/scala/za/co/absa/enceladus/standardization/samples/TestSamples.scala).
 

--- a/utils/create_docs.rb
+++ b/utils/create_docs.rb
@@ -19,7 +19,7 @@ PAGES_ROOT = File.expand_path('..', __dir__)
 DOC_FOLDER = "#{PAGES_ROOT}/_docs"
 VERSIONS_YAML = "#{PAGES_ROOT}/_data/versions.yaml"
 
-unless NEW_VERSION =~ /[0-9]+\.[0-9]+\.[0-9]+/
+unless NEW_VERSION =~ /\Av?([0-9]+\.){2}[0-9]+(-(R|r)(C|c)[1-9][0-9]*)?\Z/
   raise ArgumentError, "Version not in correct format", caller
 end
 

--- a/utils/create_docs.rb
+++ b/utils/create_docs.rb
@@ -1,0 +1,26 @@
+require 'fileutils'
+
+NEW_VERSION = ARGV[0]
+PAGES_ROOT = File.expand_path('..', __dir__)
+DOC_FOLDER = "#{PAGES_ROOT}/_docs"
+VERSIONS_YAML = "#{PAGES_ROOT}/_data/versions.yaml"
+
+unless NEW_VERSION =~ /[0-9]+\.[0-9]+\.[0-9]+/
+  raise ArgumentError, "Version not in correct format", caller
+end
+
+FileUtils.cd(DOC_FOLDER, verbose: true) do
+  last_version = Dir.glob('*').sort_by { |v| Gem::Version.new(v) }.last
+
+  FileUtils.cp_r(last_version, NEW_VERSION, verbose: true)
+
+  Dir.glob("#{NEW_VERSION}/*").each do |file_path|
+    puts "Updating version for #{file_path}"
+    file_content = File.read(file_path)
+    new_content = file_content.gsub(last_version, NEW_VERSION)
+    File.open(file_path, 'w') { |file| file.puts(new_content) }
+  end
+end
+
+puts "Appending #{NEW_VERSION} to versions.yaml"
+open(VERSIONS_YAML, 'a') { |f| f.puts "- '#{NEW_VERSION}'" }

--- a/utils/create_docs.rb
+++ b/utils/create_docs.rb
@@ -1,3 +1,17 @@
+# Copyright 2018-2019 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 require 'fileutils'
 
 NEW_VERSION = ARGV[0]
@@ -16,8 +30,10 @@ FileUtils.cd(DOC_FOLDER, verbose: true) do
 
   Dir.glob("#{NEW_VERSION}/*").each do |file_path|
     puts "Updating version for #{file_path}"
-    file_content = File.read(file_path)
-    new_content = file_content.gsub(last_version, NEW_VERSION)
+    file_content = File.read(file_path).partition( /---.*?(---)/m )
+    new_content = file_content[0]
+    new_content << file_content[1].gsub(last_version, NEW_VERSION)
+    new_content << file_content[2]
     File.open(file_path, 'w') { |file| file.puts(new_content) }
   end
 end

--- a/utils/get_release_notes.rb
+++ b/utils/get_release_notes.rb
@@ -72,10 +72,10 @@ end
 
 choosen_release = if OptParser.options.use_zenhub
   get_release_object(uri: URI("#{OptParser.options.zenhub_url}/p1/repositories/" +
-                          "#{OptParser.options.repository_id}/reports/releases"),
+                          "#{OptParser.options.repository_id}/reports/releases") ,
                      klass: ZenhubRelease)
 else
-  get_release_object(uri: URI("#{OptParser.options.github_url}/milestones"),
+  get_release_object(uri: URI("#{OptParser.options.github_url}/milestones?state=all"),
                      klass: GithubRelease)
 end
 

--- a/utils/get_release_notes.rb
+++ b/utils/get_release_notes.rb
@@ -1,0 +1,129 @@
+require 'uri'
+require 'net/http'
+require 'openssl'
+require 'json'
+
+PATH_TO_ZENHUB_TOKEN = 'token'
+RN_OUT_PATH_PREFIX = ''
+
+ZENHUB_URL = 'https://api.zenhub.io'
+GITHUB_URL = 'https://api.github.com/repos/AbsaOss/enceladus'
+REPO_ID = '154513089' # ENCELADUS REPO ID
+ZENHUB_TOKEN = File.read(PATH_TO_ZENHUB_TOKEN).strip
+
+class String
+  def remove_first_line
+    first_newline = (index("\n") || size - 1) + 1
+    slice!(0, first_newline).sub("\n",'')
+    self
+  end
+end
+
+class Release
+  attr_accessor :release_id, :title, :description, :start_date, :desired_end_date
+  attr_accessor :created_at, :closed_at, :state, :issues
+
+  def initialize(release_id:, title:, description:, start_date:, desired_end_date:, created_at:, closed_at:, state:)
+    @release_id = release_id
+    @title = title
+    @description = description
+    @start_date = start_date
+    @desired_end_date = desired_end_date
+    @created_at = created_at
+    @closed_at = closed_at
+    @state= state
+    @date = Time.now
+    @liquid = {
+        layout: 'default',
+        title: "Release v#{title}",
+        tags: ["v#{title}", 'changelog'],
+        excerpt_separator: '<!--more-->'
+    }
+    @liquid[:tags] << "hotfix" if title.split('.').last != '0'
+  end
+
+  def get_file_name
+    "#{RN_OUT_PATH_PREFIX}#{@date.strftime('%Y-%m-%d')}-release-#{@title}.md"
+  end
+
+  def get_issues
+    issues = call(URI("#{ZENHUB_URL}/p1/reports/release/#{release_id}/issues"))
+    @issues = issues.inject([]) { |acc, v| acc << Issue.new(v[:issue_number]) }
+  end
+
+  def get_release_notes
+    issue_list = ""
+    issues.map do |issue|
+      issue.get_release_notes
+      issue_list << issue.make_release_note_string
+    end
+
+    release_notes = ""
+    release_notes << "---\n"
+    @liquid.each do |key, value|
+      release_notes << "#{key}: #{value}\n"
+    end
+    release_notes << "---\n"
+    release_notes << "As of #{@date.strftime('%d/%m %Y')} the new version #{@title} is out\n"
+    release_notes << "<!--more-->\n\n"
+    release_notes << issue_list
+  end
+end
+
+class Issue
+  attr_accessor :number, :release_comment
+
+  def initialize(number)
+    @number = number
+  end
+
+  def get_release_notes
+    comments = call(URI("#{GITHUB_URL}/issues/#{@number}/comments"))
+    release_notes = comments.select { |comment| comment[:body] =~ /^Release Notes.*/ }
+    if release_notes.nil? || release_notes.empty?
+      @release_comment = "Couldn't find Release Notes for #{number}"
+    else
+      @release_comment = release_notes.inject('') { |acc, note| "#{acc}#{note[:body].remove_first_line}\n" }
+    end
+  end
+
+  def make_release_note_string
+    "- [##{@number}]({{ site.github.issues_url }}/#{@number}) #{@release_comment}\n"
+  end
+end
+
+def call(url)
+  http = Net::HTTP.new(url.host, url.port)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+  request = Net::HTTP::Get.new(url)
+  request["x-authentication-token"] = ZENHUB_TOKEN if url.host == 'api.zenhub.io'
+  request["content-type"] = 'application/json'
+  response = http.request(request)
+  body_json = JSON.parse(response.body)
+  keys_to_symbols(body_json)
+end
+
+def keys_to_symbols(whatever)
+  if whatever.is_a?(Hash)
+    whatever.inject({}) do |acc,(k,v)|
+      acc[k.to_sym] = v
+      acc
+    end
+  elsif whatever.is_a?(Array)
+    whatever.inject([]) do |acc, v|
+      acc << (v.is_a?(Hash) ? keys_to_symbols(v) : v)
+      acc
+    end
+  else
+    whatever
+  end
+end
+
+
+all_releases = call(URI("#{ZENHUB_URL}/p1/repositories/#{REPO_ID}/reports/releases"))
+latest_release = Release.new(all_releases.last)
+latest_release.get_issues
+release_notes = latest_release.get_release_notes
+File.open(latest_release.get_file_name, 'w') { |file| file.write(release_notes) }

--- a/utils/get_release_notes.rb
+++ b/utils/get_release_notes.rb
@@ -72,10 +72,10 @@ end
 
 choosen_release = if OptParser.options.use_zenhub
   get_release_object(uri: URI("#{OptParser.options.zenhub_url}/p1/repositories/" +
-                          "#{OptParser.options.repository_id}/reports/releases")
+                          "#{OptParser.options.repository_id}/reports/releases"),
                      klass: ZenhubRelease)
 else
-  get_release_object(uri: URI("#{OptParser.options.github_url}/milestones"))
+  get_release_object(uri: URI("#{OptParser.options.github_url}/milestones"),
                      klass: GithubRelease)
 end
 

--- a/utils/get_release_notes/issue.rb
+++ b/utils/get_release_notes/issue.rb
@@ -37,7 +37,7 @@ class Issue
 
     if release_notes.nil? || release_notes.empty?
       @release_comment = ''
-      @release_comment << "Couldn't find Release Notes for #{@number} - " unless OptParser.options.print_only_tile
+      @release_comment << "Couldn't find Release Notes for #{@number} - " unless OptParser.options.print_only_title
       @release_comment << "#{@title}"
     else
       @empty = false

--- a/utils/get_release_notes/issue.rb
+++ b/utils/get_release_notes/issue.rb
@@ -12,11 +12,17 @@
 # limitations under the License.
 
 class Issue
-  attr_accessor :number, :release_comment, :empty
+  attr_accessor :number, :release_comment, :empty, :state
 
   def initialize(number:, title: nil)
+    issue_call = call(URI("#{OptParser.options.github_url}/issues/#{number}"))
     @number = number
-    @title = title
+    @title = if title.nil?
+      issue_call[:title]
+    else
+      title
+    end
+    @state = issue_call[:state]
     @empty = true
   end
 
@@ -30,7 +36,6 @@ class Issue
     end
 
     if release_notes.nil? || release_notes.empty?
-      @title = call(URI("#{OptParser.options.github_url}/issues/1102"))[:title] if @title.nil?
       @release_comment = ''
       @release_comment << "Couldn't find Release Notes for #{@number} - " unless OptParser.options.print_only_tile
       @release_comment << "#{@title}"

--- a/utils/get_release_notes/issue.rb
+++ b/utils/get_release_notes/issue.rb
@@ -1,0 +1,41 @@
+# Copyright 2018-2019 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Issue
+  attr_accessor :number, :release_comment, :empty
+
+  def initialize(number:, title: nil)
+    @number = number
+    @title = title
+    @empty = true
+  end
+
+  def get_release_notes
+    comments = call(URI("#{OptParser.options.github_url}/issues/#{@number}/comments"))
+    release_notes = comments.select do |comment|
+      comment[:body] =~ /\A[[:blank:]]*(R|r)elease (N|n)otes([[:blank:]]|-|:)*\n/
+    end
+
+    if release_notes.nil? || release_notes.empty?
+      @title = call(URI("#{OptParser.options.github_url}/issues/1102"))[:title] if @title.nil?
+      @release_comment = "Couldn't find Release Notes for #{number} - #{@title}"
+    else
+      @empty = false
+      @release_comment = release_notes.inject('') { |acc, note| "#{acc}#{note[:body].remove_first_line}" }
+    end
+  end
+
+  def make_release_note_string
+    "- [##{@number}]({{ site.github.issues_url }}/#{@number}) #{@release_comment}\n"
+  end
+end

--- a/utils/get_release_notes/issue.rb
+++ b/utils/get_release_notes/issue.rb
@@ -31,7 +31,7 @@ class Issue
 
     if release_notes.nil? || release_notes.empty?
       @title = call(URI("#{OptParser.options.github_url}/issues/1102"))[:title] if @title.nil?
-      @release_comment = "Couldn't find Release Notes for #{number} - #{@title}"
+      @release_comment = "Couldn't find Release Notes for #{@number} - #{@title}"
     else
       @empty = false
       @release_comment = release_notes.inject('') { |acc, note| "#{acc}#{note[:body].remove_first_line}" }

--- a/utils/get_release_notes/issue.rb
+++ b/utils/get_release_notes/issue.rb
@@ -23,6 +23,9 @@ class Issue
   def get_release_notes
     comments = call(URI("#{OptParser.options.github_url}/issues/#{@number}/comments"))
     release_notes = comments.select do |comment|
+      # First line of a comment can start by blanks (spaces, tabs), then Release Notes eaither
+      # capitalized or all lower case. Then any combination of blanks, dashes or columns followed
+      # by a new line. The first line is going to be removed, so the new line is important.
       comment[:body] =~ /\A[[:blank:]]*(R|r)elease (N|n)otes([[:blank:]]|-|:)*\n/
     end
 

--- a/utils/get_release_notes/issue.rb
+++ b/utils/get_release_notes/issue.rb
@@ -31,7 +31,9 @@ class Issue
 
     if release_notes.nil? || release_notes.empty?
       @title = call(URI("#{OptParser.options.github_url}/issues/1102"))[:title] if @title.nil?
-      @release_comment = "Couldn't find Release Notes for #{@number} - #{@title}"
+      @release_comment = ''
+      @release_comment << "Couldn't find Release Notes for #{@number} - " unless OptParser.options.print_only_tile
+      @release_comment << "#{@title}"
     else
       @empty = false
       @release_comment = release_notes.inject('') { |acc, note| "#{acc}#{note[:body].remove_first_line}" }

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -1,0 +1,106 @@
+# Copyright 2018-2019 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'optparse'
+
+class OptParser
+
+  def self.options
+    @@options
+  end
+
+  def self.parse(args)
+    options = OpenStruct.new
+    options.use_zenhub = false
+    options.print_empty = true
+    options.organization = 'AbsaOss'
+    options.repository = 'enceladus'
+    options.repository_id = '154513089' # ENCELADUS REPO ID
+    options.zenhub_url = 'https://api.zenhub.io'
+    options.github_url = "https://api.github.com/repos/#{options.organization}/#{options.repository}"
+    options.github_token = ENV['GITHUB_TOKEN']
+    options.zenhub_token = ENV['ZENHUB_TOKEN']
+
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = "Usage: get_release_notes.rb [options]"
+
+      opts.separator ""
+      opts.separator "Specific options:"
+
+      opts.on("--github-token TOKEN", 'Github token.') do |gt|
+        options.github_token = "token #{gt}"
+      end
+
+      opts.on("--zenhub-token TOKEN", 'Zenhub token. This means we will use ' +
+                                      'Release object for release notes.') do |zt|
+        options.use_zenhub = true
+        options.zenhub_token = zt
+      end
+
+      opts.on("-z", "--use-zenhub", 'Run using zenhub. IT needs environment variable ZENHUB_TOKEN.' +
+                                    ' If you use --zenhub-token option, you don\'t need to use this.' +
+                                    ' This means we will use Release object for release notes.') do |z|
+        if options.zenhub_token.nil? || options.zenhub_token.empty?
+          raise ArgumentError, "Can't find ZENHUB_TOKEN environemnt variable", caller
+        end
+        options.use_zenhub = z
+        options.zenhub_token = options.zenhub_token
+      end
+
+      opts.on('-v', '--version VERSION', 'Version of release notes') do |v|
+        unless v =~ /[0-9]+\.[0-9]+\.[0-9]+/
+          raise OptionParser::InvalidArgument, 'Wrong version format', caller
+        end
+        options.version = v
+      end
+
+      opts.on('--organization ORGANIZATION', 'Github Organization') do |org|
+        options.organization = org
+      end
+
+      opts.on('--repository REPOSITORY', 'Github Repository name') do |repo|
+        options.repository = repo
+      end
+
+      opts.on('--repository-id REPOSITORYID', 'Zenhub Repository ID') do |repo_id|
+        options.repository_id = repo_id
+      end
+
+      opts.on('--zenhub-url ZENURL', 'Zenhub API URL') do |url|
+        options.zenhub_url = url
+      end
+
+      opts.on('--github-url GITURL', 'Github API URL') do |url|
+        options.github_url = url
+      end
+
+      opts.on('-p', '--print_empty', 'Github API URL') do |p|
+        options.print_empty = p
+      end
+
+      opts.on_tail("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+
+    opt_parser.parse!(args)
+
+    raise OptionParser::MissingArgument, 'Missing version argument', caller if options[:version].nil?
+    if options.github_token.nil? || options.github_token.empty?
+      raise OptionParser::MissingArgument, 'Missing Github token argument or environment variable', caller
+    end
+    @@options = options
+    options
+  end
+end

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -67,13 +67,6 @@ class OptParser
         options.zenhub_token = options.zenhub_token
       end
 
-      opts.on('-v', '--version VERSION', 'Version of release notes') do |v|
-        unless v =~ /[0-9]+\.[0-9]+\.[0-9]+/
-          raise OptionParser::InvalidArgument, 'Wrong version format', caller
-        end
-        options.version = v
-      end
-
       opts.on('--organization ORGANIZATION', 'Github Organization') do |org|
         options.organization = org
       end

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -18,10 +18,7 @@ class OptParser
   ROOT_PATH = "#{File.expand_path('../..', __dir__)}"
   GIT_PATH = "#{ROOT_PATH}/.git"
 
-  if File.exist?(GIT_PATH)
-    require 'bundler/inline'
-    gemfile { source 'https://rubygems.org'; gem 'git' }
-  end
+  require 'git' if File.exist?(GIT_PATH)
 
   def self.options
     @@options

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -27,7 +27,6 @@ class OptParser
     options.repository = 'enceladus'
     options.repository_id = '154513089' # ENCELADUS REPO ID
     options.zenhub_url = 'https://api.zenhub.io'
-    options.github_url = "https://api.github.com/repos/#{options.organization}/#{options.repository}"
     options.github_token = ENV['GITHUB_TOKEN']
     options.zenhub_token = ENV['ZENHUB_TOKEN']
     options.version = args.shift
@@ -104,6 +103,11 @@ class OptParser
     if options.github_token.nil? || options.github_token.empty?
       raise OptionParser::MissingArgument, 'Missing Github token argument or environment variable', caller
     end
+
+    if options.github_url.nil? || options.github_url.empty?
+      options.github_url = "https://api.github.com/repos/#{options.organization}/#{options.repository}"
+    end
+
     @@options = options
     options
   end

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -39,7 +39,7 @@ class OptParser
     options = OpenStruct.new
     options.use_zenhub = app_conf[:use_zenhub]
     options.print_empty = app_conf[:print_empty]
-    options.print_only_tile = app_conf[:print_only_tile]
+    options.print_only_title = app_conf[:print_only_title]
     options.organization = app_conf[:organization]
     options.repository = app_conf[:repository]
     options.repository_id = app_conf[:repository_id]
@@ -112,7 +112,7 @@ class OptParser
 
       opts.on('--[no-]print-only-title', 'Should Issue with no release notes comment be ' +
                                          'preceeded with \'Couldn\'t find comment\'') do |p|
-        options.print_only_tile = p
+        options.print_only_title = p
       end
 
       opts.on('-s', '--[no-]strict', 'Treats warnings as errors') do |s|

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -32,13 +32,6 @@ class OptParser
     options.zenhub_token = ENV['ZENHUB_TOKEN']
     options.version = args.shift
 
-    # Version string can start with a small v, then version numbers X.Y.Z, after that you can follow
-    # with -RCX where dash is mandatory, RC can be downcase or uppercase and X represents any number
-    # higher then zero
-    unless options.version =~ /\Av?([0-9]+\.){2}[0-9]+(-(R|r)(C|c)[1-9][0-9]*)?\Z/
-      raise OptionParser::InvalidArgument, "Invalid Version argument - #{options.version}", caller
-    end
-
     opt_parser = OptionParser.new do |opts|
       opts.banner = "Usage: ruby utils/get_release_notes.rb VERSION [options]"
 
@@ -95,6 +88,15 @@ class OptParser
         puts opts
         exit
       end
+    end
+
+    opt_parser.parse!(['-h']) if options.version =~ /\A(-h|--help)/
+
+    # Version string can start with a small v, then version numbers X.Y.Z, after that you can follow
+    # with -RCX where dash is mandatory, RC can be downcase or uppercase and X represents any number
+    # higher then zero
+    unless options.version =~ /\Av?([0-9]+\.){2}[0-9]+(-(R|r)(C|c)[1-9][0-9]*)?\Z/
+      raise OptionParser::InvalidArgument, "Invalid Version argument - #{options.version}", caller
     end
 
     opt_parser.parse!(args)

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -30,9 +30,17 @@ class OptParser
     options.github_url = "https://api.github.com/repos/#{options.organization}/#{options.repository}"
     options.github_token = ENV['GITHUB_TOKEN']
     options.zenhub_token = ENV['ZENHUB_TOKEN']
+    options.version = args.shift
+
+    # Version string can start with a small v, then version numbers X.Y.Z, after that you can follow
+    # with -RCX where dash is mandatory, RC can be downcase or uppercase and X represents any number
+    # higher then zero
+    unless options.version =~ /\Av?([0-9]+\.){2}[0-9]+(-(R|r)(C|c)[1-9][0-9]*)?\Z/
+      raise OptionParser::InvalidArgument, "Invalid Version argument - #{options.version}", caller
+    end
 
     opt_parser = OptionParser.new do |opts|
-      opts.banner = "Usage: ruby utils/get_release_notes.rb [options]"
+      opts.banner = "Usage: ruby utils/get_release_notes.rb VERSION [options]"
 
       opts.separator ""
       opts.separator "Specific options:"
@@ -99,7 +107,6 @@ class OptParser
 
     opt_parser.parse!(args)
 
-    raise OptionParser::MissingArgument, 'Missing version argument', caller if options[:version].nil?
     if options.github_token.nil? || options.github_token.empty?
       raise OptionParser::MissingArgument, 'Missing Github token argument or environment variable', caller
     end

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -64,7 +64,6 @@ class OptParser
           raise ArgumentError, "Can't find ZENHUB_TOKEN environemnt variable", caller
         end
         options.use_zenhub = z
-        options.zenhub_token = options.zenhub_token
       end
 
       opts.on('--organization ORGANIZATION', 'Github Organization') do |org|

--- a/utils/get_release_notes/opt_parser.rb
+++ b/utils/get_release_notes/opt_parser.rb
@@ -32,17 +32,19 @@ class OptParser
     options.zenhub_token = ENV['ZENHUB_TOKEN']
 
     opt_parser = OptionParser.new do |opts|
-      opts.banner = "Usage: get_release_notes.rb [options]"
+      opts.banner = "Usage: ruby utils/get_release_notes.rb [options]"
 
       opts.separator ""
       opts.separator "Specific options:"
 
-      opts.on("--github-token TOKEN", 'Github token.') do |gt|
+      opts.on("--github-token TOKEN", 'Github token. Can be specified using environment variable GITHUB_TOKEN') do |gt|
         options.github_token = "token #{gt}"
       end
 
       opts.on("--zenhub-token TOKEN", 'Zenhub token. This means we will use ' +
-                                      'Release object for release notes.') do |zt|
+                                      'Release object for release notes. You don\'t '+
+                                      'have to use --use-zenhub in case you use this. ' +
+                                      'Can be specified using environment variable ZENHUB_TOKEN') do |zt|
         options.use_zenhub = true
         options.zenhub_token = zt
       end
@@ -84,7 +86,8 @@ class OptParser
         options.github_url = url
       end
 
-      opts.on('-p', '--print_empty', 'Github API URL') do |p|
+      opts.on('-p', '--[no-]print-empty', 'Should Issue with no release notes comment be ' +
+                                          'included in the output file') do |p|
         options.print_empty = p
       end
 

--- a/utils/get_release_notes/release.rb
+++ b/utils/get_release_notes/release.rb
@@ -17,7 +17,6 @@ class Release
   def post_init
     get_issues
     open_issues = @issues.select { |issue| issue.state == 'open' }
-    p open_issues
     if OptParser.options.strict && open_issues.size > 0
       raise StandardError, "Release has open issues #{open_issues.map(&:number)}", caller
     end

--- a/utils/get_release_notes/release.rb
+++ b/utils/get_release_notes/release.rb
@@ -48,7 +48,7 @@ class GithubRelease < Release
   end
 
   def get_issues
-    issues_with_prs = call(URI("#{OptParser.options.github_url}/issues?milestone=#{id}"))
+    issues_with_prs = call(URI("#{OptParser.options.github_url}/issues?milestone=#{id}&state=all"))
     issues = issues_with_prs.select { |issue| issue[:pull_request].nil? }
     super(issues: issues)
   end

--- a/utils/get_release_notes/release.rb
+++ b/utils/get_release_notes/release.rb
@@ -1,0 +1,55 @@
+# Copyright 2018-2019 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Release
+  attr_accessor :id, :title, :description, :issues
+
+  def initialize(id:, title:, description:)
+    @id = id
+    @title = title
+    @description = description
+  end
+
+  def get_issues(issues: [])
+    @issues = issues.inject([]) { |acc, v| acc << Issue.new(number: v[:number], title: v[:title]) }
+    @issues
+  end
+end
+
+class ZenhubRelease < Release
+  def self.create(args)
+    ZenhubRelease.new(id: args[:release_id],
+                      title: args[:title],
+                      description: args[:description])
+  end
+
+  def get_issues
+    issues = call(URI("#{OptParser.options.zenhub_url}/p1/reports/release/#{id}/issues"))
+    super(issues: issues)
+  end
+end
+
+class GithubRelease < Release
+  def self.create(args)
+    puts "WARN You have #{args[:open_issues]} issues open" if args[:open_issues] > 0
+    GithubRelease.new(title: args[:title],
+                      id: args[:number],
+                      description: args[:description])
+  end
+
+  def get_issues
+    issues_with_prs = call(URI("#{OptParser.options.github_url}/issues?milestone=#{id}"))
+    issues = issues_with_prs.select { |issue| issue[:pull_request].nil? }
+    super(issues: issues)
+  end
+end

--- a/utils/get_release_notes/release.rb
+++ b/utils/get_release_notes/release.rb
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 class Release
-  attr_accessor :id, :title, :description, :issues
+  attr_reader :id, :title, :description, :issues
 
   def initialize(id:, title:, description:)
     @id = id
@@ -20,7 +20,7 @@ class Release
     @description = description
   end
 
-  def get_issues(issues: [])
+  def get_issues(issues:)
     @issues = issues.inject([]) { |acc, v| acc << Issue.new(number: v[:number], title: v[:title]) }
     @issues
   end
@@ -42,8 +42,8 @@ end
 class GithubRelease < Release
   def self.create(args)
     puts "WARN You have #{args[:open_issues]} issues open" if args[:open_issues] > 0
-    GithubRelease.new(title: args[:title],
-                      id: args[:number],
+    GithubRelease.new(id: args[:number],
+                      title: args[:title],
                       description: args[:description])
   end
 

--- a/utils/get_release_notes/release_notes.rb
+++ b/utils/get_release_notes/release_notes.rb
@@ -1,0 +1,64 @@
+# Copyright 2018-2019 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ReleaseNotes
+  def initialize(version:, release:, print_empty: true)
+    @liquid_separator = '---'
+    @date = Time.now
+    @version = version
+    @print_empty = print_empty
+    @release = release
+  end
+
+  def get_liquid
+    liquid = {
+      layout: 'default',
+      title: "Release v#{@version}",
+      tags: ["v#{@version}", 'changelog'],
+      excerpt_separator: '<!--more-->'
+    }
+
+    liquid[:tags] << "hotfix" if @version.split('.').last != '0'
+    liquid
+  end
+
+  def get_release_notes
+    issue_list = ""
+    @release.get_issues.map do |issue|
+      if issue.empty
+        puts "WARN - Issue #{issue.number} has no Release Notes"
+        next if !@print_empty
+      end
+      issue.get_release_notes
+      issue_list << issue.make_release_note_string
+    end
+
+    release_notes = ""
+    release_notes << @liquid_separator << "\n"
+    get_liquid.each do |key, value|
+      release_notes << "#{key}: #{value}\n"
+    end
+    release_notes << @liquid_separator << "\n\n"
+    release_notes << "As of #{@date.strftime('%d/%m %Y')} the new version #{@version} is out\n"
+    release_notes << "<!--more-->\n\n"
+    release_notes << issue_list
+  end
+
+  def get_file_name(folder)
+    "#{folder}/#{@date.strftime('%Y-%m-%d')}-release-#{@version}.md"
+  end
+
+  def write(folder)
+    File.write(get_file_name(folder), get_release_notes)
+  end
+end

--- a/utils/get_release_notes/release_notes.rb
+++ b/utils/get_release_notes/release_notes.rb
@@ -28,7 +28,7 @@ class ReleaseNotes
       excerpt_separator: '<!--more-->'
     }
 
-    liquid[:tags] << "hotfix" if @version.split('.').last != '0'
+    liquid[:tags] << "hotfix" unless @version.split('.').last =~ /\A0.*/
     liquid
   end
 

--- a/utils/resources/get_release_notes.conf.template
+++ b/utils/resources/get_release_notes.conf.template
@@ -1,7 +1,7 @@
 {
   "use_zenhub" : false,
   "print_empty" : true,
-  "print_only_tile" : true,
+  "print_only_title" : true,
   "organization" : "AbsaOss",
   "repository" : "enceladus",
   "repository_id" : "154513089",

--- a/utils/resources/get_release_notes.conf.template
+++ b/utils/resources/get_release_notes.conf.template
@@ -1,0 +1,10 @@
+{
+  "use_zenhub" : false,
+  "print_empty" : true,
+  "print_only_tile" : true,
+  "organization" : "AbsaOss",
+  "repository" : "enceladus",
+  "repository_id" : "154513089",
+  "zenhub_url" : "https://api.zenhub.io",
+  "github_url" : "https://api.github.com"
+}

--- a/utils/resources/get_release_notes.conf.template
+++ b/utils/resources/get_release_notes.conf.template
@@ -6,5 +6,6 @@
   "repository" : "enceladus",
   "repository_id" : "154513089",
   "zenhub_url" : "https://api.zenhub.io",
-  "github_url" : "https://api.github.com"
+  "github_url" : "https://api.github.com",
+  "strict": true
 }


### PR DESCRIPTION
1. I did a quick fix of the non-formating json in schema, it bugged me so I just used a gist to do it for now. We will solve later.
2. `create_docs.rb` creates a full folder and goes over every file and changes the versions. Needs an argument and that is the new version. Other things it gets by itself. In the future, I might do this automatically as well.
3. `get_release_notes.rb` connects to ZenHub and GitHub and automatically generates release notes. It takes the latest release, collects issues and then collects comments from these issues that start with `Release Notes`. So basically now you have to comment release note as:
```
Release Notes
This fixes this thing and the other. 
I can even use special formating characters here.
```

This should close #1039 