### PR TITLE
#1285 Fixes wrongly enforced minimum Spark version with the default

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/SparkCompatibility.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/SparkCompatibility.scala
@@ -27,6 +27,5 @@ import za.co.absa.commons.version.impl.SemVer20Impl.SemanticVersion
 
 object SparkCompatibility {
   val minSparkVersionIncluded: SemanticVersion = semver"2.4.2"
-  val minSparkHyperConformanceIncluded: SemanticVersion = semver"2.4.3"
   val maxSparkVersionExcluded: Option[SemanticVersion] = Some(semver"3.0.0")
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/version/SparkVersionGuard.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/version/SparkVersionGuard.scala
@@ -28,11 +28,6 @@ object SparkVersionGuard {
   def fromDefaultSparkCompatibilitySettings: SparkVersionGuard =
     SparkVersionGuard(SparkCompatibility.minSparkVersionIncluded, SparkCompatibility.maxSparkVersionExcluded)
 
-  /**
-   * Populates the guard with the HyperConformance requirement from [[za.co.absa.enceladus.common.SparkCompatibility]]
-   */
-  def fromHyperConformanceSparkCompatibilitySettings: SparkVersionGuard =
-    SparkVersionGuard(SparkCompatibility.minSparkHyperConformanceIncluded, SparkCompatibility.maxSparkVersionExcluded)
 }
 
 /**

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -99,9 +99,7 @@ object HyperConformance extends StreamTransformerFactory with HyperConformanceAt
   override def apply(conf: Configuration): StreamTransformer = {
     log.info("Building HyperConformance")
 
-    SparkVersionGuard
-      .fromHyperConformanceSparkCompatibilitySettings
-      .ensureSparkVersionCompatibility(SPARK_VERSION)
+    SparkVersionGuard.fromDefaultSparkCompatibilitySettings.ensureSparkVersionCompatibility(SPARK_VERSION)
 
     validateConfiguration(conf)
 


### PR DESCRIPTION
As pointed out [here](https://github.com/AbsaOSS/enceladus/pull/1297/files#r413867037), only the default Spark minimum of `2.4.2` will be enforced to Hyper Conformance