### PR TITLE
Feature/1173 add run search by spark app

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/RunController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/RunController.scala
@@ -72,6 +72,12 @@ class RunController @Autowired()(runService: RunService) extends BaseController 
     runService.getRunSummariesPerDatasetVersion(datasetName)
   }
 
+  @GetMapping(Array("/bySparkAppId/{appId}"))
+  @ResponseStatus(HttpStatus.OK)
+  def getRunBySparkAppId(@PathVariable appId: String): CompletableFuture[String] = {
+    runService.getRunBySparkAppId(appId).map(ControlUtils.asJson)
+  }
+
   @GetMapping(Array("/{datasetName}/{datasetVersion}"))
   @ResponseStatus(HttpStatus.OK)
   def getSummariesByDatasetNameAndVersion(@PathVariable datasetName: String,

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/RunMongoRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/RunMongoRepository.scala
@@ -283,7 +283,7 @@ class RunMongoRepository @Autowired()(mongoDb: MongoDatabase)
 
   def getRunBySparkAppId(appId: String): Future[Option[Run]] = {
     val stdAppIdFilter = equal("controlMeasure.metadata.additionalInfo.std_application_id", appId)
-    val conformAppIdFilter =  equal("controlMeasure.metadata.additionalInfo.conform_application_id", appId)
+    val conformAppIdFilter = equal("controlMeasure.metadata.additionalInfo.conform_application_id", appId)
 
     collection
       .find[BsonDocument](or(stdAppIdFilter, conformAppIdFilter))

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/RunMongoRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/RunMongoRepository.scala
@@ -281,13 +281,13 @@ class RunMongoRepository @Autowired()(mongoDb: MongoDatabase)
       .toFuture()
   }
 
-  def getRunBySparkAppId(appId: String): Future[Option[Run]] = {
+  def getRunBySparkAppId(appId: String): Future[Seq[Run]] = {
     val stdAppIdFilter = equal("controlMeasure.metadata.additionalInfo.std_application_id", appId)
     val conformAppIdFilter = equal("controlMeasure.metadata.additionalInfo.conform_application_id", appId)
 
     collection
       .find[BsonDocument](or(stdAppIdFilter, conformAppIdFilter))
-      .headOption()
+      .toFuture()
       .map(_.map(bson => ControlUtils.fromJson[Run](bson.toJson)))
   }
 

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/RunMongoRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/RunMongoRepository.scala
@@ -281,6 +281,16 @@ class RunMongoRepository @Autowired()(mongoDb: MongoDatabase)
       .toFuture()
   }
 
+  def getRunBySparkAppId(appId: String): Future[Option[Run]] = {
+    val stdAppIdFilter = equal("controlMeasure.metadata.additionalInfo.std_application_id", appId)
+    val conformAppIdFilter =  equal("controlMeasure.metadata.additionalInfo.conform_application_id", appId)
+
+    collection
+      .find[BsonDocument](or(stdAppIdFilter, conformAppIdFilter))
+      .headOption()
+      .map(_.map(bson => ControlUtils.fromJson[Run](bson.toJson)))
+  }
+
   def getRun(datasetName: String, datasetVersion: Int, runId: Int): Future[Option[Run]] = {
     val datasetFilter = getDatasetFilter(datasetName, datasetVersion)
     val runIdEqFilter = equal("runId", runId)

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/RunService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/RunService.scala
@@ -89,11 +89,8 @@ class RunService @Autowired()(runMongoRepository: RunMongoRepository)
     runMongoRepository.getSummariesByDatasetNameAndVersion(datasetName, datasetVersion)
   }
 
-  def getRunBySparkAppId(appId: String): Future[Run] = {
-    runMongoRepository.getRunBySparkAppId(appId).map {
-      case Some(run) => run
-      case None      => throw NotFoundException()
-    }
+  def getRunBySparkAppId(appId: String): Future[Seq[Run]] = {
+    runMongoRepository.getRunBySparkAppId(appId)
   }
 
   def getRun(datasetName: String, datasetVersion: Int, runId: Int): Future[Run] = {

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/RunService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/RunService.scala
@@ -89,6 +89,13 @@ class RunService @Autowired()(runMongoRepository: RunMongoRepository)
     runMongoRepository.getSummariesByDatasetNameAndVersion(datasetName, datasetVersion)
   }
 
+  def getRunBySparkAppId(appId: String): Future[Run] = {
+    runMongoRepository.getRunBySparkAppId(appId).map {
+      case Some(run) => run
+      case None      => throw NotFoundException()
+    }
+  }
+
   def getRun(datasetName: String, datasetVersion: Int, runId: Int): Future[Run] = {
     runMongoRepository.getRun(datasetName, datasetVersion, runId).map {
       case Some(run) => run

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/RunApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/RunApiIntegrationSuite.scala
@@ -1058,21 +1058,6 @@ class RunApiIntegrationSuite extends BaseRestApiTest {
     run
   }
 
-  private def setUpRunWithAppIds(stdAppId: String, cnfrmAppId: String = "", runId: Int = 1): Run = {
-
-    val additionalInfo: Map[String, String] = if (cnfrmAppId == "") {
-      Map("std_application_id" -> stdAppId)
-    } else{
-      Map("std_application_id" -> stdAppId, "conform_application_id" -> cnfrmAppId)
-    }
-
-    val metadata = RunFactory.getDummyMetadata(additionalInfo = additionalInfo)
-    val controlMeasure = RunFactory.getDummyControlMeasure(metadata=metadata)
-    val run = RunFactory.getDummyRun(runId = runId, controlMeasure = controlMeasure)
-    runFixture.add(run)
-    run
-  }
-
   private def getDummyRunJson(dataset: String,
                               datasetVersion: Int,
                               runId: Int,
@@ -1085,6 +1070,19 @@ class RunApiIntegrationSuite extends BaseRestApiTest {
       """"controlMeasure":{"metadata":{"sourceApplication":"dummySourceApplication","country":"dummyCountry","historyType":"dummyHistoryType",""" +
       """"dataFilename":"dummyDataFilename","sourceType":"dummySourceType","version":1,"informationDate":"04-12-2017 16:19:17 +0200","additionalInfo":{}},""" +
       s""""runUniqueId":"$runUniqueId","checkpoints":[]}}"""
+  }
+
+  private def setUpRunWithAppIds(stdAppId: String, cnfrmAppId: String = "", runId: Int = 1): Run = {
+    val additionalInfo: Map[String, String] = if (cnfrmAppId == "") {
+      Map("std_application_id" -> stdAppId)
+    } else{
+      Map("std_application_id" -> stdAppId, "conform_application_id" -> cnfrmAppId)
+    }
+    val metadata = RunFactory.getDummyMetadata(additionalInfo = additionalInfo)
+    val controlMeasure = RunFactory.getDummyControlMeasure(metadata=metadata)
+    val run = RunFactory.getDummyRun(runId = runId, controlMeasure = controlMeasure)
+    runFixture.add(run)
+    run
   }
 
 }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/RunApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/RunApiIntegrationSuite.scala
@@ -994,8 +994,81 @@ class RunApiIntegrationSuite extends BaseRestApiTest {
     }
   }
 
+  s"GET $apiUrl/bySparkAppId/{appId}" can {
+    val sampleAppId1 = "application_1578585424019_0008" // YARN
+    val sampleAppId2 = "local-1433865536131"            // local
+    val sampleAppId3 = "driver-20170926223339-0001"     // MESOS
+
+    "return 200" when {
+      "there are no Run entities stored in the database" should {
+        "return an empty collection" in{
+          val response = sendGet[Array[Run]](s"$apiUrl/bySparkAppId/$sampleAppId1")
+          assertOk(response)
+          val body = response.getBody
+          assert(body.isEmpty)
+        }
+      }
+
+      "there are Run entities stored in the database" should{
+        "return empty collection when searching for missing app_id" in {
+          val run1 = setUpRunWithAppIds(sampleAppId1, runId = 1)
+          val wrongAppId = "missing-100500777-0042"     // MESOS
+          val response = sendGet[Array[Run]](s"$apiUrl/bySparkAppId/$wrongAppId")
+          assertOk(response)
+          val body = response.getBody
+          assert(body.isEmpty)
+        }
+
+        "return [correctRun] when searching for unique app_id" in {
+          // std app_id only
+          val run1 = setUpRunWithAppIds(sampleAppId1, runId = 1)
+          // both std and cnfrm app_ids
+          val run2 = setUpRunWithAppIds(sampleAppId2, sampleAppId3, runId = 2)
+          // get run1 by std app_id
+          val response1 = sendGet[String](s"$apiUrl/bySparkAppId/$sampleAppId1")
+          val body1 = response1.getBody
+          assert(body1 == ControlUtils.asJson(Seq(run1)))
+          // get run2 by std app_id
+          val response2 = sendGet[String](s"$apiUrl/bySparkAppId/$sampleAppId2")
+          val body2 = response2.getBody
+          assert(body2 == ControlUtils.asJson(Seq(run2)))
+          // get run2 by conform app_id
+          val response3 = sendGet[String](s"$apiUrl/bySparkAppId/$sampleAppId3")
+          val body3 = response3.getBody
+          assert(body3 == ControlUtils.asJson(Seq(run2)))
+        }
+
+        "return [run1, run2] when there are 2 runs with the same app_ids" in {
+          val run1 = setUpRunWithAppIds(sampleAppId1, runId = 1)
+          val run2 = setUpRunWithAppIds(sampleAppId1, runId = 2)
+
+          // get run1 by std app_id
+          val response = sendGet[String](s"$apiUrl/bySparkAppId/$sampleAppId1")
+          val actual = response.getBody
+          val expected = ControlUtils.asJson(Seq(run1, run2))
+          assert(actual == expected)
+        }
+      }
+    }
+  }
+
   private def setUpSimpleRun(): Run = {
     val run = RunFactory.getDummyRun(dataset = "dataset", datasetVersion = 1, runId = 1)
+    runFixture.add(run)
+    run
+  }
+
+  private def setUpRunWithAppIds(stdAppId: String, cnfrmAppId: String = "", runId: Int = 1): Run = {
+
+    val additionalInfo: Map[String, String] = if (cnfrmAppId == "") {
+      Map("std_application_id" -> stdAppId)
+    } else{
+      Map("std_application_id" -> stdAppId, "conform_application_id" -> cnfrmAppId)
+    }
+
+    val metadata = RunFactory.getDummyMetadata(additionalInfo = additionalInfo)
+    val controlMeasure = RunFactory.getDummyControlMeasure(metadata=metadata)
+    val run = RunFactory.getDummyRun(runId = runId, controlMeasure = controlMeasure)
     runFixture.add(run)
     run
   }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/repositories/RunRepositoryIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/repositories/RunRepositoryIntegrationSuite.scala
@@ -855,10 +855,79 @@ class RunRepositoryIntegrationSuite extends BaseRepositoryTest {
     }
   }
 
+  "RunMongoRepository::getRunBySparkAppId" should {
+    val sampleAppId1 = "application_1578585424019_0008" // YARN
+    val sampleAppId2 = "local-1433865536131"            // local
+    val sampleAppId3 = "driver-20170926223339-0001"     // MESOS
+    "return []" when {
+      "there are no runs" in {
+        assert(await(runMongoRepository.getRunBySparkAppId(sampleAppId1)).isEmpty)
+      }
+
+      "there are runs with different spark app_id" in{
+        val run = setupRunWithAppIds(sampleAppId1)
+        await(runMongoRepository.create(run))
+        assert(await(runMongoRepository.getRunBySparkAppId(sampleAppId2)).isEmpty)
+      }
+    }
+
+    "return [correctRun]" when {
+      "there are 2 runs with different app_ids" in {
+        // std app_id only
+        val run1 = setupRunWithAppIds(sampleAppId1, runId = 1)
+        await(runMongoRepository.create(run1))
+
+        // both std and cnfrm app_ids
+        val run2 = setupRunWithAppIds(sampleAppId2, sampleAppId3, runId = 2)
+        await(runMongoRepository.create(run2))
+
+        // get run1 by std app_id
+        val actual1 = await(runMongoRepository.getRunBySparkAppId(sampleAppId1))
+        assert(actual1 == Seq(run1))
+
+        // get run2 by std app_id
+        val actual2 = await(runMongoRepository.getRunBySparkAppId(sampleAppId2))
+        assert(actual2 == Seq(run2))
+
+        // get run2 by conform app_id
+        val actual3 = await(runMongoRepository.getRunBySparkAppId(sampleAppId3))
+        assert(actual3 == Seq(run2))
+      }
+    }
+
+    "return [run1, run2]" when {
+      "there are 2 runs with the same std app_id" in {
+        val run1 = setupRunWithAppIds(sampleAppId1, runId = 1)
+        await(runMongoRepository.create(run1))
+
+        val run2 = setupRunWithAppIds(sampleAppId1, runId = 2)
+        await(runMongoRepository.create(run2))
+
+        // get run1 by std app_id
+        val actual = await(runMongoRepository.getRunBySparkAppId(sampleAppId1))
+        val expected = Seq(run1, run2)
+        assert(actual == expected)
+      }
+    }
+  }
+
   private def setUpSimpleRun(): Run = {
     val run = RunFactory.getDummyRun(dataset = "dataset", datasetVersion = 1, runId = 1)
     runFixture.add(run)
     run
+  }
+
+  private def setupRunWithAppIds(stdAppId: String, cnfrmAppId: String = "", runId: Int = 1): Run = {
+
+    val additionalInfo: Map[String, String] = if (cnfrmAppId == "") {
+      Map("std_application_id" -> stdAppId)
+    } else{
+      Map("std_application_id" -> stdAppId, "conform_application_id" -> cnfrmAppId)
+    }
+
+    val metadata = RunFactory.getDummyMetadata(additionalInfo = additionalInfo)
+    val controlMeasure = RunFactory.getDummyControlMeasure(metadata=metadata)
+    RunFactory.getDummyRun(runId = runId, controlMeasure = controlMeasure)
   }
 
 }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/repositories/RunRepositoryIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/repositories/RunRepositoryIntegrationSuite.scala
@@ -861,25 +861,24 @@ class RunRepositoryIntegrationSuite extends BaseRepositoryTest {
     val sampleAppId3 = "driver-20170926223339-0001"     // MESOS
     "return []" when {
       "there are no runs" in {
-        assert(await(runMongoRepository.getRunBySparkAppId(sampleAppId1)).isEmpty)
+        val actual = await(runMongoRepository.getRunBySparkAppId(sampleAppId1))
+        assert(actual.isEmpty)
       }
 
       "there are runs with different spark app_id" in{
-        val run = setupRunWithAppIds(sampleAppId1)
-        await(runMongoRepository.create(run))
-        assert(await(runMongoRepository.getRunBySparkAppId(sampleAppId2)).isEmpty)
+        val run = setUpRunWithAppIds(sampleAppId1)
+        val actual = await(runMongoRepository.getRunBySparkAppId(sampleAppId2))
+        assert(actual.isEmpty)
       }
     }
 
-    "return [correctRun]" when {
+    "return Seq(correctRun)" when {
       "there are 2 runs with different app_ids" in {
         // std app_id only
-        val run1 = setupRunWithAppIds(sampleAppId1, runId = 1)
-        await(runMongoRepository.create(run1))
+        val run1 = setUpRunWithAppIds(sampleAppId1, runId = 1)
 
         // both std and cnfrm app_ids
-        val run2 = setupRunWithAppIds(sampleAppId2, sampleAppId3, runId = 2)
-        await(runMongoRepository.create(run2))
+        val run2 = setUpRunWithAppIds(sampleAppId2, sampleAppId3, runId = 2)
 
         // get run1 by std app_id
         val actual1 = await(runMongoRepository.getRunBySparkAppId(sampleAppId1))
@@ -895,13 +894,11 @@ class RunRepositoryIntegrationSuite extends BaseRepositoryTest {
       }
     }
 
-    "return [run1, run2]" when {
+    "return Seq(run1, run2)" when {
       "there are 2 runs with the same std app_id" in {
-        val run1 = setupRunWithAppIds(sampleAppId1, runId = 1)
-        await(runMongoRepository.create(run1))
+        val run1 = setUpRunWithAppIds(sampleAppId1, runId = 1)
 
-        val run2 = setupRunWithAppIds(sampleAppId1, runId = 2)
-        await(runMongoRepository.create(run2))
+        val run2 = setUpRunWithAppIds(sampleAppId1, runId = 2)
 
         // get run1 by std app_id
         val actual = await(runMongoRepository.getRunBySparkAppId(sampleAppId1))
@@ -917,7 +914,7 @@ class RunRepositoryIntegrationSuite extends BaseRepositoryTest {
     run
   }
 
-  private def setupRunWithAppIds(stdAppId: String, cnfrmAppId: String = "", runId: Int = 1): Run = {
+  private def setUpRunWithAppIds(stdAppId: String, cnfrmAppId: String = "", runId: Int = 1): Run = {
 
     val additionalInfo: Map[String, String] = if (cnfrmAppId == "") {
       Map("std_application_id" -> stdAppId)
@@ -927,7 +924,9 @@ class RunRepositoryIntegrationSuite extends BaseRepositoryTest {
 
     val metadata = RunFactory.getDummyMetadata(additionalInfo = additionalInfo)
     val controlMeasure = RunFactory.getDummyControlMeasure(metadata=metadata)
-    RunFactory.getDummyRun(runId = runId, controlMeasure = controlMeasure)
+    val run = RunFactory.getDummyRun(runId = runId, controlMeasure = controlMeasure)
+    runFixture.add(run)
+    run
   }
 
 }


### PR DESCRIPTION
#1173 Add Run search by Spark app_id

It is needed to find corresponding Run documents for given Spark History data

Add API api/runs/bySparkAppId/{spark_app_id}
which will return Run document where std_application_id OR conform_application_id equals {spark_app_id}