### PR TITLE
#1294 enceladus_record_id added to Standardization (& Conformance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,19 +235,6 @@ The list of additional options available for running Conformance:
 | --catalyst-workaround **true/false**       | Turns on (`true`) or off (`false`) workaround for Catalyst optimizer issue. It is `true` by default. Turn this off only is you encounter timing freeze issues when running Conformance. | 
 | --autoclean-std-folder **true/false**      | If `true`, the standardized folder will be cleaned automatically after successful execution of a Conformance job. |
 
-#### Notable config options
-Standardization and Conformance also feature number of config settings read from `application.conf` (Take a look at 
-[the template](spark-jobs/src/main/resources/application.conf.template)). These values can be overridden using the `-D` 
-property values as in:
-```shell script
-spark submit --conf "spark.driver.extraJavaOptions= -Dkey1=value1 -Dkey2=value2" ...
-```
-
-|            Config path                 |                           Description                                                                                                              |
-|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| enceladus.recordId.generation.strategy | If and how a record id generated to the `enceladus_record_id` column. Can be one of `none` (no column with IDs added), `uuid` (default - UUID-based values are generated), `stableHashId` (always-the-same Murmur3 Int hash is generated - for testing)     
-
-
 ## Plugins
 
 Standardization and Conformance support plugins that allow executing additional actions at certain times of the computation.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,19 @@ The list of additional options available for running Conformance:
 | --catalyst-workaround **true/false**       | Turns on (`true`) or off (`false`) workaround for Catalyst optimizer issue. It is `true` by default. Turn this off only is you encounter timing freeze issues when running Conformance. | 
 | --autoclean-std-folder **true/false**      | If `true`, the standardized folder will be cleaned automatically after successful execution of a Conformance job. |
 
+#### Notable config options
+Standardization and Conformance also feature number of config settings read from `application.conf` (Take a look at 
+[the template](spark-jobs/src/main/resources/application.conf.template)). These values can be overridden using the `-D` 
+property values as in:
+```shell script
+spark submit --conf "spark.driver.extraJavaOptions= -Dkey1=value1 -Dkey2=value2" ...
+```
+
+|            Config path                 |                           Description                                                                                                              |
+|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| enceladus.recordId.generation.strategy | If and how a record id generated to the `enceladus_record_id` column. Can be one of `none` (no column with IDs added), `uuid` (default - UUID-based values are generated), `stableHashId` (always-the-same Murmur3 Int hash is generated - for testing)     
+
+
 ## Plugins
 
 Standardization and Conformance support plugins that allow executing additional actions at certain times of the computation.

--- a/spark-jobs/src/main/resources/application.conf.template
+++ b/spark-jobs/src/main/resources/application.conf.template
@@ -17,6 +17,10 @@ enceladus.version=${project.version}
 # each can have multiple comma-separated hosts, these are used for fault-tolerance
 menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,host2:9000/menas"
 
+# 'enceladus_record_id' with an id can be added containing either true UUID, always the same UUIDs (pseudo) or the column
+# will not be added at all. Allowed values: "no", "pseudo", "true"
+enceladus.recordid.generation.strategy="true"
+
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"
 
 # Pattern to look for mapping table for the specified date

--- a/spark-jobs/src/main/resources/application.conf.template
+++ b/spark-jobs/src/main/resources/application.conf.template
@@ -19,7 +19,7 @@ menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,ho
 
 # 'enceladus_record_id' with an id can be added containing either true UUID, always the same UUIDs (pseudo) or the column
 # will not be added at all. Allowed values: "true", "pseudo", "no"
-enceladus.recordid.generation.strategy="true"
+enceladus.recordId.generation.strategy="true"
 
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"
 

--- a/spark-jobs/src/main/resources/application.conf.template
+++ b/spark-jobs/src/main/resources/application.conf.template
@@ -17,9 +17,9 @@ enceladus.version=${project.version}
 # each can have multiple comma-separated hosts, these are used for fault-tolerance
 menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,host2:9000/menas"
 
-# 'enceladus_record_id' with an id can be added containing either true UUID, always the same UUIDs (pseudo) or the column
-# will not be added at all. Allowed values: "true", "pseudo", "no"
-enceladus.recordId.generation.strategy="true"
+# 'enceladus_record_id' with an id can be added containing either true UUID, always the same IDs (row-hash-based) or the
+# column will not be added at all. Allowed values: "uuid", "stableHashId", "none"
+enceladus.recordId.generation.strategy="uuid"
 
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"
 

--- a/spark-jobs/src/main/resources/application.conf.template
+++ b/spark-jobs/src/main/resources/application.conf.template
@@ -18,7 +18,7 @@ enceladus.version=${project.version}
 menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,host2:9000/menas"
 
 # 'enceladus_record_id' with an id can be added containing either true UUID, always the same UUIDs (pseudo) or the column
