### PR TITLE
#1333 Change the way 'enceladus_info_date' is generated for streaming jobs

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -15,6 +15,9 @@
 
 package za.co.absa.enceladus.conformance
 
+import java.text.SimpleDateFormat
+import java.util.Date
+
 import org.apache.commons.configuration2.Configuration
 import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.functions.lit
@@ -112,6 +115,7 @@ object HyperConformance extends StreamTransformerFactory with HyperConformanceAt
     implicit val cmd: ConfCmdConfig = ConfCmdConfig(
       datasetName = conf.getString(datasetNameKey),
       datasetVersion = conf.getInt(datasetVersionKey),
+      reportDate = new SimpleDateFormat(ReportDateFormat).format(new Date()), // Still need a report date for mapping table patterns
       reportVersion = Option(getReportVersion(conf)),
       menasCredentialsFactory = menasCredentialsFactory,
       performanceMetricsFile = None,

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -20,7 +20,7 @@ import java.util.Date
 
 import org.apache.commons.configuration2.Configuration
 import org.apache.spark.SPARK_VERSION
-import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.enceladus.common.Constants._
@@ -58,7 +58,7 @@ class HyperConformance (implicit cmd: ConfCmdConfig,
 
     DynamicInterpreter.interpret(conformance, streamData)
       .withColumnIfDoesNotExist(InfoDateColumn, infoDateColumn)
-      .withColumnIfDoesNotExist(InfoDateColumnString, lit(cmd.reportDate))
+      .withColumnIfDoesNotExist(InfoDateColumnString, date_format(infoDateColumn,"yyyy-MM-dd"))
       .withColumnIfDoesNotExist(InfoVersionColumn, lit(reportVersion))
   }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -15,18 +15,13 @@
 
 package za.co.absa.enceladus.conformance
 
-import java.text.SimpleDateFormat
-import java.util.Date
-
 import org.apache.commons.configuration2.Configuration
 import org.apache.spark.SPARK_VERSION
-import org.apache.spark.sql.functions.{col, current_timestamp, lit, to_date}
-import org.apache.spark.sql.types.DateType
-import org.apache.spark.sql.{Column, DataFrame, SparkSession}
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.enceladus.common.Constants._
 import za.co.absa.enceladus.common.version.SparkVersionGuard
-import za.co.absa.enceladus.conformance.datasource.PartitioningUtils
 import za.co.absa.enceladus.conformance.interpreter.{Always, DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.conformance.streaming.InfoDateFactory
 import za.co.absa.enceladus.dao.MenasDAO
@@ -98,6 +93,8 @@ class HyperConformance (implicit cmd: ConfCmdConfig,
  * }}}
  */
 object HyperConformance extends StreamTransformerFactory with HyperConformanceAttributes {
+  import HyperConformanceAttributes._
+
   val log: Logger = LoggerFactory.getLogger(this.getClass)
 
   private val defaultReportVersion = 1

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
@@ -30,6 +30,7 @@ trait HyperConformanceAttributes extends HasComponentAttributes {
   val reportDateKey = s"$keysPrefix.report.date"
   val reportVersionKey = s"$keysPrefix.report.version"
   val eventTimestampColumnKey = s"$keysPrefix.event.timestamp.column"
+  val eventTimestampPatternKey = s"$keysPrefix.event.timestamp.pattern"
 
   override def getName: String = "HyperConformance"
 
@@ -48,7 +49,12 @@ trait HyperConformanceAttributes extends HasComponentAttributes {
       PropertyMetadata("Report version", Some("Will be determined automatically by default if not specified"), required = false),
     eventTimestampColumnKey ->
       PropertyMetadata("Event timestamp column",
-        Some("If specified, the column will be used to generate 'enceladus_info_date'"), required = false),
+        Some("If specified, the column will be used to generate 'enceladus_info_date'"),
+        required = false),
+    eventTimestampPatternKey ->
+      PropertyMetadata("Event timestamp pattern",
+        Some("If the event timestamp column is string, the pattern is used to parse it (default is 'yyyy-MM-dd'T'HH:mm'Z''"),
+        required = false),
     menasCredentialsFileKey ->
       PropertyMetadata("Menas credentials file", Some("Relative or absolute path to the file on local FS or HDFS"), required = false),
     menasAuthKeytabKey ->

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
@@ -29,6 +29,7 @@ trait HyperConformanceAttributes extends HasComponentAttributes {
   val datasetVersionKey = s"$keysPrefix.dataset.version"
   val reportDateKey = s"$keysPrefix.report.date"
   val reportVersionKey = s"$keysPrefix.report.version"
+  val eventTimestampColumnKey = s"$keysPrefix.event.timestamp.column"
 
   override def getName: String = "HyperConformance"
 
@@ -45,6 +46,9 @@ trait HyperConformanceAttributes extends HasComponentAttributes {
       PropertyMetadata("Report date", Some("The current date is used by default0"), required = false),
     reportVersionKey ->
       PropertyMetadata("Report version", Some("Will be determined automatically by default if not specified"), required = false),
+    eventTimestampColumnKey ->
+      PropertyMetadata("Event timestamp column",
+        Some("If specified, the column will be used to generate 'enceladus_info_date'"), required = false),
     menasCredentialsFileKey ->
       PropertyMetadata("Menas credentials file", Some("Relative or absolute path to the file on local FS or HDFS"), required = false),
     menasAuthKeytabKey ->

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
@@ -17,8 +17,7 @@ package za.co.absa.enceladus.conformance
 
 import za.co.absa.hyperdrive.ingestor.api.{HasComponentAttributes, PropertyMetadata}
 
-trait HyperConformanceAttributes extends HasComponentAttributes {
-
+object HyperConformanceAttributes {
   val keysPrefix = "transformer.hyperconformance"
 
   // Configuration keys expected to be set up when running Conformance as a Transformer component for Hyperdrive
@@ -31,6 +30,10 @@ trait HyperConformanceAttributes extends HasComponentAttributes {
   val reportVersionKey = s"$keysPrefix.report.version"
   val eventTimestampColumnKey = s"$keysPrefix.event.timestamp.column"
   val eventTimestampPatternKey = s"$keysPrefix.event.timestamp.pattern"
+}
+
+trait HyperConformanceAttributes extends HasComponentAttributes {
+  import HyperConformanceAttributes._
 
   override def getName: String = "HyperConformance"
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/datasource/PartitioningUtils.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/datasource/PartitioningUtils.scala
@@ -78,7 +78,12 @@ object PartitioningUtils {
     MessageFormat.format(partitioningPattern, reportYear, reportMonth, reportDay)
   }
 
-  private def validateReportDate(reportDate: String): Unit = {
+  /**
+   * Validates the port date to be in tyhe expected format: 'yyyy-MM-dd'.
+   *
+   * @param reportDate          A report date string
+   */
+  def validateReportDate(reportDate: String): Unit = {
     val reportDateRegEx = """\d\d\d\d-\d\d-\d\d""".r
 
     if (!reportDateRegEx.pattern.matcher(reportDate).matches()) {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactory.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactory.scala
@@ -45,7 +45,7 @@ class InfoDateLiteralFactory(infoDate: String) extends InfoDateFactory {
 class InfoDateFromColumnFactory(columnName: String, pattern: String) extends InfoDateFactory {
   override def getInfoDateColumn(df: DataFrame): Column = {
     val dt = SchemaUtils.getFieldType(columnName, df.schema)
-    dt match {
+    val eventDate = dt match {
       case Some(TimestampType) =>
         col(columnName).cast(DateType)
       case Some(DateType) =>
@@ -57,6 +57,7 @@ class InfoDateFromColumnFactory(columnName: String, pattern: String) extends Inf
       case None =>
         throw new IllegalArgumentException(s"The specified event time column does not exist: $columnName")
     }
+    coalesce(eventDate, current_timestamp().cast(DateType))
   }
 }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactory.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactory.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.conformance.streaming
+
+import org.apache.commons.configuration2.Configuration
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DateType, TimestampType, StringType}
+import org.apache.spark.sql.{Column, DataFrame}
+import org.slf4j.{Logger, LoggerFactory}
+import za.co.absa.enceladus.common.Constants.ReportDateFormat
+import za.co.absa.enceladus.conformance.HyperConformance.{eventTimestampColumnKey, eventTimestampPatternKey, reportDateKey}
+import za.co.absa.enceladus.conformance.datasource.PartitioningUtils
+import za.co.absa.enceladus.utils.schema.SchemaUtils
+
+/**
+ * Info date factory allows to create an expression for the information date based on the strategy used.
+ * It is one of:
+ * - Have a fixed information date provided by the configuration (or Hyperdrive command line)
+ * - Derive it from an event timestamp column
+ * - Use the processing time
+ */
+sealed trait InfoDateFactory {
+  def getInfoDateColumn(df: DataFrame): Column
+}
+
+class InfoDateLiteralFactory(infoDate: String) extends InfoDateFactory {
+  override def getInfoDateColumn(df: DataFrame): Column = {
+    PartitioningUtils.validateReportDate(infoDate)
+    to_date(lit(infoDate), ReportDateFormat)
+  }
+}
+
+class InfoDateFromColumnFactory(columnName: String, pattern: String) extends InfoDateFactory {
+  override def getInfoDateColumn(df: DataFrame): Column = {
+    val dt = SchemaUtils.getFieldType(columnName, df.schema)
+    dt match {
+      case Some(TimestampType) =>
+        col(columnName).cast(DateType)
+      case Some(DateType) =>
+        col(columnName)
+      case Some(StringType) =>
+        to_timestamp(col(columnName), pattern).cast(DateType)
+      case Some(_) =>
+        throw new IllegalArgumentException(s"The specified event time column $columnName has an incompatible type: $dt")
+      case None =>
+        throw new IllegalArgumentException(s"The specified event time column does not exist: $columnName")
+    }
+  }
+}
+
+class InfoDateFromProcessingTimeFactory extends InfoDateFactory {
+  override def getInfoDateColumn(df: DataFrame): Column = current_timestamp().cast(DateType)
+}
+
+object InfoDateFactory {
+  private val defaultEventTimestampPattern = "yyyy-MM-dd'T'HH:mm'Z'"
+
+  val log: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def getFactoryFromConfig(conf: Configuration): InfoDateFactory = {
+    if (conf.containsKey(reportDateKey)) {
+      val reportDate = conf.getString(reportDateKey)
+      log.info(s"Information date: Explicit from the job configuration = $reportDate")
+      new InfoDateLiteralFactory(reportDate)
+    } else if (conf.containsKey(eventTimestampColumnKey)) {
+      val eventTimestampColumnName = conf.getString(eventTimestampColumnKey)
+      val eventTimestampPattern = conf.getString(eventTimestampPatternKey, defaultEventTimestampPattern)
+      log.info(s"Information date: Derived from the event time column = $eventTimestampColumnName")
+      new InfoDateFromColumnFactory(eventTimestampColumnName, eventTimestampPattern)
+    } else {
+      log.info(s"Information date: Processing time is used")
+      new InfoDateFromProcessingTimeFactory()
+    }
+  }
+}

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactory.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactory.scala
@@ -17,11 +17,10 @@ package za.co.absa.enceladus.conformance.streaming
 
 import org.apache.commons.configuration2.Configuration
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{DateType, TimestampType, StringType}
+import org.apache.spark.sql.types.{DateType, StringType, TimestampType}
 import org.apache.spark.sql.{Column, DataFrame}
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.enceladus.common.Constants.ReportDateFormat
-import za.co.absa.enceladus.conformance.HyperConformance.{eventTimestampColumnKey, eventTimestampPatternKey, reportDateKey}
 import za.co.absa.enceladus.conformance.datasource.PartitioningUtils
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 
@@ -66,6 +65,8 @@ class InfoDateFromProcessingTimeFactory extends InfoDateFactory {
 }
 
 object InfoDateFactory {
+  import za.co.absa.enceladus.conformance.HyperConformanceAttributes._
+
   private val defaultEventTimestampPattern = "yyyy-MM-dd'T'HH:mm'Z'"
 
   val log: Logger = LoggerFactory.getLogger(this.getClass)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactorySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactorySuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.conformance.streaming
+
+import org.apache.commons.configuration2.Configuration
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import za.co.absa.enceladus.conformance.HyperConformanceAttributes._
+
+class InfoDateFactorySuite extends WordSpec with Matchers with MockitoSugar {
+  private val configStub: Configuration = mock[Configuration]
+
+  "InfoDateFactory" should {
+    "return an explicit info date factory from config" when {
+      "an explicit report date is specified in config" in {
+        when(configStub.containsKey(reportDateKey)).thenReturn(true)
+        when(configStub.getString(reportDateKey)).thenReturn("2019-01-01")
+
+        val infoDateFactory = InfoDateFactory.getFactoryFromConfig(configStub)
+
+        assert(infoDateFactory.isInstanceOf[InfoDateLiteralFactory])
+      }
+
+      "several configuration options are specified so the explicit report date takes precedence" in {
+        when(configStub.containsKey(reportDateKey)).thenReturn(true)
+        when(configStub.getString(reportDateKey)).thenReturn("2019-01-01")
+        when(configStub.containsKey(eventTimestampColumnKey)).thenReturn(true)
+        when(configStub.getString(eventTimestampColumnKey)).thenReturn("EV_TIME")
+
+        val infoDateFactory = InfoDateFactory.getFactoryFromConfig(configStub)
+
+        assert(infoDateFactory.isInstanceOf[InfoDateLiteralFactory])
+      }
+    }
+
+    "return an event time strategy when an event timestamp column is specified in config config" when {
+      "an explicit report date is specified in config" in {
+        when(configStub.containsKey(reportDateKey)).thenReturn(false)
+        when(configStub.containsKey(eventTimestampColumnKey)).thenReturn(true)
+        when(configStub.getString(eventTimestampColumnKey)).thenReturn("EV_TIME")
+
+        val infoDateFactory = InfoDateFactory.getFactoryFromConfig(configStub)
+
+        assert(infoDateFactory.isInstanceOf[InfoDateFromColumnFactory])
+      }
+    }
+
+    "return an processing time strategy by default" in {
+      when(configStub.containsKey(reportDateKey)).thenReturn(false)
+      when(configStub.containsKey(eventTimestampColumnKey)).thenReturn(false)
+
+      val infoDateFactory = InfoDateFactory.getFactoryFromConfig(configStub)
+
+      assert(infoDateFactory.isInstanceOf[InfoDateFromProcessingTimeFactory])
+    }
+  }
+
+}


### PR DESCRIPTION
 * If transformer.hyperconformance.report.date is specified, it will be used
 * If transformer.hyperconformance.event.timestamp.column is specified, the event date derived from it will be used
 * Otherwise the processing date will be used.

Closes #1331 and closes #1333