### PR TITLE
#1234 export file fix, menas attachment version fix

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/SchemaController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/SchemaController.scala
@@ -63,7 +63,7 @@ class SchemaController @Autowired()(
       try {
         val url = new URL(remoteUrl)
         val connection = url.openConnection()
-        val mimeType = SchemaController.avscConentType // only AVSC is expected to come from the schema registry
+        val mimeType = SchemaController.avscContentType // only AVSC is expected to come from the schema registry
         val fileStream = Source.fromInputStream(connection.getInputStream)
         val fileContent = fileStream.mkString
         fileStream.close()
@@ -104,7 +104,7 @@ class SchemaController @Autowired()(
 
     // for avro schema type, always force the same mime-type to be persisted
     val mime = if (schemaType == SchemaType.Avro) {
-     SchemaController.avscConentType
+     SchemaController.avscContentType
     } else {
       file.getContentType
     }
@@ -166,5 +166,5 @@ class SchemaController @Autowired()(
 }
 
 object SchemaController {
-  val avscConentType = "application/vnd.schemaregistry.v1+json"
+  val avscContentType = "application/vnd.schemaregistry.v1+json"
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/AttachmentService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/AttachmentService.scala
@@ -35,8 +35,8 @@ class AttachmentService @Autowired()(attachmentMongoRepository: AttachmentMongoR
 
   def uploadAttachment(attachment: MenasAttachment): Future[Completed] = {
     chooseRepository(attachment.refCollection).getLatestVersionValue(attachment.refName).flatMap {
-      case Some(version) =>
-        // the attachment version should already increased by one from the currently latest by the caller
+      case Some(_) =>
+        // the attachment version should already be increased by one from the currently latest by the caller
         attachmentMongoRepository.create(attachment)
       case _ =>
         throw NotFoundException()

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/AttachmentService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/AttachmentService.scala
@@ -36,8 +36,8 @@ class AttachmentService @Autowired()(attachmentMongoRepository: AttachmentMongoR
   def uploadAttachment(attachment: MenasAttachment): Future[Completed] = {
     chooseRepository(attachment.refCollection).getLatestVersionValue(attachment.refName).flatMap {
       case Some(version) =>
-        val updated = attachment.copy(refVersion = version + 1)
-        attachmentMongoRepository.create(updated)
+        // the attachment version should already increased by one from the currently latest by the caller
+        attachmentMongoRepository.create(attachment)
       case _ =>
         throw NotFoundException()
     }

--- a/menas/ui/components/schema/schemaDetail.controller.js
+++ b/menas/ui/components/schema/schemaDetail.controller.js
@@ -132,6 +132,8 @@ sap.ui.define([
           return ".json";
         case "application/octet-stream":
           return ".cob"; //copybook
+        case "application/vnd.schemaregistry.v1+json":
+          return ".avsc";
         default:
           return "";
       }


### PR DESCRIPTION
 - AVSC is always saved and exported with the same mime-type: `application/vnd.schemaregistry.v1+json`
 - means attachment version is now in line with the schema version (shown in Menas)


### A possible naive remapping script:
// edit: will need to create something more convoluted, see comments.
The following MongoDB script can be used to remap means attachments version, provided there are no holes (i.e. means without and with the bug was not used over the same persistence and the ids are not e.g. `2, 3, (missing 4 here) 5, 6`):

- `2, 3, 4` -> `2, 3, 4` (no change, all should be already correct)
- `3, 4, 5, 6` -> `2, 3, 4, 5` (all -1, all should be correct)
- `2, 3, 5, 6` -> `2, 3, 5, 6` (no change, does not work for version sequences with holes, so the second half of the version would stay incorrect)

```javascript
db.getCollection('attachment_v1').aggregate(
    [
        {
            $match: {}
        },
        {
            $group: {
                _id: "$refName",
                minVersion: { $min: "$refVersion" }
            }
        },
        { "$out": "tmp_indicators" }
    ]
);
     
var bulkOps = db.tmp_indicators.find().map(function (doc) { 
    // for every minimal version larger than 3, lower each menas attachment version by 1
    // if no records are missing, the correct lowerst should be v2, the incorrect lowest version should be v3
    if (doc.minVersion >= NumberInt(3)) {
        return { 
            "updateMany": { 
                "filter": { "refName": doc._id } ,              
                "update": { "$inc": { "refVersion": NumberInt(-1) } } 
            }         
        };
    }
});

// bulkOps contain undefined for ops that did not satisfy the minVersion condition
var bulkOpsCleaned = bulkOps.filter(function(d) { return d != undefined})

db.getCollection('attachment_v1').bulkWrite(bulkOpsCleaned);
db.tmp_indicators.drop()
```

It would make sense to discuss what the state of the persistence with users might be and if we need a smarter script - e.g. checking for the holes, too. Or will the above do?

fixes #1234 fixed #1347 