### PR TITLE
1170 fix release notes generation

### DIFF
--- a/utils/get_release_notes/issue.rb
+++ b/utils/get_release_notes/issue.rb
@@ -32,7 +32,6 @@ class Issue
       # First line of a comment can start by blanks (spaces, tabs), then Release Notes eaither
       # capitalized or all lower case. Then any combination of blanks, dashes or columns followed
       # by a new line. The first line is going to be removed, so the new line is important.
-      # puts comment[:body]
       comment[:body] =~ /\A[[:blank:]]*(R|r)elease (N|n)otes([[:blank:]]|-|:)*(\r)?\n/
     end
 

--- a/utils/get_release_notes/issue.rb
+++ b/utils/get_release_notes/issue.rb
@@ -32,7 +32,8 @@ class Issue
       # First line of a comment can start by blanks (spaces, tabs), then Release Notes eaither
       # capitalized or all lower case. Then any combination of blanks, dashes or columns followed
       # by a new line. The first line is going to be removed, so the new line is important.
-      comment[:body] =~ /\A[[:blank:]]*(R|r)elease (N|n)otes([[:blank:]]|-|:)*\n/
+      # puts comment[:body]
+      comment[:body] =~ /\A[[:blank:]]*(R|r)elease (N|n)otes([[:blank:]]|-|:)*(\r)?\n/
     end
 
     if release_notes.nil? || release_notes.empty?

--- a/utils/get_release_notes/release.rb
+++ b/utils/get_release_notes/release.rb
@@ -15,7 +15,7 @@ class Release
   attr_reader :id, :title, :description, :issues
 
   def post_init
-    get_issues
+    get_issues.each { |issue| issue.get_release_notes }
     open_issues = @issues.select { |issue| issue.state == 'open' }
     if OptParser.options.strict && open_issues.size > 0
       raise StandardError, "Release has open issues #{open_issues.map(&:number)}", caller


### PR DESCRIPTION
- add an option for \r on the end of lines
- actually invoke the API for getting issue comments