### PR TITLE
1294 config docs

### DIFF
--- a/_docs/1.0.0/usage-schema.md
+++ b/_docs/1.0.0/usage-schema.md
@@ -139,7 +139,7 @@ You provide *Schema* to **Standardization** in a JSON file:
 }
 ```
 
-Example of data adhering to the above schema can be found [here](https://github.com/AbsaOSS/enceladus/blob/develop/standardization/src/test/scala/za/co/absa/enceladus/standardization/samples/TestSamples.scala).
+Example of data adhering to the above schema can be found [here](https://github.com/AbsaOSS/enceladus/blob/master/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/samples/TestSamples.scala).
 
 Automatically added columns
 ---------------------------

--- a/_docs/1.0.0/usage-schema.md
+++ b/_docs/1.0.0/usage-schema.md
@@ -139,7 +139,7 @@ You provide *Schema* to **Standardization** in a JSON file:
 }
 ```
 
-Example of data adhering to the above schema can be found [here](https://github.com/AbsaOSS/enceladus/blob/master/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/samples/TestSamples.scala).
+Example of data adhering to the above schema can be found [here](https://github.com/AbsaOSS/enceladus/blob/v1.7.1/standardization/src/test/scala/za/co/absa/enceladus/standardization/samples/TestSamples.scala).
 
 Automatically added columns
 ---------------------------

--- a/_docs/2.0.0/usage.md
+++ b/_docs/2.0.0/usage.md
@@ -10,6 +10,7 @@ Usage
 =====
 
 * [Schema]({{ site.baseurl }}/docs/{{ page.version }}/usage/schema)
+* [Configuration]({{ site.baseurl }}/docs/{{ page.version }}/usage/config)
 
 Details
 -------

--- a/_docs/2.0.0/usage/config.md
+++ b/_docs/2.0.0/usage/config.md
@@ -1,0 +1,42 @@
+---
+layout: docs
+title: Usage - Configuration
+version: '2.0.0'
+categories:
+    - '2.0.0'
+    - usage
+redirect_from: /docs/usage/config
+---
+
+Configuration
+============
+
+<!-- toc -->
+- [Configuration](#configuration)
+  - [Intro](#intro) 
+  - [General options](#general-options)
+<!-- tocstop -->
+
+Intro
+-----------
+
+This page describes the usage of configuration of _Standardization_ and _Conformance_.
+There are number of default options that 
+[Project's readme](https://github.com/AbsaOSS/enceladus/blob/develop/README.md) documents
+this page describes the configuration values stored in `spark-jobs`'s `application.conf` (or its
+[template](https://github.com/AbsaOSS/enceladus/blob/develop/spark-jobs/src/main/resources/application.conf.template)).
+These values can be overridden using the `-D` property values as in:
+```shell
+spark-submit --conf "spark.driver.extraJavaOptions= -Dkey1=value1 -Dkey2=value2" ...
+```
+
+General options
+-----------
+
+|            Config path                   |                 Description                                                                                                              |
+|------------------------------------------|----------------------------------------------|
+| `enceladus.recordId.generation.strategy` | If and how a record ID is generated within the `enceladus_record_id` column. Can be one of `uuid` (default - UUID-based values are generated), `stableHashId` (always-the-same Murmur3 Int hash is generated - for testing), and `none` (no column with IDs added). |
+| `menas.rest.uri`                         | Comma-separated list of URLs where Menas will be looked for. |
+
+<!-- specific sections on Standardization & Conformance options may follow in the future -->
+    

--- a/_docs/2.0.0/usage/config.md
+++ b/_docs/2.0.0/usage/config.md
@@ -22,9 +22,9 @@ Intro
 
 This page describes the usage of configuration of _Standardization_ and _Conformance_.
 There are number of default options that 
-[Project's readme](https://github.com/AbsaOSS/enceladus/blob/develop/README.md) documents
-this page describes the configuration values stored in `spark-jobs`'s `application.conf` (or its
-[template](https://github.com/AbsaOSS/enceladus/blob/develop/spark-jobs/src/main/resources/application.conf.template)).
+[Project's readme](https://github.com/AbsaOSS/enceladus/blob/master/README.md) documents.
+This page describes the configuration values stored in `spark-jobs`'s `application.conf` (or its
+[template](https://github.com/AbsaOSS/enceladus/blob/master/spark-jobs/src/main/resources/application.conf.template)).
 These values can be overridden using the `-D` property values as in:
 ```shell
 spark-submit --conf "spark.driver.extraJavaOptions= -Dkey1=value1 -Dkey2=value2" ...
@@ -33,10 +33,12 @@ spark-submit --conf "spark.driver.extraJavaOptions= -Dkey1=value1 -Dkey2=value2"
 General options
 -----------
 
-|            Config path                   |                 Description                                                                                                              |
-|------------------------------------------|----------------------------------------------|
-| `enceladus.recordId.generation.strategy` | If and how a record ID is generated within the `enceladus_record_id` column. Can be one of `uuid` (default - UUID-based values are generated), `stableHashId` (always-the-same Murmur3 Int hash is generated - for testing), and `none` (no column with IDs added). |
-| `menas.rest.uri`                         | Comma-separated list of URLs where Menas will be looked for. |
+|            Config path                   | Possible value(s) |        Description        |
+|------------------------------------------|-------------------|---------------------------|
+| `enceladus.recordId.generation.strategy` |  `uuid` (default) | `enceladus_record_id` column will be added and will contain a UUID `String` for each row. |
+|                                          |  `stableHashId`   | `enceladus_record_id` column will be added and populated with an always-the-same `Int` hash (Murmur3-based, for testing). |
+|                                          |  `none`           | no column will be added to the output. |
+| `menas.rest.uri`                         |  string with URLs | Comma-separated list of URLs where Menas will be looked for. E.g.: `http://example.com/menas1,http://domain.com:8080/menas2` |
 
 <!-- specific sections on Standardization & Conformance options may follow in the future -->
     

--- a/_docs/2.0.0/usage/schema.md
+++ b/_docs/2.0.0/usage/schema.md
@@ -147,7 +147,7 @@ You provide *Schema* to **Standardization** in a JSON file:
 }
 ```
 
-Example of data adhering to the above schema can be found [here](https://github.com/AbsaOSS/enceladus/blob/develop/standardization/src/test/scala/za/co/absa/enceladus/standardization/samples/TestSamples.scala).
+Example of data adhering to the above schema can be found [here](https://github.com/AbsaOSS/enceladus/blob/master/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/samples/TestSamples.scala).
 
 Automatically added columns
 ---------------------------


### PR DESCRIPTION
_Usage > Configuration_ page was started, brief info about general config and overriding it has been added (mainly for the sake of documenting the `enceladus.recordId.generation.strategy`)

closes #1294