### PR TITLE
1348: Links in Release notes v2.5.0 doesn't work

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <div class="row bordered-header">
     <div id="logo" class="col-sm-4 col-lg-3 media">
       <a href="{{ site.baseurl }}" id="logo">
-        <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/logo.png"/>
+        <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/logo.png" alt="Logo"/>
       </a>
     </div>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <div class="row bordered-header">
     <div id="logo" class="col-sm-4 col-lg-3 media">
       <a href="{{ site.baseurl }}" id="logo">
-        <img class="img-fluid" src="{{ site.baseurl }}/assets/images/logo.png" class="mr-3"/>
+        <img class="img-fluid mr-3" src="{{ site.baseurl }}/assets/images/logo.png"/>
       </a>
     </div>
 

--- a/_posts/2020-05-15-release-2.5.0.md
+++ b/_posts/2020-05-15-release-2.5.0.md
@@ -11,10 +11,10 @@ As of 15/05 2020 the new version 2.5.0 is out
 ## Standardization & Conformance Improvements
 
 - [#1294]({{ site.github.issues_url }}/1294) **Record ID generation:** `enceladus_record_id` column is added in Enceladus (Standardization/Conformance) if it does not exist. By default it contains UUID for each record, but the implementation is overridable with `-Denceladus.recordId.generation.strategy={uuid|stableHashId|none}` 
-- [#1322]({{ site.github.issues_url }}/1322) [**\_INFO file validation:**](/docs/2.0.0/usage/info-file#validation) Added `control.info.validation` configuration option for \_INFO file validation which can have the following values: `strict` will fail the job on failed validation, `warning` will display the error as warning, but will not fail the job and `none` will ignore the result of the validation. Providing an incorrect value will fail the job with a RuntimeException
-- [#1317]({{ site.github.issues_url }}/1317) [**\_INFO file validation:**](/docs/2.0.0/usage/info-file#validation)  When \_INFO file validation is enabled ([#1322]({{ site.github.issues_url }}/1322)), the error will provide a verbose error such as _"Checkpoint validation failed: Missing source checkpoint"_
+- [#1322]({{ site.github.issues_url }}/1322) **[\_INFO file validation]({{ site.baseurl }}/docs/2.0.0/usage/info-file#validation):** Added `control.info.validation` configuration option for \_INFO file validation which can have the following values: `strict` will fail the job on failed validation, `warning` will display the error as warning, but will not fail the job and `none` will ignore the result of the validation. Providing an incorrect value will fail the job with a RuntimeException
+- [#1317]({{ site.github.issues_url }}/1317) **[\_INFO file validation]({{ site.baseurl }}/docs/2.0.0/usage/info-file#validation):** When \_INFO file validation is enabled ([#1322]({{ site.github.issues_url }}/1322)), the error will provide a verbose error such as _"Checkpoint validation failed: Missing source checkpoint"_
 - [#1329]({{ site.github.issues_url }}/1329) Added support of specifying JavaX security properties in `application.conf` instead of passing them via command line as `-D...`. Added support for secure Kafka operation when Spark jobs are running in cluster mode (only client mode was supported until now for secure Kafka). 
 
-### New Configuration options
-- [`control.info.validation`](/docs/2.0.0/usage/config#control.info.validation)
-- [`enceladus.recordId.generation.strategy`](/docs/2.0.0/usage/config#enceladus.recordId.generation.strategy)
+### New Configuration Options
+- [`control.info.validation`]({{ site.baseurl }}/docs/2.0.0/usage/config#control.info.validation)
+- [`enceladus.recordId.generation.strategy`]({{ site.baseurl }}/docs/2.0.0/usage/config#enceladus.recordId.generation.strategy)


### PR DESCRIPTION
* Links fixed
* Better typography
* header.html `class` fix