### PR TITLE
#1129 Add a configuration switch to control the broadcasting strategy  for mapping rules.

### DIFF
--- a/spark-jobs/src/main/resources/application.conf.template
+++ b/spark-jobs/src/main/resources/application.conf.template
@@ -27,6 +27,15 @@ conformance.mappingtable.pattern="reportDate={0}-{1}-{2}"
 # operating on the same array
 conformance.mapping.rule.experimental.implementation=false
 
+# Specify when to use the broadcasting strategy for mapping rules.
+# Can be one of: auto, never, always (warning! use 'always' with caution)
+# When set to 'auto' the strategy will be used for mapping tables that have size
+# bigger than specified in 'conformance.mapping.rule.max.broadcast.size.mb'
+conformance.mapping.rule.broadcast=never
+
+# Maximum size (in MB) of a mapping table to use the efficient broadcasting mapping rule strategy
+conformance.mapping.rule.max.broadcast.size.mb=50
+
 # Enable workaround for Catalyst execution plan optimization freeze
 conformance.catalyst.workaround=true
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -27,7 +27,7 @@ import za.co.absa.atum.AtumImplicits
 import za.co.absa.atum.AtumImplicits.{DataSetWrapper, StringToPath}
 import za.co.absa.atum.core.Atum
 import za.co.absa.enceladus.conformance.interpreter.rules.ValidationException
-import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches, ThreeStateSwitch}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.menasplugin.{MenasCredentials, MenasPlugin}
 import za.co.absa.enceladus.dao.rest.{MenasConnectionStringParser, RestDaoFactory}
@@ -137,6 +137,14 @@ object DynamicConformanceJob {
     enabled
   }
 
