### PR TITLE
#1163 Loading Schema from URL

### DIFF
--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -272,12 +272,11 @@
             <version>2.26.3</version>
             <scope>test</scope>
         </dependency>
-        <!-- guava 27 for wire mock -->
+        <!-- guava 27 for wire mock test, but not just test scope, because guava is needed for spring, too -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>27.0.1-jre</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -265,6 +265,20 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- WireMock - to act as SchemaRegistry for IntegTest-->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.26.3</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- guava 27 for wire mock -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>27.0.1-jre</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -29,6 +29,8 @@
         <scala.xml.version>1.0.4</scala.xml.version>
         <webui.basedir>${project.basedir}/ui</webui.basedir>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>
+        <guava.version>27.0.1-jre</guava.version>
+        <wiremock.version>2.26.3</wiremock.version>
     </properties>
 
     <dependencies>
@@ -258,6 +260,12 @@
             <artifactId>spark-cobol</artifactId>
             <version>${cobrix.version}</version>
         </dependency>
+        <!-- guava 27 for spring & wire mock testing, too -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -269,14 +277,8 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
-            <version>2.26.3</version>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
-        </dependency>
-        <!-- guava 27 for wire mock test, but not just test scope, because guava is needed for spring, too -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
         </dependency>
     </dependencies>
     <build>

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/RestExceptionHandler.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/RestExceptionHandler.scala
@@ -24,8 +24,8 @@ import za.co.absa.enceladus.menas.models.{RestError, Validation}
 import org.springframework.http.HttpStatus
 import org.slf4j.LoggerFactory
 import za.co.absa.enceladus.menas.models.rest.RestResponse
-import za.co.absa.enceladus.menas.models.rest.errors.{SchemaFormatError, SchemaParsingError}
-import za.co.absa.enceladus.menas.models.rest.exceptions.{SchemaFormatException, SchemaParsingException}
+import za.co.absa.enceladus.menas.models.rest.errors.{RemoteSchemaRetrievalError, SchemaFormatError, SchemaParsingError}
+import za.co.absa.enceladus.menas.models.rest.exceptions.{RemoteSchemaRetrievalException, SchemaFormatException, SchemaParsingException}
 import org.apache.oozie.client.OozieClientException
 import org.springframework.beans.factory.annotation.Value
 
@@ -55,6 +55,13 @@ class RestExceptionHandler {
   @ExceptionHandler(value = Array(classOf[SchemaFormatException]))
   def handleBadRequestException(exception: SchemaFormatException): ResponseEntity[Any] = {
     val response = RestResponse(exception.message, Option(SchemaFormatError.fromException(exception)))
+    logger.error(s"Exception: $response", exception)
+    ResponseEntity.badRequest().body(response)
+  }
+
+  @ExceptionHandler(value = Array(classOf[RemoteSchemaRetrievalException]))
+  def handleBadRequestException(exception: RemoteSchemaRetrievalException): ResponseEntity[Any] = {
+    val response = RestResponse(exception.message, Option(RemoteSchemaRetrievalError.fromException(exception)))
     logger.error(s"Exception: $response", exception)
     ResponseEntity.badRequest().body(response)
   }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/SchemaController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/SchemaController.scala
@@ -72,7 +72,7 @@ class SchemaController @Autowired()(
 
       } catch {
         case NonFatal(e) =>
-          throw RemoteSchemaRetrievalException(schemaType, s"$remoteUrl is currently unreachable to download a schema file from.", e)
+          throw RemoteSchemaRetrievalException(schemaType, s"Could not retrieve a schema file from $remoteUrl. Please check the correctness of the URL and a presence of the schema at the mentioned endpoint", e)
       }
     }
 

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/models/rest/errors/RemoteSchemaRetrievalError.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/models/rest/errors/RemoteSchemaRetrievalError.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.models.rest.errors
+
+import za.co.absa.enceladus.menas.models.rest.ResponseError
+import za.co.absa.enceladus.menas.models.rest.exceptions.RemoteSchemaRetrievalException
+import za.co.absa.enceladus.menas.utils.SchemaType
+
+/**
+  * This error is produced when an incorrect schema format is provided.
+  */
+case class RemoteSchemaRetrievalError(
+                              errorType: String,
+                              schemaType: SchemaType.Value
+                            ) extends ResponseError
+
+object RemoteSchemaRetrievalError {
+  def fromException(ex: RemoteSchemaRetrievalException): RemoteSchemaRetrievalError = RemoteSchemaRetrievalError(
+    errorType = "schema_retrieval_error",
+    schemaType = ex.schemaType)
+}
+

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/models/rest/exceptions/RemoteSchemaRetrievalException.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/models/rest/exceptions/RemoteSchemaRetrievalException.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.models.rest.exceptions
+
+import za.co.absa.enceladus.menas.utils.SchemaType
+
+/**
+ * This exception is thrown if there is problem loading a remote schema (not an issue with format but with the retrieval itself)
+ */
+case class RemoteSchemaRetrievalException(
+                                           schemaType: SchemaType.Value,
+                                           message: String,
+                                           cause: Throwable = null
+                                         ) extends Exception(message, cause)

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/BaseRestApiTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/BaseRestApiTest.scala
@@ -198,7 +198,6 @@ abstract class BaseRestApiTest extends BaseRepositoryTest {
     restTemplate.exchange(url, HttpMethod.POST, httpEntity, clazz)
   }
 
