### PR TITLE
#1277 Use onApplicationEnd event to close Enceladus plugins

### DIFF
--- a/data-model/src/main/scala/za/co/absa/enceladus/model/test/factories/RunFactory.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/test/factories/RunFactory.scala
@@ -85,7 +85,7 @@ object RunFactory {
                          workflowName: String = "dummyWorkFlowName",
                          order: Int = 0,
                          controls: List[Measurement] = List()): Checkpoint = {
-    Checkpoint(name, processStartTime, processEndTime, workflowName, order, controls)
+    Checkpoint(name, None, None, processStartTime, processEndTime, workflowName, order, controls)
   }
 
   def getDummyMeasurement(controlName: String = "dummyControlName",

--- a/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/buildin/factories/DceControlInfoFactory.scala
+++ b/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/buildin/factories/DceControlInfoFactory.scala
@@ -37,9 +37,9 @@ object DceControlInfoFactory {
       version,
       informationDate,
       additionalInfo), None, List(
-      Checkpoint("Source", "2019-12-21 10:21:33", "2019-12-21 12:10:57", "Source", 1,
+      Checkpoint("Source", None, None, "2019-12-21 10:21:33", "2019-12-21 12:10:57", "Source", 1,
         List(Measurement("recordCount", "controlType.count", "*", "223929"))),
-      Checkpoint("Raw", "2019-12-21 12:11:22", "2019-12-21 13:20:21", "Raw", 2,
+      Checkpoint("Raw", None, None, "2019-12-21 12:11:22", "2019-12-21 13:20:21", "Raw", 2,
         List(Measurement("recordCount", "controlType.count", "*", "223929")))
     ))
   }

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <maven.rat.plugin.version>0.12</maven.rat.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
         <!--dependency versions-->
-        <atum.version>0.2.5</atum.version>
+        <atum.version>0.2.6</atum.version>
         <junit.version>4.11</junit.version>
         <specs.version>2.4.16</specs.version>
         <scalatest.version>3.0.5</scalatest.version>

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/plugin/menas/EventListenerMenas.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/plugin/menas/EventListenerMenas.scala
@@ -139,7 +139,7 @@ class EventListenerMenas(config: Config,
     }
   }
 
-  def close(): Unit = {
+  override def onApplicationEnd(): Unit = {
     controlMetricPlugins.foreach(plugin => {
       try {
         plugin.close()

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/plugin/menas/MenasPlugin.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/plugin/menas/MenasPlugin.scala
@@ -59,6 +59,4 @@ object MenasPlugin {
 
   def runNumber: Option[Int] = listener.flatMap(_.runNumber)
 
-  def close(): Unit = listener.foreach(_.close())
-
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -110,7 +110,6 @@ object DynamicConformanceJob {
           log.info(s"Menas UI Run URL: $menasBaseUrl/#/runs/$name/$version/$runNumber")
         }
       }
-      MenasPlugin.close()
     }
   }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -129,7 +129,6 @@ object StandardizationJob {
           log.info(s"Menas UI Run URL: $menasBaseUrl/#/runs/$name/$version/$runNumber")
         }
       }
-      MenasPlugin.close()
     }
   }
 


### PR DESCRIPTION
This fixes the attempt to send control info when the Kafka producer is already closed.