+  private def broadcastingStrategyMode: ThreeStateSwitch = {
+    ThreeStateSwitch(conf.getString("conformance.mapping.rule.broadcast"))
+  }
+
+  private def broadcastingMaxSizeMb: Int = {
+    conf.getInt("conformance.mapping.rule.max.broadcast.size.mb")
+  }
+
   /**
     * Returns an effective value of a parameter according to the following priorities:
     * - Command line arguments [highest]
@@ -219,6 +227,8 @@ object DynamicConformanceJob {
       .setExperimentalMappingRuleEnabled(isExperimentalRuleEnabled())
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled())
       .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(broadcastingStrategyMode)
+      .setBroadcastMaxSizeMb(broadcastingMaxSizeMb)
 
     try {
       DynamicInterpreter.interpret(conformance, inputData)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
@@ -16,25 +16,36 @@
 package za.co.absa.enceladus.conformance.interpreter
 
 /**
- * Class bundling together switched for features to be used during Conformance
- * It's a sealed abstract case class to enforce the the provided constructor (apply). This way values can be
- * changed only via the setters. This way enforces setting them by name only instead of by position like it would be in
- * the case of classical constructor.
- * @param experimentalMappingRuleEnabled  If true the new explode-optimized conformance mapping rule interpreter will be used
- * @param catalystWorkaroundEnabled       If true the Catalyst optimizer workaround is enabled
- * @param controlFrameworkEnabled         If true sets the checkpoints on the dataset upon conforming
- */
+  * Class bundling together switched for features to be used during Conformance
+  * It's a sealed abstract case class to enforce the the provided constructor (apply). This way values can be
+  * changed only via the setters. This way enforces setting them by name only instead of by position like it would be in
+  * the case of classical constructor.
+  *
+  * @param experimentalMappingRuleEnabled If true the new explode-optimized conformance mapping rule interpreter will be used
+  * @param catalystWorkaroundEnabled      If true the Catalyst optimizer workaround is enabled
+  * @param controlFrameworkEnabled        If true sets the checkpoints on the dataset upon conforming
+  * @param broadcastStrategyMode          Specifies the mode of operation of the broadcasting strategy for mapping rules
+  * @param broadcastMaxSizeMb             Specifies the maximum size of a mapping table for which the broadcasting strategy can be used.
+  */
 sealed abstract case class FeatureSwitches(
                                             experimentalMappingRuleEnabled: Boolean = false,
                                             catalystWorkaroundEnabled: Boolean = false,
-                                            controlFrameworkEnabled: Boolean = false
+                                            controlFrameworkEnabled: Boolean = false,
+                                            broadcastStrategyMode: ThreeStateSwitch = Auto,
+                                            broadcastMaxSizeMb: Int = 0
                                           ) {
   private def copy(
                     experimentalMappingRuleEnabled: Boolean = this.experimentalMappingRuleEnabled,
                     catalystWorkaroundEnabled: Boolean = this.catalystWorkaroundEnabled,
-                    controlFrameworkEnabled: Boolean = this.controlFrameworkEnabled
-          ): FeatureSwitches = {
-    new FeatureSwitches(experimentalMappingRuleEnabled, catalystWorkaroundEnabled, controlFrameworkEnabled) {}
+                    controlFrameworkEnabled: Boolean = this.controlFrameworkEnabled,
+                    broadcastStrategyMode: ThreeStateSwitch = this.broadcastStrategyMode,
+                    broadcastMaxSizeMb: Int = this.broadcastMaxSizeMb
+                  ): FeatureSwitches = {
+    new FeatureSwitches(experimentalMappingRuleEnabled,
+      catalystWorkaroundEnabled,
+      controlFrameworkEnabled,
+      broadcastStrategyMode,
+      broadcastMaxSizeMb) {}
   }
 
   def setExperimentalMappingRuleEnabled(value: Boolean): FeatureSwitches = {
@@ -47,6 +58,14 @@ sealed abstract case class FeatureSwitches(
 
   def setControlFrameworkEnabled(value: Boolean): FeatureSwitches = {
     copy(controlFrameworkEnabled = value)
+  }
+
+  def setBroadcastStrategyMode(value: ThreeStateSwitch): FeatureSwitches = {
+    copy(broadcastStrategyMode = value)
+  }
+
+  def setBroadcastMaxSizeMb(value: Int): FeatureSwitches = {
+    copy(broadcastMaxSizeMb = value)
   }
 
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/ThreeStateSwitch.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/ThreeStateSwitch.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.conformance.interpreter
+
+sealed trait ThreeStateSwitch {
+  val name: String
+}
+
+object ThreeStateSwitch {
+  def apply(value: String): ThreeStateSwitch = value match {
+    case Always.name => Always
+    case Never.name  => Never
+    case Auto.name   => Auto
+    case str         => throw new IllegalArgumentException(s"Unknown switch: '$str'. It should be one of: 'always', 'never', 'auto'.")
+  }
+}
+
+case object Always extends ThreeStateSwitch {
+  val name = "always"
+}
+
+case object Never extends ThreeStateSwitch {
+  val name = "never"
+}
+
+case object Auto extends ThreeStateSwitch {
+  val name = "auto"
+}

--- a/spark-jobs/src/test/resources/application.conf
+++ b/spark-jobs/src/test/resources/application.conf
@@ -21,5 +21,12 @@ standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"
 # {0} - Year, {1} - Month, {2} - Day of month
 conformance.mappingtable.pattern="reportDate={0}-{1}-{2}"
 
+# Specify when to use the broadcasting strategy for mapping rules.
+# Can be one of: auto [default], never, always (warning! use 'always' with caution)
+conformance.mapping.rule.broadcast=never
+
+# Maximum size (in MB) of a mapping table to use the efficient broadcasting mapping rule strategy
+conformance.mapping.rule.max.broadcast.size.mb=0
+
 #system-wide time zone
 timezone="UTC"

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ArrayConformanceSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ArrayConformanceSuite.scala
@@ -56,6 +56,7 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
       .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(Never)
 
     val conformedDf = DynamicInterpreter.interpret(ArraySamples.conformanceDef,
       df)
@@ -80,6 +81,7 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
       .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(Never)
 
     val conformedDf = DynamicInterpreter.interpret(NullArraySamples.mappingOnlyConformanceDef,
       df)
@@ -109,6 +111,7 @@ class ArrayConformanceSuite extends FunSuite with SparkTestBase with BeforeAndAf
       .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(Never)
 
     val conformedDf = DynamicInterpreter.interpret(EmtpyArraySamples.mappingOnlyConformanceDef,
       df)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
@@ -69,6 +69,7 @@ class ChorusMockSuite extends FunSuite with SparkTestBase with LoggerTestBase {
       .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(Never)
 
     val confd = DynamicInterpreter.interpret(conformanceDef, inputDf).repartition(2)
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -67,6 +67,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
       .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(Never)
 
     val conformed = DynamicInterpreter.interpret(EmployeeConformance.employeeDS, dfs)
 
@@ -121,6 +122,7 @@ class InterpreterSuite extends FunSuite with SparkTestBase with BeforeAndAfterAl
       .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(Never)
 
     val conformed = DynamicInterpreter.interpret(TradeConformance.tradeDS, dfs).cache
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/LiteralJoinMappingRuleTest.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/LiteralJoinMappingRuleTest.scala
@@ -65,6 +65,7 @@ class LiteralJoinMappingRuleTest extends FunSuite with SparkTestBase with Logger
       .setExperimentalMappingRuleEnabled(useExperimentalMappingRule)
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(Never)
 
     val confd = DynamicInterpreter.interpret(conformanceDef, inputDf).repartition(2)
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleBroadcastSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleBroadcastSuite.scala
@@ -47,7 +47,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/simpleResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, simpleMappingRule)
+      simpleTestCaseFactory.getTestCase(true, true, simpleMappingRule)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
@@ -65,7 +65,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/simpleDefValResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, simpleMappingRuleWithDefaultValue)
+      simpleTestCaseFactory.getTestCase(true, true, simpleMappingRuleWithDefaultValue)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
@@ -83,7 +83,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/nested1Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, nestedMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, true, nestedMappingRule1)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum1")
@@ -101,7 +101,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/nested2Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, nestedMappingRule2)
+      nestedTestCaseFactory.getTestCase(true, true, nestedMappingRule2)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum2")
@@ -119,7 +119,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/nested3Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, nestedMappingRule3)
+      nestedTestCaseFactory.getTestCase(true, true, nestedMappingRule3)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"conformedNum3", $"errCol")
@@ -137,7 +137,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/array1Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, arrayMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule1)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
@@ -155,7 +155,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/array2Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, arrayMappingRule2)
+      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule2)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -173,7 +173,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/array3Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, arrayMappingRule3)
+      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule3)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -187,12 +187,11 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
   }
 
   test("Test broadcasting rule when key fields are in different array levels for an array of array") {
-    // ToDo The support for this mode of broadcasting rule is to be implemented in #1078
     val expectedSchema = getResourceString("/interpreter/mappingCases/array4Schema.txt")
     val expectedResults = getResourceString("/interpreter/mappingCases/array4Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, arrayMappingRule4)
+      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule4)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -210,7 +209,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
     val expectedResults = getResourceString("/interpreter/mappingCases/array5Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, arrayMappingRule5)
+      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule5)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -224,12 +223,11 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
   }
 
   test("Test broadcasting rule when 3 key fields are at different array levels") {
-    // ToDo The support for this mode of broadcasting rule is to be implemented in #1078
     val expectedSchema = getResourceString("/interpreter/mappingCases/array6Schema.txt")
     val expectedResults = getResourceString("/interpreter/mappingCases/array6Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, arrayMappingRule6)
+      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule6)
 
     val dfOut = DynamicInterpreter.interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -244,7 +242,7 @@ class MappingRuleBroadcastSuite extends FunSuite with SparkTestBase with LoggerT
 
   test("Test broadcasting rule failure if key fields are in different arrays") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, wrongMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, true, wrongMappingRule1)
 
     intercept[Exception] {
       DynamicInterpreter.interpret(dataset, inputDf)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleSuite.scala
@@ -37,7 +37,7 @@ class MappingRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase w
 
   test("Test non-existent mapping table directory handling in a mapping rule") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      testCaseFactory.getTestCase(true, nonExistentTableMappingRule)
+      testCaseFactory.getTestCase(true, false, nonExistentTableMappingRule)
 
     val ex = intercept[AnalysisException] {
       DynamicInterpreter.interpret(dataset, inputDf).cache
@@ -48,7 +48,7 @@ class MappingRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase w
 
   test("Test non-existent mapping table directory handling in an experimental mapping rule") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      testCaseFactory.getTestCase(false, nonExistentTableMappingRule)
+      testCaseFactory.getTestCase(false, false, nonExistentTableMappingRule)
 
     val ex = intercept[AnalysisException] {
       DynamicInterpreter.interpret(dataset, inputDf).cache
@@ -59,7 +59,7 @@ class MappingRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase w
 
   test("Test empty mapping table error handling in a mapping rule") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      testCaseFactory.getTestCase(true, emptyTableMappingRule)
+      testCaseFactory.getTestCase(true, false, emptyTableMappingRule)
 
     val ex = intercept[RuntimeException] {
       DynamicInterpreter.interpret(dataset, inputDf).cache
@@ -70,7 +70,7 @@ class MappingRuleSuite extends FunSuite with SparkTestBase with LoggerTestBase w
 
   test("Test empty mapping table error handling in an experimental mapping rule") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      testCaseFactory.getTestCase(false, emptyTableMappingRule)
+      testCaseFactory.getTestCase(false, false, emptyTableMappingRule)
 
     val ex = intercept[RuntimeException] {
       DynamicInterpreter.interpret(dataset, inputDf).cache

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/RuleOptimizationSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/RuleOptimizationSuite.scala
@@ -17,7 +17,7 @@ package za.co.absa.enceladus.conformance.interpreter.rules
 
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches, InterpreterContext}
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches, InterpreterContext, Never}
 import za.co.absa.enceladus.model.conformanceRule.{ConformanceRule, MappingConformanceRule}
 import za.co.absa.enceladus.conformance.samples.TradeConformance._
 
@@ -103,7 +103,7 @@ class RuleOptimizationSuite extends FunSuite {
 
   private implicit val ictxDummy: InterpreterContext = InterpreterContext(schema,
     null,
-    FeatureSwitches().setExperimentalMappingRuleEnabled(true),
+    FeatureSwitches().setExperimentalMappingRuleEnabled(true).setBroadcastStrategyMode(Never),
     "dummy",
     null,
     null,

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/testcasefactories/SimpleTestCaseFactory.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/testcasefactories/SimpleTestCaseFactory.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.mockito.Mockito.{mock, when => mockWhen}
 import za.co.absa.enceladus.conformance.ConfCmdConfig
-import za.co.absa.enceladus.conformance.interpreter.FeatureSwitches
+import za.co.absa.enceladus.conformance.interpreter.{Always, FeatureSwitches, Never}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.{ConformanceRule, MappingConformanceRule}
 import za.co.absa.enceladus.model.test.factories.{DatasetFactory, MappingTableFactory}
@@ -131,15 +131,17 @@ class SimpleTestCaseFactory(implicit spark: SparkSession) {
     * This method returns all objects necessary to run a dynamic conformance job.
     * You can customize conformance features used and a list of conformance rules to apply.
     *
-    * @param experimentalMappingRule If true, the experimental mapping rule will be used.
-    * @param conformanceRules        Zero or more conformance rules to be applied as the part of conformance.
+    * @param experimentalMappingRule       If true, the experimental mapping rule will be used.
+    * @param conformanceRules              Zero or more conformance rules to be applied as the part of conformance.
+    * @param enableMappingRuleBroadcasting Specify if the broadcasting strategy will be used for the mapping rule.
     * @return A dataframe, a dataset, a Menas DAO, a Cmd Config and feature switches prepared to run conformance interpreter
     */
   def getTestCase(experimentalMappingRule: Boolean,
+                  enableMappingRuleBroadcasting: Boolean,
                   conformanceRules: ConformanceRule*): (DataFrame, Dataset, MenasDAO, ConfCmdConfig, FeatureSwitches) = {
     val inputDf = spark.read.schema(testCaseSchema).json(testCaseDataJson.toDS)
     val dataset = getDataSetWithConformanceRules(testCaseDataset, conformanceRules: _*)
-    val cmdConfig  = ConfCmdConfig(reportDate = reportDate)
+    val cmdConfig = ConfCmdConfig(reportDate = reportDate)
 
     val dao = mock(classOf[MenasDAO])
     mockWhen(dao.getDataset(testCaseName, 1)) thenReturn testCaseDataset
@@ -153,6 +155,7 @@ class SimpleTestCaseFactory(implicit spark: SparkSession) {
       .setExperimentalMappingRuleEnabled(experimentalMappingRule)
       .setCatalystWorkaroundEnabled(true)
       .setControlFrameworkEnabled(false)
+      .setBroadcastStrategyMode(if (enableMappingRuleBroadcasting) Always else Never)
 
     (inputDf, dataset, dao, cmdConfig, featureSwitches)
   }


### PR DESCRIPTION
* auto - will always use the broadcasting strategy.
* never - never user the broadcasting strategy.
* auto - use the strategy depending on the size of the mapping table.