-
   def assertOk(responseEntity: ResponseEntity[_]): Unit = {
     assert(responseEntity.getStatusCode == HttpStatus.OK)
   }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/BaseRestApiTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/BaseRestApiTest.scala
@@ -181,16 +181,16 @@ abstract class BaseRestApiTest extends BaseRepositoryTest {
   def fromRemote[T](urlPath: String,
                     headers: HttpHeaders = HttpHeaders.EMPTY,
                     params: Map[String, Any])
-               (implicit ct: ClassTag[T]): ResponseEntity[T] = {
+                   (implicit ct: ClassTag[T]): ResponseEntity[T] = {
 
     val parameters = new LinkedMultiValueMap[String, Any]
     params.foreach {
-      case (key, value) => parameters.add(key, value) // TODO convert to Map<K, List<V>> and pass to LMVM directly?
+      case (key, value) => parameters.add(key, value)
     }
 
     val url = s"$baseUrl/$urlPath"
     headers.addAll(authHeaders)
-    headers.setContentType(MediaType.MULTIPART_FORM_DATA) // no payload transfer besides the form data? application/x-www-form-urlencoded?
+    headers.setContentType(MediaType.MULTIPART_FORM_DATA)
 
     val clazz = ct.runtimeClass.asInstanceOf[Class[T]]
 

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/BaseRestApiTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/BaseRestApiTest.scala
@@ -26,7 +26,7 @@ import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.context.annotation.Bean
 import org.springframework.http._
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
-import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.{LinkedMultiValueMap, MultiValueMap}
 import za.co.absa.enceladus.menas.integration.repositories.BaseRepositoryTest
 
 import scala.concurrent.Future
@@ -183,18 +183,18 @@ abstract class BaseRestApiTest extends BaseRepositoryTest {
                     params: Map[String, Any])
                    (implicit ct: ClassTag[T]): ResponseEntity[T] = {
 
-    val parameters = new LinkedMultiValueMap[String, Any]
+    val parameters: MultiValueMap[String, String] = new LinkedMultiValueMap()
     params.foreach {
-      case (key, value) => parameters.add(key, value)
+      case (key, value) => parameters.add(key, value.toString)
     }
 
     val url = s"$baseUrl/$urlPath"
     headers.addAll(authHeaders)
-    headers.setContentType(MediaType.MULTIPART_FORM_DATA)
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED)
 
     val clazz = ct.runtimeClass.asInstanceOf[Class[T]]
 
-    val httpEntity = new HttpEntity[LinkedMultiValueMap[String, Any]](parameters, headers)
+    val httpEntity = new HttpEntity(parameters, headers)
     restTemplate.exchange(url, HttpMethod.POST, httpEntity, clazz)
   }
 

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiIntegrationSuite.scala
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
 import org.springframework.test.context.junit4.SpringRunner
 import za.co.absa.enceladus.menas.TestResourcePath
 import za.co.absa.enceladus.menas.integration.fixtures._
@@ -626,13 +627,13 @@ class SchemaApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll {
         refVersion = 2,
         refCollection = schemaRefCollection,
         fileContent = Array(2, 3, 4),
-        fileMIMEType = "application/octet-stream")
+        fileMIMEType = MediaType.APPLICATION_OCTET_STREAM_VALUE)
       val attachment4 = AttachmentFactory.getDummyAttachment(
         refName = "schemaName",
         refVersion = 4,
         refCollection = schemaRefCollection,
         fileContent = Array(4, 5, 6),
-        fileMIMEType = "application/json")
+        fileMIMEType = MediaType.APPLICATION_JSON_VALUE)
       val attachment5 = AttachmentFactory.getDummyAttachment(
         refName = "schemaName",
         refVersion = 5,
@@ -646,7 +647,7 @@ class SchemaApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll {
 
           assertOk(response)
           assert(response.getHeaders.containsKey("mime-type"))
-          assert(response.getHeaders.get("mime-type").get(0) == "application/octet-stream")
+          assert(response.getHeaders.get("mime-type").get(0) == MediaType.APPLICATION_OCTET_STREAM_VALUE)
 
           val body = response.getBody
           assert(body.sameElements(attachment2.fileContent))
@@ -861,7 +862,7 @@ class SchemaApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll {
     def readTestResourceAsResponseWithContentType(path: String): ResponseDefinitionBuilder = {
       // this is crazy, but it works better than hardcoding mime-types
       val filePath: Path = new File(getClass.getResource(path).toURI()).toPath
-      val mime = Option(Files.probeContentType(filePath)).getOrElse("application/octet-stream") // default for e.g. cob
+      val mime = Option(Files.probeContentType(filePath)).getOrElse(MediaType.APPLICATION_OCTET_STREAM_VALUE) // default for e.g. cob
 
       val content = readTestResourceAsString(path)
       okForContentType(mime, content)

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiIntegrationSuite.scala
@@ -880,7 +880,7 @@ class SchemaApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll {
             .willReturn(readTestResourceAsResponseWithContentType(TestResourcePath.Copybook.ok)))
 
           val params = HashMap[String, Any](
-            "name" -> schema.name, "version" -> schema.version, "format" -> "copybook", "remoteUrl" -> remoteUrl) // TODO string value from somewhere?
+            "name" -> schema.name, "version" -> schema.version, "format" -> "copybook", "remoteUrl" -> remoteUrl)
           val responseRemoteLoaded = sendPostRemoteFile[Schema](s"$apiUrl/remote", params)
           assertCreated(responseRemoteLoaded)
 

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/package.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/package.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus
+
+package object menas {
+
+  /**
+   * Resource paths of files for schema testing
+   */
+  object TestResourcePath {
+
+    object Json {
+      val ok = "/test_data/schemas/json/schema_json_ok.json"
+      val bogus = "/test_data/schemas/json/schema_json_bogus.json"
+    }
+
+    object Copybook {
+      val ok = "/test_data/schemas/copybook/copybook_ok.cob"
+      val bogus = "/test_data/schemas/copybook/copybook_bogus.cob"
+      val okJsonEquivalent = "/test_data/schemas/copybook/equivalent-to-copybook.json"
+    }
+
+    object Avro {
+      val ok = "/test_data/schemas/avro/avroschema_json_ok.avsc"
+      val bogus = "/test_data/schemas/avro/avroschema_json_bogus.avsc"
+      val okJsonEquivalent = "/test_data/schemas/avro/equivalent-to-avroschema.json"
+    }
+
+  }
+
+}

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/utils/parsers/SchemaParserSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/utils/parsers/SchemaParserSuite.scala
@@ -23,6 +23,7 @@ import org.mockito.Mockito
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Inside, Matchers, WordSpec}
 import za.co.absa.cobrix.cobol.parser.exceptions.SyntaxErrorException
+import za.co.absa.enceladus.menas.TestResourcePath
 import za.co.absa.enceladus.menas.models.rest.exceptions.SchemaParsingException
 import za.co.absa.enceladus.menas.utils.SchemaType
 import za.co.absa.enceladus.menas.utils.converters.SparkMenasSchemaConvertor
@@ -65,9 +66,9 @@ class SchemaParserSuite extends WordSpec with Matchers with MockitoSugar with In
     val avroParser = schemaParserFactory.getParser(Avro)
     "parse avro schema to StructType" when {
       "correct avsc file content is given" in {
-        val expectedStructType = readTestResourceAsDataType("/test_data/schemas/avro/equivalent-to-avroschema.json")
+        val expectedStructType = readTestResourceAsDataType(TestResourcePath.Avro.okJsonEquivalent)
 
-        val schemaContent = readTestResourceAsString("/test_data/schemas/avro/avroschema_json_ok.avsc")
+        val schemaContent = readTestResourceAsString(TestResourcePath.Avro.ok)
         avroParser.parse(schemaContent) shouldBe expectedStructType
       }
     }
@@ -88,16 +89,16 @@ class SchemaParserSuite extends WordSpec with Matchers with MockitoSugar with In
     val copybookParser = schemaParserFactory.getParser(Copybook)
     "parse cobol copybook schema to StructType" when {
       "correct cob file content is given" in {
-        val expectedCopybookType = readTestResourceAsDataType("/test_data/schemas/copybook/equivalent-to-copybook.json")
+        val expectedCopybookType = readTestResourceAsDataType(TestResourcePath.Copybook.okJsonEquivalent)
 
-        val schemaContent = readTestResourceAsString("/test_data/schemas/copybook/copybook_ok.cob")
+        val schemaContent = readTestResourceAsString(TestResourcePath.Copybook.ok)
         copybookParser.parse(schemaContent) shouldBe expectedCopybookType
       }
     }
 
     "throw SchemaParsingException at parse copybook" when {
       "given unparsable cob content" in {
-        val schemaContent = readTestResourceAsString("/test_data/schemas/copybook/copybook_bogus.cob")
+        val schemaContent = readTestResourceAsString(TestResourcePath.Copybook.bogus)
 
         val caughtException = the[SchemaParsingException] thrownBy {
           copybookParser.parse(schemaContent)

--- a/menas/ui/components/schema/schemaDetail.controller.js
+++ b/menas/ui/components/schema/schemaDetail.controller.js
@@ -162,6 +162,38 @@ sap.ui.define([
       }
     },
 
+    handleRemoteUrlSubmit: function (oParams) {
+      const schemaType = this.byId("schemaFormatUploadSelect").getSelectedKey(); // same as getSelectedItem().getKey();
+      const remoteUrl = this.byId("remoteUrl").getValue();
+      const schema = this._model.getProperty("/currentSchema");
+
+      console.log("format = " + schemaType + ", remoteUrl = " + remoteUrl + ", version = " + schema.version + ", name = " + schema.name);
+
+      let data = {
+        "format" : schemaType,
+        "remoteUrl" : remoteUrl,
+        "name" : schema.name,
+        "version" :  schema.version
+      };
+
+      jQuery.ajax({
+        url: "api/schema/remote",
+        type: 'POST',
+        data: $.param(data),
+        contentType: 'application/x-www-form-urlencoded',
+        headers: {
+          'X-CSRF-TOKEN': localStorage.getItem("csrfToken")
+        },
+        success: function(data){
+          console.log("success: " + data);
+        },
+        error: function(e){
+          console.log("error: " + e);
+        }
+      });
+
+    },
+
     handleUploadProgress: function (oParams) {
       console.log((oParams.getParameter("loaded") / oParams.getParameter("total")) * 100)
     },

--- a/menas/ui/components/schema/schemaDetail.controller.js
+++ b/menas/ui/components/schema/schemaDetail.controller.js
@@ -211,7 +211,7 @@ sap.ui.define([
         isOkToSubmit = false; // may get submitted by the MessageBox
         const fixedUrl = this.fixSchemaRegistryUrl(schemaUrl);
 
-        sap.m.MessageBox.show(`The schema url should probably end with "/schema" \nDo you want use ${fixedUrl} instead?`, {
+        sap.m.MessageBox.show(`The schema url should probably end with "/schema". \nDo you want use ${fixedUrl} instead?`, {
           icon: sap.m.MessageBox.Icon.WARNING,
           title: "Auto-correct schema repository URL?",
           actions: [sap.m.MessageBox.Action.YES, sap.m.MessageBox.Action.NO, sap.m.MessageBox.Action.CANCEL],
@@ -333,7 +333,7 @@ sap.ui.define([
       return pattern.test(url);
     },
 
-    // this is what the schema registry url should look like to be "fixable", e.g. http://zapalnrapp1079.corp.dsarena.com:8081/subjects/somename/versions/1
+    // this is what the schema registry url should look like to be "fixable", e.g. http://example.schemaregistry.org/subjects/somename/versions/1
     schemaRegistryRx: /^(https?:\/\/[^ ]+\/versions\/\d+)\/?$/,
 
     isFixableSchemaRegistryUrl: function(str) {

--- a/menas/ui/components/schema/schemaDetail.view.xml
+++ b/menas/ui/components/schema/schemaDetail.view.xml
@@ -56,6 +56,15 @@
                         </u:FileUploader>
                         <Button text="Upload File" press="handleUploadPress"/>
                     </IconTabFilter>
+                    <IconTabFilter id="LoadRemote" icon="sap-icon://internet-browser" text="Load from URL">
+                        <Select id="schemaFormatUploadSelect" forceSelection="true" selectedKey="{/currentSchema/schemaFormat}">
+                            <core:Item key="struct" text="Spark StructType JSON"/>
+                            <core:Item key="copybook" text="COBOL Copybook"/>
+                            <core:Item key="avro" text="Avro Schema (avsc)"/>
+                        </Select>
+                        <Input id="remoteUrl" type="Text" placeholder="Enter URL" />
+                        <Button text="Submit URL" press="handleRemoteUrlSubmit"/>
+                    </IconTabFilter>
                     <IconTabFilter id="UsedIn" icon="sap-icon://detail-view" text="Used In">
                         <Panel headerText="Datasets" height="50%">
                             <List items="{/currentSchema/usedIn/datasets}" mode="None"

--- a/menas/ui/components/schema/schemaDetail.view.xml
+++ b/menas/ui/components/schema/schemaDetail.view.xml
@@ -57,13 +57,20 @@
                         <Button text="Upload File" press="handleUploadPress"/>
                     </IconTabFilter>
                     <IconTabFilter id="LoadRemote" icon="sap-icon://internet-browser" text="Load from URL">
-                        <Select id="remoteSchemaFormatSelect" forceSelection="true" selectedKey="{/currentSchema/schemaFormat}">
-                            <core:Item key="struct" text="Spark StructType JSON"/>
-                            <core:Item key="copybook" text="COBOL Copybook"/>
-                            <core:Item key="avro" text="Avro Schema (avsc)"/>
-                        </Select>
-                        <Input id="remoteUrl" type="Text" placeholder="Enter URL"/>
-                        <Button text="Submit URL" press="handleRemoteUrlSubmit"/>
+                        <HBox alignItems="Center">
+                            <Select id="remoteSchemaFormatSelect" forceSelection="true"
+                                    selectedKey="{/currentSchema/schemaFormat}">
+                                <core:Item key="struct" text="Spark StructType JSON"/>
+                                <core:Item key="copybook" text="COBOL Copybook"/>
+                                <core:Item key="avro" text="Avro Schema (avsc)"/>
+                            </Select>
+                            <Input id="remoteUrl" type="Text" placeholder="Enter URL of the new schema">
+                                <layoutData>
+                                    <FlexItemData growFactor="1"/>
+                                </layoutData>
+                            </Input>
+                            <Button text="Submit URL" press="handleRemoteUrlSubmit"/>
+                        </HBox>
                     </IconTabFilter>
                     <IconTabFilter id="UsedIn" icon="sap-icon://detail-view" text="Used In">
                         <Panel headerText="Datasets" height="50%">

--- a/menas/ui/components/schema/schemaDetail.view.xml
+++ b/menas/ui/components/schema/schemaDetail.view.xml
@@ -57,12 +57,12 @@
                         <Button text="Upload File" press="handleUploadPress"/>
                     </IconTabFilter>
                     <IconTabFilter id="LoadRemote" icon="sap-icon://internet-browser" text="Load from URL">
-                        <Select id="schemaFormatUploadSelect" forceSelection="true" selectedKey="{/currentSchema/schemaFormat}">
+                        <Select id="remoteSchemaFormatSelect" forceSelection="true" selectedKey="{/currentSchema/schemaFormat}">
                             <core:Item key="struct" text="Spark StructType JSON"/>
                             <core:Item key="copybook" text="COBOL Copybook"/>
                             <core:Item key="avro" text="Avro Schema (avsc)"/>
                         </Select>
-                        <Input id="remoteUrl" type="Text" placeholder="Enter URL" />
+                        <Input id="remoteUrl" type="Text" placeholder="Enter URL"/>
                         <Button text="Submit URL" press="handleRemoteUrlSubmit"/>
                     </IconTabFilter>
                     <IconTabFilter id="UsedIn" icon="sap-icon://detail-view" text="Used In">

--- a/menas/ui/components/schema/schemaDetail.view.xml
+++ b/menas/ui/components/schema/schemaDetail.view.xml
@@ -59,10 +59,10 @@
                     <IconTabFilter id="LoadRemote" icon="sap-icon://internet-browser" text="Load from URL">
                         <HBox alignItems="Center">
                             <Select id="remoteSchemaFormatSelect" forceSelection="true"
-                                    selectedKey="{/currentSchema/schemaFormat}">
+                                    selectedKey="avro"> <!-- schema registry default is avro -->
                                 <core:Item key="struct" text="Spark StructType JSON"/>
                                 <core:Item key="copybook" text="COBOL Copybook"/>
-                                <core:Item key="avro" text="Avro Schema (avsc)"/>
+                                <core:Item key="avro" text="Avro Schema (avsc)" />
                             </Select>
                             <Input id="remoteUrl" type="Text" placeholder="Enter URL of the new schema">
                                 <layoutData>

--- a/menas/ui/components/schema/schemaDetail.view.xml
+++ b/menas/ui/components/schema/schemaDetail.view.xml
@@ -38,32 +38,29 @@
                         <core:Fragment type="XML" fragmentName="components.schemaTable"/>
                     </IconTabFilter>
                     <IconTabFilter id="UploadNew" icon="sap-icon://upload" text="Upload new">
-                        <Select id="schemaFormatSelect" forceSelection="true"
-                                selectedKey="{/currentSchema/schemaFormat}">
-                            <core:Item key="struct" text="Spark StructType JSON"/>
-                            <core:Item key="copybook" text="COBOL Copybook"/>
-                            <core:Item key="avro" text="Avro Schema (avsc)"/>
-                        </Select>
-                        <u:FileUploader id="fileUploader" name="file" uploadUrl="api/schema/upload"
-                                        tooltip="Upload new version of the schema" uploadComplete="handleUploadComplete"
-                                        sendXHR="true"
-                                        uploadProgress="handleUploadProgress" sameFilenameAllowed="true">
-                            <u:parameters>
-                                <u:FileUploaderParameter name="name" value="{/currentSchema/name}"/>
-                                <u:FileUploaderParameter name="version" value="{/currentSchema/version}"/>
-                                <u:FileUploaderParameter name="format" value="{/currentSchema/schemaFormat}"/>
-                            </u:parameters>
-                        </u:FileUploader>
-                        <Button text="Upload File" press="handleUploadPress"/>
-                    </IconTabFilter>
-                    <IconTabFilter id="LoadRemote" icon="sap-icon://internet-browser" text="Load from URL">
-                        <HBox alignItems="Center">
-                            <Select id="remoteSchemaFormatSelect" forceSelection="true"
-                                    selectedKey="avro"> <!-- schema registry default is avro -->
+                        <Label text="Upload schema from file:" labelFor="schemaFormatSelect"/>
+                        <HBox width="35em">
+                            <Select id="schemaFormatSelect" forceSelection="true"
+                                    selectedKey="{/currentSchema/schemaFormat}">
                                 <core:Item key="struct" text="Spark StructType JSON"/>
                                 <core:Item key="copybook" text="COBOL Copybook"/>
-                                <core:Item key="avro" text="Avro Schema (avsc)" />
+                                <core:Item key="avro" text="Avro Schema (avsc)"/>
                             </Select>
+                            <u:FileUploader id="fileUploader" name="file" uploadUrl="api/schema/upload"
+                                            tooltip="Upload new version of the schema"
+                                            uploadComplete="handleUploadComplete"
+                                            sendXHR="true"
+                                            uploadProgress="handleUploadProgress" sameFilenameAllowed="true" >
+                                <u:parameters>
+                                    <u:FileUploaderParameter name="name" value="{/currentSchema/name}"/>
+                                    <u:FileUploaderParameter name="version" value="{/currentSchema/version}"/>
+                                    <u:FileUploaderParameter name="format" value="{/currentSchema/schemaFormat}"/>
+                                </u:parameters>
+                            </u:FileUploader>
+                            <Button text="Upload File" press="handleUploadPress"/>
+                        </HBox>
+                        <Label text="Load avro schema from URL:" labelFor="remoteUrl"/>
+                        <HBox width="35em">
                             <Input id="remoteUrl" type="Text" placeholder="Enter URL of the new schema">
                                 <layoutData>
                                     <FlexItemData growFactor="1"/>


### PR DESCRIPTION
![1163-menas-load-from-ui](https://user-images.githubusercontent.com/4457378/78010166-59cf1200-7342-11ea-965c-062001493439.png)

 - Tested against local HTTP server, e.g. `http://localhost:8000/avro_users-v1-struct.json`
 - also works against a REST client with the `x-www-form-urlencoded` content type, provided there is an appropriate `X-CSRF-TOKEN` present.
![menas-remote-url-postman](https://user-images.githubusercontent.com/4457378/78010497-b5010480-7342-11ea-8c33-0e5a5abaad6e.png)

 - integtest updated to cover the `/remote` load variant. WireMock HTTP server mocking is used there, including mocking proper mime types of the served files.

`schemaDetail.controller`:
- the UI also works, but jQuery ajax call is used (`handleRemoteUrlSubmit`) whose response is quite similar, but not too similar to the uploading variant (`handleRemoteLoadComplete` vs `handleUploadComplete` - not sure it pays off to generalize. Or is there a way to convert one response to the type of the other?)

 - also tested to work with `Avro Schema (avsc)` and URL `http://zapalnrapp1079.corp.dsarena.com:8081/subjects/ruslan.avro.users-value/versions/1/schema`

## Update:
The UI now detects Schema registry URL missing the `/schema` suffix:
![1163-menas-schema-url-autocorrect](https://user-images.githubusercontent.com/4457378/78156333-f37be980-743e-11ea-8dab-ec08495c815d.png)
 - The reason is that the schema is also available on the `/version/$x` endpoint, but is only available in the `schema` field there as a JSON-in-a-JSON.