-# will not be added at all. Allowed values: "no", "pseudo", "true"
+# will not be added at all. Allowed values: "true", "pseudo", "no"
 enceladus.recordid.generation.strategy="true"
 
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/Constants.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/Constants.scala
@@ -20,4 +20,5 @@ object Constants {
   final val InfoDateColumnString = s"${InfoDateColumn}_string"
   final val ReportDateFormat = "yyyy-MM-dd"
   final val InfoVersionColumn = "enceladus_info_version"
+  final val EnceladusRecordId = "enceladus_record_id"
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
@@ -17,9 +17,8 @@ package za.co.absa.enceladus.common
 
 import com.typesafe.config.{Config, ConfigException}
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.functions.{callUDF, col, hash}
+import org.apache.spark.sql.functions.{col, hash, expr}
 import org.slf4j.{Logger, LoggerFactory}
-import za.co.absa.enceladus.utils.udf.{UDFLibrary, UDFNames}
 
 object RecordIdGeneration {
 
@@ -53,10 +52,9 @@ object RecordIdGeneration {
    * @param origDf       dataframe to be possibly extended
    * @param idColumnName name of the id column to be used (usually [[Constants.EnceladusRecordId]])
    * @param strategy     decides if and what ids will be appended to the origDf
-   * @param udfLib       library that registred UDFs [[UDFNames.uuid]]
    * @return possibly updated `origDf`
    */
-  def addRecordIdColumnByStrategy(origDf: DataFrame, idColumnName: String, strategy: IdType)(implicit udfLib: UDFLibrary): DataFrame = {
+  def addRecordIdColumnByStrategy(origDf: DataFrame, idColumnName: String, strategy: IdType): DataFrame = {
     strategy match {
       case IdType.NoId =>
         log.info("Record id generation is off.")
@@ -68,7 +66,7 @@ object RecordIdGeneration {
 
       case IdType.TrueUuids =>
         log.info("Record id generation is on and true UUIDs will be added to output.")
-        origDf.withColumn(Constants.EnceladusRecordId, callUDF(UDFNames.uuid))
+        origDf.withColumn(Constants.EnceladusRecordId, expr("uuid()"))
     }
   }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
@@ -23,13 +23,17 @@ import za.co.absa.enceladus.utils.udf.{UDFLibrary, UDFNames}
 
 object RecordIdGeneration {
 
-  private val log: Logger = LoggerFactory.getLogger(this.getClass)
+  sealed trait UuidType
 
-  object UuidType extends Enumeration {
-    val TrueUuids, PseudoUuids, NoUuids = Value
+  object UuidType {
+    case object TrueUuids extends UuidType
+    case object PseudoUuids extends UuidType
+    case object NoUuids  extends UuidType
   }
 
-  def getRecordIdGenerationStrategyFromConfig(conf: Config): UuidType.Value = {
+  private val log: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def getRecordIdGenerationStrategyFromConfig(conf: Config): UuidType = {
     conf.getString("enceladus.recordid.generation.strategy") match {
       case "true" => UuidType.TrueUuids
       case "pseudo" => UuidType.PseudoUuids
@@ -49,7 +53,7 @@ object RecordIdGeneration {
    * @param udfLib
    * @return possibly updated `origDf`
    */
-  def addRecordIdColumnByStrategy(origDf: DataFrame, strategy: UuidType.Value)
+  def addRecordIdColumnByStrategy(origDf: DataFrame, strategy: UuidType)
                                  (implicit udfLib: UDFLibrary) : DataFrame = {
     strategy match {
       case UuidType.NoUuids => origDf

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
@@ -46,9 +46,9 @@ object RecordIdGeneration {
   }
 
   /**
-   * The supplied dataframe `origDf` is either kept as-is (`strategy` = [[IdType.NoId]]) or appended an ID column
-   * with an ID for each record. These ID true UUID (`strategy` = [[IdType.TrueUuids]]) or always the same ones for testing
-   * purposes (`strategy` = [[IdType.StableHashId]]
+   * The supplied dataframe `origDf` is either kept as-is (`strategy` = [[IdType.NoId]]) or has a column appended
+   * with an (presumably) unique value for each record. These are true UUIDs (`strategy` = [[IdType.TrueUuids]]) or
+   * values always the same for the same row, mainly for testing purposes (`strategy` = [[IdType.StableHashId]]
    *
    * @param origDf       dataframe to be possibly extended
    * @param idColumnName name of the id column to be used (usually [[Constants.EnceladusRecordId]])

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.common
+
+import com.typesafe.config.{Config, ConfigException}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.callUDF
+import org.slf4j.{Logger, LoggerFactory}
+import za.co.absa.enceladus.utils.udf.{UDFLibrary, UDFNames}
+
+object RecordIdGeneration {
+
+  private val log: Logger = LoggerFactory.getLogger(this.getClass)
+
+  object UuidType extends Enumeration {
+    val TrueUuids, PseudoUuids, NoUuids = Value
+  }
+
+  def getRecordIdGenerationStrategyFromConfig(conf: Config): UuidType.Value = {
+    conf.getString("enceladus.recordid.generation.strategy") match {
+      case "true" => UuidType.TrueUuids
+      case "pseudo" => UuidType.PseudoUuids
+      case "no" => UuidType.NoUuids
+      case other => throw new ConfigException.BadValue("enceladus.recordid.generation.strategy",
+        s"Invalid value $other was encountered for id generation strategy, use one of: true, pseudo, no.")
+    }
+  }
+
+  /**
+   * The supplied dataframe `origDf` is either kept as-is (`stragegy` = [[UuidType.NoUuids]]) or appended the a column named
+   * [[Constants.EnceladusRecordId]] with an ID for each record. These ID true UUID (`stragegy` = [[UuidType.TrueUuids]])
+   * or always the same ones for testing purposes (`stragegy` = [[UuidType.PseudoUuids]]
+   *
+   * @param origDf dataframe to be possibly extended
+   * @param strategy decides if and what ids will be appended to the origDf
+   * @param udfLib
+   * @return possibly updated `origDf`
+   */
+  def addRecordIdColumnByStrategy(origDf: DataFrame, strategy: UuidType.Value)
+                                 (implicit udfLib: UDFLibrary) : DataFrame = {
+    strategy match {
+      case UuidType.NoUuids => origDf
+      case other => {
+        val udfName = if (other == UuidType.TrueUuids) UDFNames.uuid else UDFNames.pseudoUuid
+        log.info(s"Adding UUIDs ($other) to the records.")
+        origDf.withColumn(Constants.EnceladusRecordId, callUDF(udfName))
+      }
+    }
+  }
+
+}

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
@@ -46,16 +46,17 @@ object RecordIdGeneration {
   }
 
   /**
-   * The supplied dataframe `origDf` is either kept as-is (`strategy` = [[IdType.NoId]]) or appended the a column named
-   * [[Constants.EnceladusRecordId]] with an ID for each record. These ID true UUID (`strategy` = [[IdType.TrueUuids]])
-   * or always the same ones for testing purposes (`strategy` = [[IdType.StableHashId]]
+   * The supplied dataframe `origDf` is either kept as-is (`strategy` = [[IdType.NoId]]) or appended an ID column
+   * with an ID for each record. These ID true UUID (`strategy` = [[IdType.TrueUuids]]) or always the same ones for testing
+   * purposes (`strategy` = [[IdType.StableHashId]]
    *
-   * @param origDf   dataframe to be possibly extended
-   * @param strategy decides if and what ids will be appended to the origDf
-   * @param udfLib   library that registred UDFs [[UDFNames.uuid]]
+   * @param origDf       dataframe to be possibly extended
+   * @param idColumnName name of the id column to be used (usually [[Constants.EnceladusRecordId]])
+   * @param strategy     decides if and what ids will be appended to the origDf
+   * @param udfLib       library that registred UDFs [[UDFNames.uuid]]
    * @return possibly updated `origDf`
    */
-  def addRecordIdColumnByStrategy(origDf: DataFrame, strategy: IdType)(implicit udfLib: UDFLibrary): DataFrame = {
+  def addRecordIdColumnByStrategy(origDf: DataFrame, idColumnName: String, strategy: IdType)(implicit udfLib: UDFLibrary): DataFrame = {
     strategy match {
       case IdType.NoId =>
         log.info("Record id generation is off.")

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
@@ -34,12 +34,14 @@ object RecordIdGeneration {
   private val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   def getRecordIdGenerationStrategyFromConfig(conf: Config): UuidType = {
-    conf.getString("enceladus.recordid.generation.strategy") match {
+    val strategyValue = conf.getString("enceladus.recordid.generation.strategy")
+
+    strategyValue.toLowerCase match {
       case "true" => UuidType.TrueUuids
       case "pseudo" => UuidType.PseudoUuids
       case "no" => UuidType.NoUuids
       case other => throw new ConfigException.BadValue("enceladus.recordid.generation.strategy",
-        s"Invalid value $other was encountered for id generation strategy, use one of: true, pseudo, no.")
+        s"Invalid value $strategyValue was encountered for id generation strategy, use one of: true, pseudo, no.")
     }
   }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/RecordIdGeneration.scala
@@ -17,7 +17,7 @@ package za.co.absa.enceladus.common
 
 import com.typesafe.config.{Config, ConfigException}
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.functions.callUDF
+import org.apache.spark.sql.functions.{callUDF, col, hash}
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.enceladus.utils.udf.{UDFLibrary, UDFNames}
 
@@ -28,42 +28,54 @@ object RecordIdGeneration {
   object UuidType {
     case object TrueUuids extends UuidType
     case object PseudoUuids extends UuidType
-    case object NoUuids  extends UuidType
+    case object NoUuids extends UuidType
   }
 
   private val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   def getRecordIdGenerationStrategyFromConfig(conf: Config): UuidType = {
-    val strategyValue = conf.getString("enceladus.recordid.generation.strategy")
+    val strategyValue = conf.getString("enceladus.recordId.generation.strategy")
 
     strategyValue.toLowerCase match {
       case "true" => UuidType.TrueUuids
       case "pseudo" => UuidType.PseudoUuids
       case "no" => UuidType.NoUuids
-      case other => throw new ConfigException.BadValue("enceladus.recordid.generation.strategy",
+      case _ => throw new ConfigException.BadValue("enceladus.recordId.generation.strategy",
         s"Invalid value $strategyValue was encountered for id generation strategy, use one of: true, pseudo, no.")
     }
   }
 
   /**
-   * The supplied dataframe `origDf` is either kept as-is (`stragegy` = [[UuidType.NoUuids]]) or appended the a column named
-   * [[Constants.EnceladusRecordId]] with an ID for each record. These ID true UUID (`stragegy` = [[UuidType.TrueUuids]])
-   * or always the same ones for testing purposes (`stragegy` = [[UuidType.PseudoUuids]]
+   * The supplied dataframe `origDf` is either kept as-is (`strategy` = [[UuidType.NoUuids]]) or appended the a column named
+   * [[Constants.EnceladusRecordId]] with an ID for each record. These ID true UUID (`strategy` = [[UuidType.TrueUuids]])
+   * or always the same ones for testing purposes (`strategy` = [[UuidType.PseudoUuids]]
    *
    * @param origDf dataframe to be possibly extended
    * @param strategy decides if and what ids will be appended to the origDf
-   * @param udfLib
+   * @param udfLib library that registred UDFs [[UDFNames.pseudoUuidFromHash]] and [[UDFNames.uuid]]
    * @return possibly updated `origDf`
    */
   def addRecordIdColumnByStrategy(origDf: DataFrame, strategy: UuidType)
-                                 (implicit udfLib: UDFLibrary) : DataFrame = {
+                                 (implicit udfLib: UDFLibrary): DataFrame = {
+
     strategy match {
-      case UuidType.NoUuids => origDf
-      case other => {
-        val udfName = if (other == UuidType.TrueUuids) UDFNames.uuid else UDFNames.pseudoUuid
-        log.info(s"Adding UUIDs ($other) to the records.")
-        origDf.withColumn(Constants.EnceladusRecordId, callUDF(udfName))
-      }
+      case UuidType.NoUuids =>
+        log.info("Record id generation is off.")
+        origDf
+      case UuidType.PseudoUuids =>
+        log.info("Record id generation is set to 'pseudo' - all runs will yield the same IDs.")
+
+        val hashColName = "enceladusTempHashForPseudoUuid"
+        def hashFromAllColumns(df: DataFrame) = df.withColumn(hashColName, hash(df.columns.map(col): _*))
+
+        import org.apache.spark.sql.functions.col
+        origDf.transform(hashFromAllColumns) // adds hash
+          .withColumn(Constants.EnceladusRecordId, callUDF(UDFNames.pseudoUuidFromHash, col(hashColName)))
+          .drop(hashColName) // hash is no longer needed (pseudo uuids were generated from it)
+
+      case UuidType.TrueUuids =>
+        log.info("Record id generation is on and true UUIDs will be added to output.")
+        origDf.withColumn(Constants.EnceladusRecordId, callUDF(UDFNames.uuid))
     }
   }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/package.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/package.scala
@@ -15,9 +15,6 @@
 
 package za.co.absa.enceladus
 
-import com.typesafe.config.{Config, ConfigException}
-import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter.UuidType
-
 package object common {
 
   /**
@@ -33,14 +30,4 @@ package object common {
   case class LongParameter(long: Long) extends RawFormatParameter
 
   case class DoubleParameter(double: Double) extends RawFormatParameter
-
-  def getRecordIdGenerationStrategy(conf: Config): UuidType.Value = {
-    conf.getString("enceladus.recordid.generation.strategy") match {
-      case "true" => UuidType.TrueUuids
-      case "pseudo" => UuidType.PseudoUuids
-      case "no" => UuidType.NoUuids
-      case other =>throw new ConfigException.BadValue("enceladus.recordid.generation.strategy",
-        s"Invalid value $other was encountered for id generation strategy, use one of: true, pseudo, no.")
-    }
-  }
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/package.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/package.scala
@@ -15,6 +15,9 @@
 
 package za.co.absa.enceladus
 
+import com.typesafe.config.{Config, ConfigException}
+import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter.UuidType
+
 package object common {
 
   /**
@@ -30,4 +33,14 @@ package object common {
   case class LongParameter(long: Long) extends RawFormatParameter
 
   case class DoubleParameter(double: Double) extends RawFormatParameter
+
+  def getRecordIdGenerationStrategy(conf: Config): UuidType.Value = {
+    conf.getString("enceladus.recordid.generation.strategy") match {
+      case "true" => UuidType.TrueUuids
+      case "pseudo" => UuidType.PseudoUuids
+      case "no" => UuidType.NoUuids
+      case other =>throw new ConfigException.BadValue("enceladus.recordid.generation.strategy",
+        s"Invalid value $other was encountered for id generation strategy, use one of: true, pseudo, no.")
+    }
+  }
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -252,7 +252,7 @@ object DynamicConformanceJob {
         if (SchemaUtils.fieldExists(Constants.EnceladusRecordId, conformedDF.schema)) {
           conformedDF // no new id regeneration
         } else {
-          RecordIdGeneration.addRecordIdColumnByStrategy(conformedDF, recordIdGenerationStrategy)(new UDFLibrary())
+          RecordIdGeneration.addRecordIdColumnByStrategy(conformedDF, Constants.EnceladusRecordId, recordIdGenerationStrategy)(new UDFLibrary())
         }
 
     }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -37,7 +37,6 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.MenasCredentials
 import za.co.absa.enceladus.dao.rest.{MenasConnectionStringParser, RestDaoFactory}
 import za.co.absa.enceladus.model.Dataset
-import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter.logger
 import za.co.absa.enceladus.utils.fs.FileSystemVersionUtils
 import za.co.absa.enceladus.utils.general.ProjectMetadataTools
 import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
@@ -46,8 +45,8 @@ import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 
-import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
 
 object DynamicConformanceJob {
   TimeZoneNormalizer.normalizeJVMTimeZone()
@@ -253,11 +252,6 @@ object DynamicConformanceJob {
         if (SchemaUtils.fieldExists(Constants.EnceladusRecordId, conformedDF.schema)) {
           conformedDF // no new id regenereration
         } else {
-          recordIdGenerationStrategy match {
-            case UuidType.NoUuids => log.info("Record id generation is off.")
-            case UuidType.PseudoUuids => log.info("Record id generation is set to 'pseudo' - all runs will yield the same IDs.")
-            case UuidType.TrueUuids => log.info("Record id generation is on and true UUIDs will be added to output.")
-          }
           RecordIdGeneration.addRecordIdColumnByStrategy(conformedDF, recordIdGenerationStrategy)(UDFLibrary())
         }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -228,7 +228,7 @@ object DynamicConformanceJob {
     performance
   }
 
-  private def conform(conformance: Dataset, inputData: sql.Dataset[Row], enableCF: Boolean, recordIdGenerationStrategy: UuidType)
+  private def conform(conformance: Dataset, inputData: sql.Dataset[Row], enableCF: Boolean, recordIdGenerationStrategy: IdType)
                      (implicit spark: SparkSession, cmd: ConfCmdConfig, fsUtils: FileSystemVersionUtils, dao: MenasDAO): DataFrame = {
     implicit val featureSwitcher: FeatureSwitches = FeatureSwitches()
       .setExperimentalMappingRuleEnabled(isExperimentalRuleEnabled())
@@ -250,9 +250,9 @@ object DynamicConformanceJob {
         throw e
       case Success(conformedDF) =>
         if (SchemaUtils.fieldExists(Constants.EnceladusRecordId, conformedDF.schema)) {
-          conformedDF // no new id regenereration
+          conformedDF // no new id regeneration
         } else {
-          RecordIdGeneration.addRecordIdColumnByStrategy(conformedDF, recordIdGenerationStrategy)(UDFLibrary())
+          RecordIdGeneration.addRecordIdColumnByStrategy(conformedDF, recordIdGenerationStrategy)(new UDFLibrary())
         }
 
     }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -42,6 +42,7 @@ import za.co.absa.enceladus.utils.fs.FileSystemVersionUtils
 import za.co.absa.enceladus.utils.general.ProjectMetadataTools
 import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.enceladus.utils.performance.{PerformanceMeasurer, PerformanceMetricTools}
+import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 
@@ -249,7 +250,7 @@ object DynamicConformanceJob {
         AtumImplicits.SparkSessionWrapper(spark).setControlMeasurementError("Conformance", e.getMessage, sw.toString)
         throw e
       case Success(conformedDF) =>
-        if (conformedDF.containsColumn(Constants.EnceladusRecordId)) {
+        if (SchemaUtils.fieldExists(Constants.EnceladusRecordId, conformedDF.schema)) {
           conformedDF // no new id regenereration
         } else {
           recordIdGenerationStrategy match {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -43,7 +43,6 @@ import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancem
 import za.co.absa.enceladus.utils.performance.{PerformanceMeasurer, PerformanceMetricTools}
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
-import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
@@ -252,7 +251,7 @@ object DynamicConformanceJob {
         if (SchemaUtils.fieldExists(Constants.EnceladusRecordId, conformedDF.schema)) {
           conformedDF // no new id regeneration
         } else {
-          RecordIdGeneration.addRecordIdColumnByStrategy(conformedDF, Constants.EnceladusRecordId, recordIdGenerationStrategy)(new UDFLibrary())
+          RecordIdGeneration.addRecordIdColumnByStrategy(conformedDF, Constants.EnceladusRecordId, recordIdGenerationStrategy)
         }
 
     }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
@@ -30,11 +30,12 @@ import za.co.absa.enceladus.conformance.interpreter.rules.custom.CustomConforman
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.{ConformanceRule, _}
 import za.co.absa.enceladus.model.{Dataset => ConfDataset}
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.explode.ExplosionContext
 import za.co.absa.enceladus.utils.fs.FileSystemVersionUtils
 import za.co.absa.enceladus.utils.general.Algorithms
 import za.co.absa.enceladus.utils.schema.SchemaUtils
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 object DynamicInterpreter {
   private val log = LoggerFactory.getLogger(this.getClass)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleInterpreter.scala
@@ -24,8 +24,8 @@ import za.co.absa.enceladus.conformance.ConfCmdConfig
 import za.co.absa.enceladus.conformance.interpreter.{ExplosionState, RuleValidators}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.{CastingConformanceRule, ConformanceRule}
-import za.co.absa.enceladus.utils.error.UDFNames
 import za.co.absa.enceladus.utils.schema.SchemaUtils
+import za.co.absa.enceladus.utils.udf.UDFNames
 import za.co.absa.spark.hats.transformations.NestedArrayTransformations
 
 case class CastingRuleInterpreter(rule: CastingConformanceRule) extends RuleInterpreter {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleInterpreter.scala
@@ -29,6 +29,7 @@ import za.co.absa.enceladus.utils.error._
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.transformations.ArrayTransformations
 import za.co.absa.enceladus.utils.transformations.ArrayTransformations.arrCol
+import za.co.absa.enceladus.utils.udf.UDFNames
 import za.co.absa.enceladus.utils.validation._
 
 import scala.util.Try

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleInterpreterGroupExplode.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/MappingRuleInterpreterGroupExplode.scala
@@ -28,6 +28,7 @@ import za.co.absa.enceladus.model.{MappingTable, Dataset => ConfDataset}
 import za.co.absa.enceladus.utils.error._
 import za.co.absa.enceladus.utils.explode.{ExplodeTools, ExplosionContext}
 import za.co.absa.enceladus.utils.transformations.ArrayTransformations.arrCol
+import za.co.absa.enceladus.utils.udf.UDFNames
 import za.co.absa.spark.hats.transformations.NestedArrayTransformations
 import za.co.absa.enceladus.utils.validation._
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleInterpreter.scala
@@ -23,9 +23,9 @@ import za.co.absa.enceladus.conformance.ConfCmdConfig
 import za.co.absa.enceladus.conformance.interpreter.{ExplosionState, RuleValidators}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.{ConformanceRule, NegationConformanceRule}
-import za.co.absa.enceladus.utils.error.UDFNames
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.types.GlobalDefaults
+import za.co.absa.enceladus.utils.udf.UDFNames
 import za.co.absa.enceladus.utils.validation.SchemaPathValidator
 import za.co.absa.spark.hats.transformations.NestedArrayTransformations
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -279,7 +279,7 @@ object StandardizationJob {
                                      cmd: StdCmdConfig,
                                      menasCredentials: MenasCredentials,
                                      pathCfg: PathCfg,
-                                     recordIdGenerationStrategy: UuidType.Value)
+                                     recordIdGenerationStrategy: UuidType)
                                     (implicit spark: SparkSession, udfLib: UDFLibrary, fsUtils: FileSystemVersionUtils): Unit = {
     //scalastyle:on parameter.number
     val rawDirSize: Long = fsUtils.getDirectorySize(pathCfg.inputPath)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -29,12 +29,13 @@ import za.co.absa.atum.core.Atum
 import za.co.absa.enceladus.common._
 import za.co.absa.enceladus.common.plugin.menas.MenasPlugin
 import za.co.absa.enceladus.common.version.SparkVersionGuard
+import za.co.absa.enceladus.common.RecordIdGeneration.UuidType
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.MenasCredentials
 import za.co.absa.enceladus.dao.rest.{MenasConnectionStringParser, RestDaoFactory}
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
-import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter._
+import za.co.absa.enceladus.common.RecordIdGeneration._
 import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
 import za.co.absa.enceladus.utils.fs.FileSystemVersionUtils
 import za.co.absa.enceladus.utils.general.ProjectMetadataTools
@@ -73,7 +74,7 @@ object StandardizationJob {
     val schema: StructType = dao.getSchema(dataset.schemaName, dataset.schemaVersion)
     val reportVersion = getReportVersion(cmd, dataset)
     val pathCfg = getPathCfg(cmd, dataset, reportVersion)
-    val recordIdGenerationStrategy = getRecordIdGenerationStrategy(conf)
+    val recordIdGenerationStrategy = getRecordIdGenerationStrategyFromConfig(conf)
 
     log.info(s"input path: ${pathCfg.inputPath}")
     log.info(s"output path: ${pathCfg.outputPath}")

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -29,7 +29,7 @@ import za.co.absa.atum.core.Atum
 import za.co.absa.enceladus.common._
 import za.co.absa.enceladus.common.plugin.menas.MenasPlugin
 import za.co.absa.enceladus.common.version.SparkVersionGuard
-import za.co.absa.enceladus.common.RecordIdGeneration.UuidType
+import za.co.absa.enceladus.common.RecordIdGeneration.IdType
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.MenasCredentials
 import za.co.absa.enceladus.dao.rest.{MenasConnectionStringParser, RestDaoFactory}
@@ -279,7 +279,7 @@ object StandardizationJob {
                                      cmd: StdCmdConfig,
                                      menasCredentials: MenasCredentials,
                                      pathCfg: PathCfg,
-                                     recordIdGenerationStrategy: UuidType)
+                                     recordIdGenerationStrategy: IdType)
                                     (implicit spark: SparkSession, udfLib: UDFLibrary, fsUtils: FileSystemVersionUtils): Unit = {
     //scalastyle:on parameter.number
     val rawDirSize: Long = fsUtils.getDirectorySize(pathCfg.inputPath)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
@@ -45,10 +45,10 @@ object StandardizationInterpreter {
    * @param failOnInputNotPerSchema    if true a discrepancy between expSchema and input data throws an exception
    *                                   if false the error is marked in the error column
    * @param recordIdGenerationStrategy Decides if true uuid, pseudo (always the same) is used for the
-   *                                   [[Constants.EnceladusRecordId]] or if the column is not added at all [[UuidType.NoUuids]] (default).
+   *                                   [[Constants.EnceladusRecordId]] or if the column is not added at all [[IdType.NoId]] (default).
    */
   def standardize(df: Dataset[Row], expSchema: StructType, inputType: String, failOnInputNotPerSchema: Boolean = false,
-                  recordIdGenerationStrategy: UuidType = UuidType.NoUuids)
+                  recordIdGenerationStrategy: IdType = IdType.NoId)
                  (implicit spark: SparkSession, udfLib: UDFLibrary): Dataset[Row] = {
 
     logger.info(s"Step 1: Schema validation")

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
@@ -69,7 +69,7 @@ object StandardizationInterpreter {
     logger.info(s"Step 3: Clean the final error column")
     val cleanedStd = cleanTheFinalErrorColumn(std)
 
-    val idedStd = RecordIdGeneration.addRecordIdColumnByStrategy(cleanedStd, recordIdGenerationStrategy)
+    val idedStd = RecordIdGeneration.addRecordIdColumnByStrategy(cleanedStd, Constants.EnceladusRecordId, recordIdGenerationStrategy)
 
     logger.info(s"Standardization process finished, returning to the application...")
     idedStd

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
@@ -48,7 +48,7 @@ object StandardizationInterpreter {
    *                                [[Constants.EnceladusRecordId]] or if the column is not added at all [[UuidType.NoUuids]] (default).
    */
   def standardize(df: Dataset[Row], expSchema: StructType, inputType: String, failOnInputNotPerSchema: Boolean = false,
-                  addUuids: UuidType.Value = UuidType.NoUuids)
+                  addUuids: UuidType = UuidType.NoUuids)
                  (implicit spark: SparkSession, udfLib: UDFLibrary): Dataset[Row] = {
 
     logger.info(s"Step 1: Schema validation")

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
@@ -40,15 +40,15 @@ object StandardizationInterpreter {
   /**
    * Perform the standardization of the dataframe given the expected schema
    *
-   * @param df                      Dataframe to be standardized
-   * @param expSchema               The schema for the df to be standardized into
-   * @param failOnInputNotPerSchema if true a discrepancy between expSchema and input data throws an exception
-   *                                if false the error is marked in the error column
-   * @param addUuids                Decides if true uuid, pseudo (always the same) is used for the
-   *                                [[Constants.EnceladusRecordId]] or if the column is not added at all [[UuidType.NoUuids]] (default).
+   * @param df                         Dataframe to be standardized
+   * @param expSchema                  The schema for the df to be standardized into
+   * @param failOnInputNotPerSchema    if true a discrepancy between expSchema and input data throws an exception
+   *                                   if false the error is marked in the error column
+   * @param recordIdGenerationStrategy Decides if true uuid, pseudo (always the same) is used for the
+   *                                   [[Constants.EnceladusRecordId]] or if the column is not added at all [[UuidType.NoUuids]] (default).
    */
   def standardize(df: Dataset[Row], expSchema: StructType, inputType: String, failOnInputNotPerSchema: Boolean = false,
-                  addUuids: UuidType = UuidType.NoUuids)
+                  recordIdGenerationStrategy: UuidType = UuidType.NoUuids)
                  (implicit spark: SparkSession, udfLib: UDFLibrary): Dataset[Row] = {
 
     logger.info(s"Step 1: Schema validation")
@@ -69,12 +69,7 @@ object StandardizationInterpreter {
     logger.info(s"Step 3: Clean the final error column")
     val cleanedStd = cleanTheFinalErrorColumn(std)
 
-    addUuids match {
-      case UuidType.NoUuids =>      logger.info("Step 4: Record id generation is off.")
-      case UuidType.PseudoUuids =>  logger.info("Step 4: Record id generation is set to 'pseudo' - all runs will yield the same IDs.")
-      case UuidType.TrueUuids =>    logger.info("Step 4: Record id generation is on and true UUIDs will be added to output.")
-    }
-    val idedStd = RecordIdGeneration.addRecordIdColumnByStrategy(cleanedStd, addUuids)
+    val idedStd = RecordIdGeneration.addRecordIdColumnByStrategy(cleanedStd, recordIdGenerationStrategy)
 
     logger.info(s"Standardization process finished, returning to the application...")
     idedStd

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter.scala
@@ -69,7 +69,11 @@ object StandardizationInterpreter {
     logger.info(s"Step 3: Clean the final error column")
     val cleanedStd = cleanTheFinalErrorColumn(std)
 
-    val idedStd = RecordIdGeneration.addRecordIdColumnByStrategy(cleanedStd, Constants.EnceladusRecordId, recordIdGenerationStrategy)
+    val idedStd = if (SchemaUtils.fieldExists(Constants.EnceladusRecordId, cleanedStd.schema)) {
+      cleanedStd // no new id regeneration
+    } else {
+      RecordIdGeneration.addRecordIdColumnByStrategy(cleanedStd, Constants.EnceladusRecordId, recordIdGenerationStrategy)
+    }
 
     logger.info(s"Standardization process finished, returning to the application...")
     idedStd

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/SparkXMLHack.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/SparkXMLHack.scala
@@ -18,9 +18,9 @@ package za.co.absa.enceladus.standardization.interpreter.stages
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
-import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.schema.SchemaUtils.appendPath
 import za.co.absa.enceladus.utils.transformations.ArrayTransformations.arrCol
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 /**
  * Hack around spark-xml bug: Null arrays produce array(null) instead of null.

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -22,23 +22,22 @@ import java.util.regex.Pattern
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions._
+import org.apache.spark.sql.functions.{lit, _}
 import org.apache.spark.sql.types._
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.enceladus.standardization.interpreter.dataTypes.ParseOutput
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary, UDFNames}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.schema.SchemaUtils.FieldWithSource
 import za.co.absa.enceladus.utils.time.DateTimePattern
 import za.co.absa.enceladus.utils.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.enceladus.utils.types.TypedStructField._
 import za.co.absa.enceladus.utils.types.{Defaults, TypedStructField}
-import za.co.absa.enceladus.utils.udf.UDFBuilder
+import za.co.absa.enceladus.utils.udf.{UDFBuilder, UDFLibrary, UDFNames}
 import za.co.absa.spark.hofs.transform
-import org.apache.spark.sql.functions.lit
+
 import scala.reflect.runtime.universe._
-import scala.util.Random
-import scala.util.Try
+import scala.util.{Random, Try}
 
 /**
   * Base trait for standardization function

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -22,7 +22,7 @@ import java.util.regex.Pattern
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.{lit, _}
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.enceladus.standardization.interpreter.dataTypes.ParseOutput

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/common/RecordIdGenerationSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/common/RecordIdGenerationSuite.scala
@@ -21,13 +21,11 @@ import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigValueF
 import org.scalatest.{FlatSpec, Matchers}
 import za.co.absa.enceladus.common.RecordIdGenerationSuite.{SomeData, SomeDataWithId}
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
-import za.co.absa.enceladus.utils.udf.UDFLibrary
 import RecordIdGeneration._
 import IdType._
 
 class RecordIdGenerationSuite extends FlatSpec with Matchers with SparkTestBase {
   import spark.implicits._
-  implicit val udfLib: UDFLibrary = new UDFLibrary()
 
   val data1 = Seq(
     SomeData("abc", 12),

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/common/RecordIdGenerationSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/common/RecordIdGenerationSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.common
+
+import java.util.UUID
+
+import org.scalatest.{FlatSpec, Matchers}
+import za.co.absa.enceladus.common.RecordIdGeneration.UuidType
+import za.co.absa.enceladus.common.RecordIdGenerationSuite.{SomeData, SomeDataWithId}
+import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.udf.UDFLibrary
+
+class RecordIdGenerationSuite extends FlatSpec with Matchers with SparkTestBase {
+  import spark.implicits._
+
+  val data1 = Seq(
+    SomeData("abc", 12),
+    SomeData("def", 34),
+    SomeData("xyz", 56)
+  )
+
+  "RecordIdColumnByStrategy" should s"do noop with ${UuidType.NoUuids}" in {
+    implicit val udfLib = UDFLibrary()
+
+    val df1 = spark.createDataFrame(data1)
+    val updatedDf1 = RecordIdGeneration.addRecordIdColumnByStrategy(df1, UuidType.NoUuids)
+
+    df1.collectAsList() shouldBe updatedDf1.collectAsList()
+  }
+
+  it should s"always yield the same IDs with ${UuidType.PseudoUuids}" in {
+
+    val df1 = spark.createDataFrame(data1)
+    val updatedDf1 = RecordIdGeneration.addRecordIdColumnByStrategy(df1, UuidType.PseudoUuids)(UDFLibrary())
+    val updatedDf2 = RecordIdGeneration.addRecordIdColumnByStrategy(df1, UuidType.PseudoUuids)(UDFLibrary())
+
+    updatedDf1.as[SomeDataWithId].collect() should contain theSameElementsInOrderAs updatedDf2.as[SomeDataWithId].collect()
+
+    Seq(updatedDf1, updatedDf2).foreach{ updatedDf =>
+      val updatedData = updatedDf.as[SomeDataWithId].collect()
+      updatedData.size shouldBe 3
+      updatedData.foreach(entry => UUID.fromString(entry.enceladus_record_id))
+    }
+  }
+
+  it should s"yield the different IDs with ${UuidType.TrueUuids}" in {
+
+    val df1 = spark.createDataFrame(data1)
+    val updatedDf1 = RecordIdGeneration.addRecordIdColumnByStrategy(df1, UuidType.TrueUuids)(UDFLibrary())
+    val updatedDf2 = RecordIdGeneration.addRecordIdColumnByStrategy(df1, UuidType.TrueUuids)(UDFLibrary())
+
+    updatedDf1.as[SomeDataWithId].collect() shouldNot contain theSameElementsAs updatedDf2.as[SomeDataWithId].collect()
+
+    Seq(updatedDf1, updatedDf2).foreach{ updatedDf =>
+      val updatedData = updatedDf.as[SomeDataWithId].collect()
+      updatedData.size shouldBe 3
+      updatedData.foreach(entry => UUID.fromString(entry.enceladus_record_id))
+    }
+  }
+
+}
+
+object RecordIdGenerationSuite {
+
+  case class SomeData(value1: String, value2: Int)
+  case class SomeDataWithId(value1: String, value2: Int, enceladus_record_id: String)
+
+}

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/common/RecordIdGenerationSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/common/RecordIdGenerationSuite.scala
@@ -37,7 +37,7 @@ class RecordIdGenerationSuite extends FlatSpec with Matchers with SparkTestBase 
 
   "RecordIdColumnByStrategy" should s"do noop with $NoId" in {
     val df1 = spark.createDataFrame(data1)
-    val updatedDf1 = addRecordIdColumnByStrategy(df1, NoId)
+    val updatedDf1 = addRecordIdColumnByStrategy(df1, "idColumnWontBeUsed", NoId)
 
     df1.collectAsList() shouldBe updatedDf1.collectAsList()
   }
@@ -45,8 +45,8 @@ class RecordIdGenerationSuite extends FlatSpec with Matchers with SparkTestBase 
   it should s"always yield the same IDs with ${StableHashId}" in {
 
     val df1 = spark.createDataFrame(data1)
-    val updatedDf1 = addRecordIdColumnByStrategy(df1, StableHashId)
-    val updatedDf2 = addRecordIdColumnByStrategy(df1, StableHashId)
+    val updatedDf1 = addRecordIdColumnByStrategy(df1, "stableId", StableHashId)
+    val updatedDf2 = addRecordIdColumnByStrategy(df1, "stableId", StableHashId)
 
     updatedDf1.as[SomeDataWithId].collect() should contain theSameElementsInOrderAs updatedDf2.as[SomeDataWithId].collect()
 
@@ -59,8 +59,8 @@ class RecordIdGenerationSuite extends FlatSpec with Matchers with SparkTestBase 
   it should s"yield the different IDs with $TrueUuids" in {
 
     val df1 = spark.createDataFrame(data1)
-    val updatedDf1 = addRecordIdColumnByStrategy(df1, TrueUuids)
-    val updatedDf2 = addRecordIdColumnByStrategy(df1, TrueUuids)
+    val updatedDf1 = addRecordIdColumnByStrategy(df1, "trueId", TrueUuids)
+    val updatedDf2 = addRecordIdColumnByStrategy(df1, "trueId", TrueUuids)
 
     updatedDf1.as[SomeDataWithId].collect() shouldNot contain theSameElementsAs updatedDf2.as[SomeDataWithId].collect()
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCsvSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCsvSuite.scala
@@ -242,7 +242,7 @@ class StandardizationCsvSuite extends fixture.FunSuite with SparkTestBase with T
     assert(actual == expected)
   }
 
-  test("Test standardizing a CSV file with enabled check of maxColumns limit, permissive read mode explicit, no corrupt record") { tmpFileName => //scalastyle:ignore line.size.limit readability
+  test("Test standardizing a CSV file with enabled check of maxColumns limit, permissive read mode explicit, no corrupt record") { tmpFileName =>
     // The delimiter used is '¡'
     // A quote character should be any character that cannot be encountered in the CSV
     // For this case it is '$'

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCsvSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCsvSuite.scala
@@ -242,7 +242,7 @@ class StandardizationCsvSuite extends fixture.FunSuite with SparkTestBase with T
     assert(actual == expected)
   }
 
-  test("Test standardizing a CSV file with enabled check of maxColumns limit, permissive read mode explicit, no corrupt record") { tmpFileName =>
+  test("Test standardizing a CSV file with enabled check of maxColumns limit, permissive read mode explicit, no corrupt record") { tmpFileName => //scalastyle:ignore line.size.limit readability
     // The delimiter used is '¡'
     // A quote character should be any character that cannot be encountered in the CSV
     // For this case it is '$'

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationJsonSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationJsonSuite.scala
@@ -22,10 +22,10 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
 import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
-import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.fs.FileReader
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationJsonSuite extends FunSuite with SparkTestBase with MockitoSugar{
   private implicit val udfLibrary:UDFLibrary = UDFLibrary()

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationJsonSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationJsonSuite.scala
@@ -28,7 +28,7 @@ import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancem
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationJsonSuite extends FunSuite with SparkTestBase with MockitoSugar{
-  private implicit val udfLibrary:UDFLibrary = UDFLibrary()
+  private implicit val udfLibrary:UDFLibrary = new UDFLibrary()
 
   test("Reading data from JSON input, also such that don't adhere to desired schema") {
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
@@ -18,7 +18,7 @@ package za.co.absa.enceladus.standardization
 import java.util.UUID
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types.{StructField, _}
+import org.apache.spark.sql.types._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Outcome, fixture}
 import za.co.absa.enceladus.common.RecordIdGeneration.IdType
@@ -415,7 +415,7 @@ class StandardizationParquetSuite extends fixture.FunSuite with SparkTestBase wi
         |""".stripMargin.replace("\r\n", "\n")
 
     val (cmd, sourceDF) = getTestDataFrame(tmpFileName, args)
-    import org.apache.spark.sql.functions.{concat, lit, col}
+    import org.apache.spark.sql.functions.{concat, lit}
     val sourceDfWithExistingIds = sourceDF.withColumn("enceladus_record_id", concat(lit("id"), 'id))
     sourceDfWithExistingIds.show(false)
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
@@ -387,7 +387,6 @@ class StandardizationParquetSuite extends fixture.FunSuite with SparkTestBase wi
       StructField("struct", StructType(Seq(StructField("bar", BooleanType))), nullable = false)
     )
     val schema = StructType(seq)
-    // True UUid will always yield the same ids
     val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, recordIdGenerationStrategy = IdType.TrueUuids)
 
     // same except for the record id

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
@@ -21,11 +21,11 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Outcome, fixture}
+import za.co.absa.enceladus.common.RecordIdGeneration.UuidType
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.fixtures.TempFileFixture
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
-import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter.UuidType
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserException
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
@@ -359,7 +359,7 @@ class StandardizationParquetSuite extends fixture.FunSuite with SparkTestBase wi
     )
     val schema = StructType(seq)
     // PseudoUuids will always yield the same ids
-    val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, UuidType.PseudoUuids)
+    val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, recordIdGenerationStrategy = UuidType.PseudoUuids)
 
     val actual = destDF.dataAsString(truncate = false)
     assert(actual == expected)
@@ -388,7 +388,7 @@ class StandardizationParquetSuite extends fixture.FunSuite with SparkTestBase wi
     )
     val schema = StructType(seq)
     // PseudoUuids will always yield the same ids
-    val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, UuidType.TrueUuids)
+    val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, recordIdGenerationStrategy = UuidType.TrueUuids)
 
     // same except for the record id
     val actual = destDF.drop("enceladus_record_id").dataAsString(truncate = false)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
@@ -345,8 +345,8 @@ class StandardizationParquetSuite extends fixture.FunSuite with SparkTestBase wi
       """+---+-------+-------+------+------------------------------------+
         ||id |letters|struct |errCol|enceladus_record_id                 |
         |+---+-------+-------+------+------------------------------------+
-        ||1  |[A, B] |[false]|[]    |4d003feb-bc72-3ded-abf4-5215912b1db3|
-        ||2  |[C]    |[true] |[]    |f57fa92e-1037-3411-8c49-012b422e9bc2|
+        ||1  |[A, B] |[false]|[]    |4fb44dab-0e1b-3f7e-8d93-a53862cd85c5|
+        ||2  |[C]    |[true] |[]    |0f25bab5-3150-32eb-a2fd-09ad3d462f90|
         |+---+-------+-------+------+------------------------------------+
         |
         |""".stripMargin.replace("\r\n", "\n")
@@ -359,7 +359,7 @@ class StandardizationParquetSuite extends fixture.FunSuite with SparkTestBase wi
     )
     val schema = StructType(seq)
     // PseudoUuids will always yield the same ids
-    val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, addUuids = UuidType.PseudoUuids)
+    val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, UuidType.PseudoUuids)
 
     val actual = destDF.dataAsString(truncate = false)
     assert(actual == expected)
@@ -388,7 +388,7 @@ class StandardizationParquetSuite extends fixture.FunSuite with SparkTestBase wi
     )
     val schema = StructType(seq)
     // PseudoUuids will always yield the same ids
-    val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, addUuids = UuidType.TrueUuids)
+    val destDF = StandardizationInterpreter.standardize(sourceDF, schema, cmd.rawFormat, UuidType.TrueUuids)
 
     // same except for the record id
     val actual = destDF.drop("enceladus_record_id").dataAsString(truncate = false)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationRerunSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationRerunSuite.scala
@@ -26,8 +26,9 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.fixtures.TempFileFixture
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.ValidationException
 
 class StandardizationRerunSuite extends fixture.FunSuite with SparkTestBase with TempFileFixture with MockitoSugar {

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/CounterPartySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/CounterPartySuite.scala
@@ -17,8 +17,9 @@ package za.co.absa.enceladus.standardization.interpreter
 
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 case class Root(ConformedParty: Party, errCol: Seq[ErrorMessage] = Seq.empty)
 case class Party(key: Integer, clientKeys1: Seq[String], clientKeys2: Seq[String])

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/DateTimeSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/DateTimeSuite.scala
@@ -22,8 +22,9 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker
 import za.co.absa.enceladus.standardization.samples.TestSamples
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.field.FieldValidationFailure
 import za.co.absa.enceladus.utils.validation.{SchemaValidator, ValidationError, ValidationException, ValidationWarning}
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/DateTimeSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/DateTimeSuite.scala
@@ -43,7 +43,7 @@ class DateTimeSuite extends FunSuite with SparkTestBase with LoggerTestBase{
     .getLines().mkString("\n"))
     .asInstanceOf[StructType]
 
-  private implicit val udfLib: UDFLibrary = UDFLibrary()
+  private implicit val udfLib: UDFLibrary = new UDFLibrary()
 
   test("Validation should return critical errors") {
     logger.debug(data.schema.prettyJson)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/SampleDataSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/SampleDataSuite.scala
@@ -30,7 +30,7 @@ class SampleDataSuite extends FunSuite with SparkTestBase with LoggerTestBase {
 
     logDataFrameContent(data)
 
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
 
     val sourceFile = FileReader.readFileAsString("src/test/resources/data/data1Schema.json")
     val schema = DataType.fromJson(sourceFile).asInstanceOf[StructType]

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/SampleDataSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/SampleDataSuite.scala
@@ -18,9 +18,9 @@ package za.co.absa.enceladus.standardization.interpreter
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.standardization.samples.{StdEmployee, TestSamples}
-import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.fs.FileReader
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class SampleDataSuite extends FunSuite with SparkTestBase with LoggerTestBase {
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -18,10 +18,11 @@ package za.co.absa.enceladus.standardization.interpreter
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreterSuite._
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.fs.FileReader
 import za.co.absa.enceladus.utils.general.JsonUtils
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationInterpreterSuite  extends FunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
@@ -18,11 +18,11 @@ package za.co.absa.enceladus.standardization.interpreter
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.common.error.ErrorMessageFactory
-import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.general.JsonUtils
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.enceladus.utils.schema.MetadataKeys
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.ValidationException
 
 class StandardizationInterpreter_ArraySuite extends FunSuite with SparkTestBase with LoggerTestBase {

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -19,8 +19,9 @@ import java.sql.Date
 
 import org.apache.spark.sql.types.{DateType, MetadataBuilder, StructField, StructType}
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationInterpreter_DateSuite extends FunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
@@ -20,9 +20,10 @@ import java.util.Locale
 
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationInterpreter_DecimalSuite extends FunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -17,9 +17,10 @@ package za.co.absa.enceladus.standardization.interpreter
 
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationInterpreter_FractionalSuite extends FunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
@@ -20,9 +20,10 @@ import java.util.Locale
 
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationInterpreter_IntegralSuite extends FunSuite with SparkTestBase with LoggerTestBase{
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -19,8 +19,9 @@ import java.sql.Timestamp
 
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType, TimestampType}
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationInterpreter_TimestampSuite extends FunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StdInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StdInterpreterSuite.scala
@@ -20,9 +20,9 @@ import java.sql.{Date, Timestamp}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
-import za.co.absa.enceladus.utils.udf
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 case class ErrorPreserve(a: String, b: String, errCol: List[ErrorMessage])
 case class ErrorPreserveStd(a: String, b: Int, errCol: List[ErrorMessage])
@@ -74,7 +74,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test("Non-null errors produced for non-nullable attribute in a struct") {
     import spark.implicits._
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
 
     val orig = spark.createDataFrame(Seq(
       MyWrapper(MyHolder(null)),
@@ -95,7 +95,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Existing error messages should be preserved") {
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
     import spark.implicits._
 
     val df = spark.createDataFrame(Array(
@@ -118,7 +118,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Standardize Test") {
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
 
     val sourceDF = spark.createDataFrame(
       Array(
@@ -141,7 +141,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Standardize Test (JSON source)") {
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
     val sourceDF = spark.read.json("src/test/resources/data/standardizeJsonSrc.json")
 
     val expectedSchema = stdExpectedSchema.add(
@@ -161,7 +161,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   case class RootRecordCC(id: Long, name: Option[String], orders: Option[Array[OrderCC]])
 
   test("Test standardization of non-nullable field of a contains null array") {
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
 
     val schema = StructType(
       Array(
@@ -190,7 +190,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields with default value and pattern")
   {
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
 
     val schema = StructType(
       Seq(
@@ -217,7 +217,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields with default value, without pattern")
   {
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
 
     val schema = StructType(
       Seq(
@@ -244,7 +244,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields without default value, with pattern")
   {
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
 
     val schema = StructType(
       Seq(
@@ -271,7 +271,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields without default value, without pattern")
   {
-    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
+    implicit val udfLib: UDFLibrary = UDFLibrary()
 
     val schema = StructType(
       Seq(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StdInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StdInterpreterSuite.scala
@@ -74,7 +74,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test("Non-null errors produced for non-nullable attribute in a struct") {
     import spark.implicits._
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
 
     val orig = spark.createDataFrame(Seq(
       MyWrapper(MyHolder(null)),
@@ -95,7 +95,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Existing error messages should be preserved") {
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
     import spark.implicits._
 
     val df = spark.createDataFrame(Array(
@@ -118,7 +118,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Standardize Test") {
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
 
     val sourceDF = spark.createDataFrame(
       Array(
@@ -141,7 +141,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Standardize Test (JSON source)") {
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
     val sourceDF = spark.read.json("src/test/resources/data/standardizeJsonSrc.json")
 
     val expectedSchema = stdExpectedSchema.add(
@@ -161,7 +161,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   case class RootRecordCC(id: Long, name: Option[String], orders: Option[Array[OrderCC]])
 
   test("Test standardization of non-nullable field of a contains null array") {
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
 
     val schema = StructType(
       Array(
@@ -190,7 +190,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields with default value and pattern")
   {
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
 
     val schema = StructType(
       Seq(
@@ -217,7 +217,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields with default value, without pattern")
   {
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
 
     val schema = StructType(
       Seq(
@@ -244,7 +244,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields without default value, with pattern")
   {
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
 
     val schema = StructType(
       Seq(
@@ -271,7 +271,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields without default value, without pattern")
   {
-    implicit val udfLib: UDFLibrary = UDFLibrary()
+    implicit val udfLib: UDFLibrary = new UDFLibrary()
 
     val schema = StructType(
       Seq(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StdInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StdInterpreterSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf
 
 case class ErrorPreserve(a: String, b: String, errCol: List[ErrorMessage])
 case class ErrorPreserveStd(a: String, b: Int, errCol: List[ErrorMessage])
@@ -73,7 +74,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test("Non-null errors produced for non-nullable attribute in a struct") {
     import spark.implicits._
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
 
     val orig = spark.createDataFrame(Seq(
       MyWrapper(MyHolder(null)),
@@ -94,7 +95,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Existing error messages should be preserved") {
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
     import spark.implicits._
 
     val df = spark.createDataFrame(Array(
@@ -117,7 +118,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Standardize Test") {
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
 
     val sourceDF = spark.createDataFrame(
       Array(
@@ -140,7 +141,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   }
 
   test("Standardize Test (JSON source)") {
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
     val sourceDF = spark.read.json("src/test/resources/data/standardizeJsonSrc.json")
 
     val expectedSchema = stdExpectedSchema.add(
@@ -160,7 +161,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
   case class RootRecordCC(id: Long, name: Option[String], orders: Option[Array[OrderCC]])
 
   test("Test standardization of non-nullable field of a contains null array") {
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
 
     val schema = StructType(
       Array(
@@ -189,7 +190,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields with default value and pattern")
   {
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
 
     val schema = StructType(
       Seq(
@@ -216,7 +217,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields with default value, without pattern")
   {
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
 
     val schema = StructType(
       Seq(
@@ -243,7 +244,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields without default value, with pattern")
   {
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
 
     val schema = StructType(
       Seq(
@@ -270,7 +271,7 @@ class StdInterpreterSuite extends FunSuite with SparkTestBase with LoggerTestBas
 
   test ("Test standardization of Date and Timestamp fields without default value, without pattern")
   {
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: udf.UDFLibrary = new udf.UDFLibrary
 
     val schema = StructType(
       Seq(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuite.scala
@@ -17,18 +17,17 @@ package za.co.absa.enceladus.standardization.interpreter.stages
 
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
-import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 import za.co.absa.enceladus.utils.types.TypedStructField.TypedStructFieldTagged
 import za.co.absa.enceladus.utils.types.parsers.NumericParser
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
-import za.co.absa.enceladus.utils.udf.UDFResult
+import za.co.absa.enceladus.utils.udf.{UDFLibrary, UDFResult}
 
 import scala.util.Success
 
 class TypeParserSuite extends FunSuite with SparkTestBase {
 
-  private implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+  private implicit val udfLib: UDFLibrary = new UDFLibrary
   private implicit val defaults: Defaults = GlobalDefaults
 
   test("Test standardize with sourcecolumn metadata") {

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuiteTemplate.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuiteTemplate.scala
@@ -23,14 +23,14 @@ import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.standardization.interpreter.dataTypes.ParseOutput
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate._
-import za.co.absa.enceladus.utils.error.UDFLibrary
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 import za.co.absa.enceladus.utils.time.DateTimePattern
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 trait TypeParserSuiteTemplate extends FunSuite with SparkTestBase {
 
-  private implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+  private implicit val udfLib: UDFLibrary = new UDFLibrary
   private implicit val defaults: Defaults = GlobalDefaults
 
   protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
@@ -68,6 +68,13 @@ object DataFrameImplicits {
       SparkUtils.withColumnIfDoesNotExist(df, colName, col)
     }
 
+    /**
+     * Check if column exist by name, ignores case
+     * @param colName column to be checked
+     * @return true if found, false otherwise
+     */
+    def containsColumn(colName: String): Boolean = SparkUtils.containsColumn(df, colName)
+
   }
 
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
@@ -18,7 +18,7 @@ package za.co.absa.enceladus.utils.implicits
 import java.io.ByteArrayOutputStream
 
 import org.apache.spark.sql.{Column, DataFrame}
-import za.co.absa.enceladus.utils.schema.SparkUtils
+import za.co.absa.enceladus.utils.schema.{SchemaUtils, SparkUtils}
 
 object DataFrameImplicits {
   implicit class DataFrameEnhancements(val df: DataFrame) {
@@ -73,7 +73,7 @@ object DataFrameImplicits {
      * @param colName column to be checked
      * @return true if found, false otherwise
      */
-    def containsColumn(colName: String): Boolean = SparkUtils.containsColumn(df, colName)
+    def containsColumn(colName: String): Boolean = SchemaUtils.fieldExists(colName, df.schema)
 
   }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
@@ -68,13 +68,6 @@ object DataFrameImplicits {
       SparkUtils.withColumnIfDoesNotExist(df, colName, col)
     }
 
-    /**
-     * Check if column exist by name, ignores case
-     * @param colName column to be checked
-     * @return true if found, false otherwise
-     */
-    def containsColumn(colName: String): Boolean = SchemaUtils.fieldExists(colName, df.schema)
-
   }
 
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SparkUtils.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SparkUtils.scala
@@ -67,8 +67,6 @@ object SparkUtils {
     }
   }
 
-  def containsColumn(df: DataFrame, colName: String): Boolean = df.schema.exists(field => field.name.equalsIgnoreCase(colName))
-
   /**
     * Overwrites a column with a value provided by an expression.
     * If the value in the column does not match the one provided by the expression, an error will be

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SparkUtils.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SparkUtils.scala
@@ -67,6 +67,8 @@ object SparkUtils {
     }
   }
 
+  def containsColumn(df: DataFrame, colName: String): Boolean = df.schema.exists(field => field.name.equalsIgnoreCase(colName))
+
   /**
     * Overwrites a column with a value provided by an expression.
     * If the value in the column does not match the one provided by the expression, an error will be

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SparkUtils.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/SparkUtils.scala
@@ -19,7 +19,8 @@ import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
-import za.co.absa.enceladus.utils.error.{ErrorMessage, UDFLibrary}
+import za.co.absa.enceladus.utils.error.ErrorMessage
+import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.spark.hats.transformations.NestedArrayTransformations
 
 
@@ -78,7 +79,7 @@ object SparkUtils {
     */
   private def overwriteWithErrorColumn(df: DataFrame, colName: String, colExpr: Column): DataFrame = {
     implicit val spark: SparkSession = df.sparkSession
-    implicit val udfLib: UDFLibrary = new za.co.absa.enceladus.utils.error.UDFLibrary
+    implicit val udfLib: UDFLibrary = new UDFLibrary
 
 
     val tmpColumn = SchemaUtils.getUniqueName("tmpColumn", Some(df.schema))

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
@@ -67,8 +67,6 @@ class UDFLibrary()(implicit val spark: SparkSession) {
   spark.udf.register(errorColumnAppend,
                      UDFLibrary.errorColumnAppend,
                      ArrayType.apply(ErrorMessage.errorColSchema, containsNull = false))
-
-  spark.udf.register(uuid, { () => UUID.randomUUID().toString })
 }
 
 object UDFLibrary {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
@@ -73,7 +73,15 @@ case class UDFLibrary()(implicit val spark: SparkSession) {
 
   spark.udf.register(uuid, { () => UUID.randomUUID().toString })
 
-  spark.udf.register(pseudoUuid, { () => UDFLibrary.pseudoUuid.toString })
+  private val pseudoRandom = new Random(seed = 22L) // scalastyle:ignore magic.number
+
+  def pseudoUuidFn: UUID = {
+    val arr = new Array[Byte](10) // scalastyle:ignore magic.number
+    pseudoRandom.nextBytes(arr)
+    UUID.nameUUIDFromBytes(arr)
+  }
+
+  spark.udf.register(pseudoUuid, { () => pseudoUuidFn.toString })
 
 }
 
@@ -95,11 +103,5 @@ object UDFLibrary {
     }
   }
 
-  private val pseudoRandom = new Random(seed = 22L) // scalastyle:ignore magic.number
 
-  def pseudoUuid: UUID = {
-    val arr = new Array[Byte](10) // scalastyle:ignore magic.number
-    pseudoRandom.nextBytes(arr)
-    UUID.nameUUIDFromBytes(arr)
-  }
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
@@ -13,13 +13,18 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.utils.error
+package za.co.absa.enceladus.utils.udf
+
+import java.util.UUID
 
 import org.apache.spark.sql.api.java._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SparkSession}
+import za.co.absa.enceladus.utils.error.{ErrorMessage, Mapping}
+import za.co.absa.enceladus.utils.udf.UDFNames._
+
 import scala.collection.mutable
-import UDFNames._
+import scala.util.Random
 
 
 case class UDFLibrary()(implicit val spark: SparkSession) {
@@ -28,9 +33,9 @@ case class UDFLibrary()(implicit val spark: SparkSession) {
     ErrorMessage.stdCastErr(errCol, rawValue)
   })
 
-  spark.udf.register(stdNullErr, { errCol: String => ErrorMessage.stdNullErr(errCol)})
+  spark.udf.register(stdNullErr, { errCol: String => ErrorMessage.stdNullErr(errCol) })
 
-  spark.udf.register(stdSchemaErr, { errRow: String => ErrorMessage.stdSchemaError(errRow)})
+  spark.udf.register(stdSchemaErr, { errRow: String => ErrorMessage.stdSchemaError(errRow) })
 
   spark.udf.register(confMappingErr, { (errCol: String, rawValues: Seq[String], mappings: Seq[Mapping]) =>
     ErrorMessage.confMappingErr(errCol, rawValues, mappings)
@@ -64,6 +69,12 @@ case class UDFLibrary()(implicit val spark: SparkSession) {
   spark.udf.register(errorColumnAppend,
                      UDFLibrary.errorColumnAppend,
                      ArrayType.apply(ErrorMessage.errorColSchema, containsNull = false))
+
+
+  spark.udf.register(uuid, { () => UUID.randomUUID().toString })
+
+  spark.udf.register(pseudoUuid, { () => UDFLibrary.pseudoUuid.toString })
+
 }
 
 object UDFLibrary {
@@ -79,8 +90,16 @@ object UDFLibrary {
   }
 
   private val errorColumnAppend = new UDF2[Seq[Row], Row, Seq[Row]] {
-    override def call(t1: Seq[Row], t2: Row) : Seq[Row] = {
+    override def call(t1: Seq[Row], t2: Row): Seq[Row] = {
       t1 :+ t2
     }
+  }
+
+  private val pseudoRandom = new Random(seed = 22L) // scalastyle:ignore magic.number
+
+  def pseudoUuid: UUID = {
+    val arr = new Array[Byte](10) // scalastyle:ignore magic.number
+    pseudoRandom.nextBytes(arr)
+    UUID.nameUUIDFromBytes(arr)
   }
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
@@ -25,7 +25,7 @@ import za.co.absa.enceladus.utils.udf.UDFNames._
 
 import scala.collection.mutable
 
-case class UDFLibrary()(implicit val spark: SparkSession) {
+class UDFLibrary()(implicit val spark: SparkSession) {
 
   spark.udf.register(stdCastErr, { (errCol: String, rawValue: String) =>
     ErrorMessage.stdCastErr(errCol, rawValue)
@@ -69,8 +69,6 @@ case class UDFLibrary()(implicit val spark: SparkSession) {
                      ArrayType.apply(ErrorMessage.errorColSchema, containsNull = false))
 
   spark.udf.register(uuid, { () => UUID.randomUUID().toString })
-
-  spark.udf.register(pseudoUuidFromHash, { (hash: String) => UDFLibrary.pseudoUuidFromHashFn(hash).toString })
 }
 
 object UDFLibrary {
@@ -89,9 +87,5 @@ object UDFLibrary {
     override def call(t1: Seq[Row], t2: Row): Seq[Row] = {
       t1 :+ t2
     }
-  }
-
-  private def pseudoUuidFromHashFn(hash: String): UUID = {
-    UUID.nameUUIDFromBytes(hash.getBytes())
   }
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
@@ -24,8 +24,6 @@ import za.co.absa.enceladus.utils.error.{ErrorMessage, Mapping}
 import za.co.absa.enceladus.utils.udf.UDFNames._
 
 import scala.collection.mutable
-import scala.util.Random
-
 
 case class UDFLibrary()(implicit val spark: SparkSession) {
 
@@ -70,19 +68,9 @@ case class UDFLibrary()(implicit val spark: SparkSession) {
                      UDFLibrary.errorColumnAppend,
                      ArrayType.apply(ErrorMessage.errorColSchema, containsNull = false))
 
-
   spark.udf.register(uuid, { () => UUID.randomUUID().toString })
 
-  private val pseudoRandom = new Random(seed = 22L) // scalastyle:ignore magic.number
-
-  def pseudoUuidFn: UUID = {
-    val arr = new Array[Byte](10) // scalastyle:ignore magic.number
-    pseudoRandom.nextBytes(arr)
-    UUID.nameUUIDFromBytes(arr)
-  }
-
-  spark.udf.register(pseudoUuid, { () => pseudoUuidFn.toString })
-
+  spark.udf.register(pseudoUuidFromHash, { (hash: String) => UDFLibrary.pseudoUuidFromHashFn(hash).toString })
 }
 
 object UDFLibrary {
@@ -103,5 +91,7 @@ object UDFLibrary {
     }
   }
 
-
+  private def pseudoUuidFromHashFn(hash: String): UUID = {
+    UUID.nameUUIDFromBytes(hash.getBytes())
+  }
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
@@ -30,5 +30,4 @@ object UDFNames {
   final val errorColumnAppend = "errorColumnAppend"
 
   final val uuid = "enceladusUuid"
-  final val pseudoUuidFromHash = "enceladusPseudoUuidFromHash"
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
@@ -28,6 +28,4 @@ object UDFNames {
   final val arrayDistinctErrors = "arrayDistinctErrors"
   final val cleanErrCol = "cleanErrCol"
   final val errorColumnAppend = "errorColumnAppend"
-
-  final val uuid = "enceladusUuid"
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
@@ -29,6 +29,6 @@ object UDFNames {
   final val cleanErrCol = "cleanErrCol"
   final val errorColumnAppend = "errorColumnAppend"
 
-  final val uuid = "uuid"
-  final val pseudoUuid = "pseudoUuid"
+  final val uuid = "enceladusUuid"
+  final val pseudoUuidFromHash = "enceladusPseudoUuidFromHash"
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package za.co.absa.enceladus.utils.error
+package za.co.absa.enceladus.utils.udf
 
 object UDFNames {
   final val stdCastErr = "stdCastErr"
@@ -28,4 +28,7 @@ object UDFNames {
   final val arrayDistinctErrors = "arrayDistinctErrors"
   final val cleanErrCol = "cleanErrCol"
   final val errorColumnAppend = "errorColumnAppend"
+
+  final val uuid = "uuid"
+  final val pseudoUuid = "pseudoUuid"
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/SchemaPathValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/SchemaPathValidator.scala
@@ -180,7 +180,7 @@ object SchemaPathValidator {
       case ExactMatch(_) =>
         Seq(ValidationError(s"Column '$parentPath$currentField' already exists so it cannot be used as an output column '$fullPath'."))
       case CaseInsensitiveMatch(_) =>
-        Seq(ValidationError(s"Case insensitive variant of a cloumn '$parentPath$currentField' already exists so it cannot be used as an output column '$fullPath'."))//scalastyle:ignore line.size.limit
+        Seq(ValidationError(s"Case insensitive variant of a column '$parentPath$currentField' already exists so it cannot be used as an output column '$fullPath'.")) //scalastyle:ignore line.size.limit
       case _ => Nil
     }
   }


### PR DESCRIPTION
`enceladus_record_id` can now be added to the result of standardization and conformance
 
There are 3 modes (`uuid`, `stableHashId`, and `none`), usage of which can be driven by supplying the `-Denceladus.recordid.generation.strategy={uuid|stableHashId|none}`:
 - `uuid` (default mode) - the `enceladus_record_id` column will be added with values resulting from `java.util.UUID.randomUUID()`
 - `stableHashId` - the `enceladus_record_id` column will be added with values resulting from (Murmur3) `hash` of all values in the row. This way, each run of standardization or conformance will yield the same ID.
 - `none` - the `enceladus_record_id` column will not be added at all.

## StableHashId considerations
 - `stableHashId` mode always yields the same `Int` value for the same data. In this approach, we value _stability over uniqueness_, because if there were 2 identical rows, their hash/id would end up being the same. This, however, should not happen in practice and should suffice for this mode's specific purposes.

## ID generation in Conformance
 - Both Standardization and Conformance checksthe presence of the `enceladus_record_id` in its input and the `enceladus.recordid.generation.strategy` value. If the field exists, nothing is done, no matter the strategy. If the field does not exist, the column might be added based on the strategy set.
Note, that the `stableHashId` strategy may assign different values in Conformance compared to what standardization would because there might be different data in the row after conformance (especially if there were some conformance error). In general, the basic condition holds - over the same input dataset, the strategy will assign the same values each time.

## Testing
- Individual classes responsible for ID generation are accompanied by unit tests, so is the standardization usage.
- I have did a few test-runs, the output indeed confirmed the expected - `none` turns off the id generation, `stableHashId` always generates the same IDs (even true for standardization & conformance combinations), `uuid`/omitting the override results in each-run-different UUIDs.