### PR TITLE
#1353 Add support for ASCII for 'cobol' raw format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ The list of additional options available for running Standardization:
 | --csv-escape **character**           | Specifies a character to be used for escaping other characters. By default '&#92;' (backslash) is used.                                            |
 | --trimValues **true/false**          | Indicates if string fields of fixed with text data should be trimmed.                                                                              |
 | --is-xcom **true/false**             | If `true` a mainframe input file is expected to have XCOM RDW headers.                                                                             |
+| --cobol-encoding **encoding**        | Specifies the encoding of a mainframe file (`ascii` or `ebcdic`). Code page can be specified using `--charset` option.                             |
+| --cobol-trimming-policy **policy**   | Specifies the way leading and trailing spaces should be handled. Can be `none` (do not trim spaces), `left`, `right`, `both`(default).             |
 | --folder-prefix **prefix**           | Adds a folder prefix before the date tokens.                                                                                                       |
 | --debug-set-raw-path **path**        | Override the path of the raw data (used for testing purposes).                                                                                     |
 | --strict-schema-check **true/false** | If `true` processing ends the moment a row not adhering to the schema is encountered, `false` (default) proceeds over it with an entry in _errCol_ | 

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -258,7 +258,7 @@
         <!-- Data formats -->
         <dependency>
             <groupId>za.co.absa.cobrix</groupId>
-            <artifactId>spark-cobol</artifactId>
+            <artifactId>spark-cobol_${scala.compat.version}</artifactId>
             <version>${cobrix.version}</version>
         </dependency>
         <!-- guava 27 for spring & wire mock testing, too -->

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/parsers/SchemaParser.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/parsers/SchemaParser.scala
@@ -20,7 +20,8 @@ import org.apache.spark.sql.avro.SchemaConverters
 import org.apache.spark.sql.types.StructType
 import za.co.absa.cobrix.cobol.parser.CopybookParser
 import za.co.absa.cobrix.cobol.parser.exceptions.SyntaxErrorException
-import za.co.absa.cobrix.spark.cobol.schema.{CobolSchema, SchemaRetentionPolicy}
+import za.co.absa.cobrix.cobol.reader.policies.SchemaRetentionPolicy
+import za.co.absa.cobrix.spark.cobol.schema.CobolSchema
 import za.co.absa.enceladus.menas.models.rest.exceptions.SchemaParsingException
 import za.co.absa.enceladus.menas.utils.SchemaType
 import za.co.absa.enceladus.menas.utils.converters.SparkMenasSchemaConvertor

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/parsers/SchemaParser.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/parsers/SchemaParser.scala
@@ -91,7 +91,7 @@ object SchemaParser {
     def parse(copybookContents: String): StructType = {
       try {
         val parsedSchema = CopybookParser.parseTree(copybookContents)
-        val cobolSchema = new CobolSchema(parsedSchema, SchemaRetentionPolicy.CollapseRoot, false)
+        val cobolSchema = new CobolSchema(parsedSchema, SchemaRetentionPolicy.CollapseRoot, "", false)
         cobolSchema.getSparkSchema
       } catch {
         case e: SyntaxErrorException =>

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiIntegrationSuite.scala
@@ -26,8 +26,8 @@ import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import za.co.absa.enceladus.menas.TestResourcePath
 import za.co.absa.enceladus.menas.integration.fixtures._
@@ -779,7 +779,7 @@ class SchemaApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll {
               assert(e.errorType == "schema_parsing")
               assert(e.schemaType == SchemaType.Copybook)
               assert(e.line.contains(22))
-              assert(e.field.contains("B1"))
+              assert(e.field.contains(""))
               assert(body.message.contains("Syntax error in the copybook"))
             case e => fail(s"Expected an instance of SchemaParsingError, got $e.")
           }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/utils/parsers/SchemaParserSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/utils/parsers/SchemaParserSuite.scala
@@ -105,7 +105,7 @@ class SchemaParserSuite extends WordSpec with Matchers with MockitoSugar with In
         }
 
         inside(caughtException) {
-          case SchemaParsingException(SchemaType.Copybook, msg, Some(22), None, Some("B1"), cause) =>
+          case SchemaParsingException(SchemaType.Copybook, msg, Some(22), None, Some(""), cause) =>
             msg should include("Syntax error in the copybook")
             cause shouldBe a[SyntaxErrorException]
         }

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <spray.json.version>1.3.5</spray.json.version>
         <oozie.version>4.3.0</oozie.version>
         <htrace.version>3.1.0-incubating</htrace.version>
-        <cobrix.version>2.0.7</cobrix.version>
+        <cobrix.version>2.0.8</cobrix.version>
         <cronstrue.version>1.79.0</cronstrue.version>
         <!--other properties-->
         <skip.integration.tests>true</skip.integration.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <spray.json.version>1.3.5</spray.json.version>
         <oozie.version>4.3.0</oozie.version>
         <htrace.version>3.1.0-incubating</htrace.version>
-        <cobrix.version>0.5.3</cobrix.version>
+        <cobrix.version>2.0.7</cobrix.version>
         <cronstrue.version>1.79.0</cronstrue.version>
         <!--other properties-->
         <skip.integration.tests>true</skip.integration.tests>

--- a/spark-jobs/pom.xml
+++ b/spark-jobs/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>za.co.absa.cobrix</groupId>
-            <artifactId>spark-cobol</artifactId>
+            <artifactId>spark-cobol_${scala.compat.version}</artifactId>
             <version>${cobrix.version}</version>
         </dependency>
 
@@ -137,6 +137,10 @@
                 <exclusion>
                     <groupId>net.jpountz.lz4</groupId>
                     <artifactId>lz4</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/CobolOptions.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/CobolOptions.scala
@@ -28,5 +28,6 @@ case class CobolOptions
 (
   copybook: String = "",
   encoding: Option[String] = None,
+  trimmingPolicy: Option[String] = None,
   isXcom: Boolean = false
 )

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/CobolOptions.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/CobolOptions.scala
@@ -27,5 +27,6 @@ package za.co.absa.enceladus.standardization
 case class CobolOptions
 (
   copybook: String = "",
+  encoding: Option[String] = None,
   isXcom: Boolean = false
 )

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -46,8 +46,8 @@ import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.ValidationException
 
 import scala.collection.immutable.HashMap
-import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
 
 object StandardizationJob {
   TimeZoneNormalizer.normalizeJVMTimeZone()
@@ -230,6 +230,7 @@ object StandardizationJob {
       HashMap(
         getCopybookOption(cobolOptions, dataset),
         "is_xcom" -> Option(BooleanParameter(cobolOptions.isXcom)),
+        "encoding" -> cobolOptions.encoding.map(StringParameter),
         "schema_retention_policy" -> Some(StringParameter("collapse_root"))
       )
     } else {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -227,10 +227,16 @@ object StandardizationJob {
   private def getCobolOptions(cmd: StdCmdConfig, dataset: Dataset)(implicit dao: MenasDAO): HashMap[String, Option[RawFormatParameter]] = {
     if (cmd.rawFormat.equalsIgnoreCase("cobol")) {
       val cobolOptions = cmd.cobolOptions.getOrElse(CobolOptions())
+      val isAscii = cobolOptions.encoding.exists(_.equalsIgnoreCase("ascii"))
+      // For ASCII files --charset is converted into Cobrix "ascii_charset" option
+      // For EBCDIC files --charset is converted into Cobrix "ebcdic_code_page" option
       HashMap(
         getCopybookOption(cobolOptions, dataset),
         "is_xcom" -> Option(BooleanParameter(cobolOptions.isXcom)),
+        "string_trimming_policy" -> cobolOptions.trimmingPolicy.map(StringParameter),
         "encoding" -> cobolOptions.encoding.map(StringParameter),
+        "ascii_charset" -> cmd.charset.flatMap(charset => if (isAscii) Option(StringParameter(charset)) else None),
+        "ebcdic_code_page" -> cmd.charset.flatMap(charset => if (!isAscii) Option(StringParameter(charset)) else None),
         "schema_retention_policy" -> Some(StringParameter("collapse_root"))
       )
     } else {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StdCmdConfig.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StdCmdConfig.scala
@@ -255,6 +255,16 @@ object StdCmdConfig {
           } else {
             failure("The --cobol-encoding option is supported only for COBOL data format")
           })
+
+      opt[String]("cobol-trimming-policy").optional().action((value, config) => {
+        config.copy(cobolOptions = cobolSetTrimmingPolicy(config.cobolOptions, value))
+      }).text("Specify string trimming policy for mainframe files (none, left, right, both)")
+        .validate(value =>
+          if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("cobol")) {
+            success
+          } else {
+            failure("The --cobol-trimming-policy option is supported only for COBOL data format")
+          })
     }
 
     private def cobolSetCopybook(cobolOptions: Option[CobolOptions], newCopybook: String): Option[CobolOptions] = {
@@ -275,6 +285,13 @@ object StdCmdConfig {
       cobolOptions match {
         case Some(a) => Some(a.copy(encoding = Option(newEncoding)))
         case None => Some(CobolOptions(encoding = Option(newEncoding)))
+      }
+    }
+
+    private def cobolSetTrimmingPolicy(cobolOptions: Option[CobolOptions], newTrimmingPolicy: String): Option[CobolOptions] = {
+      cobolOptions match {
+        case Some(a) => Some(a.copy(trimmingPolicy = Option(newTrimmingPolicy)))
+        case None => Some(CobolOptions(trimmingPolicy = Option(newTrimmingPolicy)))
       }
     }
   }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StdCmdConfig.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StdCmdConfig.scala
@@ -245,6 +245,16 @@ object StdCmdConfig {
           } else {
             failure("The --is-xcom option is supported only for COBOL data format")
           })
+
+      opt[String]("cobol-encoding").optional().action((value, config) => {
+        config.copy(cobolOptions = cobolSetEncoding(config.cobolOptions, value))
+      }).text("Specify encoding of mainframe files (ascii or ebcdic)")
+        .validate(value =>
+          if (rawFormat.isDefined && rawFormat.get.equalsIgnoreCase("cobol")) {
+            success
+          } else {
+            failure("The --cobol-encoding option is supported only for COBOL data format")
+          })
     }
 
     private def cobolSetCopybook(cobolOptions: Option[CobolOptions], newCopybook: String): Option[CobolOptions] = {
@@ -258,6 +268,13 @@ object StdCmdConfig {
       cobolOptions match {
         case Some(a) => Some(a.copy(isXcom = newIsXCom))
         case None => Some(CobolOptions(isXcom = newIsXCom))
+      }
+    }
+
+    private def cobolSetEncoding(cobolOptions: Option[CobolOptions], newEncoding: String): Option[CobolOptions] = {
+      cobolOptions match {
+        case Some(a) => Some(a.copy(encoding = Option(newEncoding)))
+        case None => Some(CobolOptions(encoding = Option(newEncoding)))
       }
     }
   }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StdCmdConfig.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StdCmdConfig.scala
@@ -131,12 +131,12 @@ object StdCmdConfig {
       .validate(value =>
         if (rawFormat.isDefined &&
           (rawFormat.get.equalsIgnoreCase("xml") ||
-          rawFormat.get.equalsIgnoreCase("csv") ||
-          rawFormat.get.equalsIgnoreCase("json")))
-        {
+            rawFormat.get.equalsIgnoreCase("csv") ||
+            rawFormat.get.equalsIgnoreCase("json") ||
+            rawFormat.get.equalsIgnoreCase("cobol"))) {
           success
         } else {
-          failure("The --charset option is supported only for CSV, JSON and XML")
+          failure("The --charset option is supported only for CSV, JSON, XML and COBOL")
         })
 
     opt[String]("row-tag").optional().action((value, config) =>

--- a/spark-jobs/src/test/resources/log4j.properties
+++ b/spark-jobs/src/test/resources/log4j.properties
@@ -59,3 +59,6 @@ log4j.appender.forschemachecker.filter.01.StringToMatch=Validation error for col
 log4j.appender.forschemachecker.filter.01.AcceptOnMatch=false
 log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=@log.level.testcode@, forschemachecker
 log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=false
+
+# Suppress Cobrix error messages in tests
+log4j.logger.za.co.absa.cobrix.spark.cobol.source.parameters.CobolParametersParser$=OFF

--- a/spark-jobs/src/test/resources/log4j.properties
+++ b/spark-jobs/src/test/resources/log4j.properties
@@ -61,4 +61,4 @@ log4j.logger.za.co.absa.enceladus.standardization.interpreter.stages.SchemaCheck
 log4j.additivity.za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker$=false
 
 # Suppress Cobrix error messages in tests
-log4j.logger.za.co.absa.cobrix.spark.cobol.source.parameters.CobolParametersParser$=OFF
+log4j.logger.za.co.absa.cobrix.spark.cobol.parameters.CobolParametersParser$=OFF

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolAsciiSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolAsciiSuite.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.standardization
+
+import java.nio.charset.StandardCharsets
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Outcome, fixture}
+import za.co.absa.enceladus.dao.MenasDAO
+import za.co.absa.enceladus.model.Dataset
+import za.co.absa.enceladus.standardization.fixtures.TempFileFixture
+import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+
+class StandardizationCobolAsciiSuite extends fixture.FunSuite with SparkTestBase with TempFileFixture with MockitoSugar {
+
+  type FixtureParam = String
+
+  private implicit val dao: MenasDAO = mock[MenasDAO]
+
+  private val tmpFilePrefix = "cobol-fix-ascii-"
+  private val tmpFileSuffix = ".dat"
+
+  // Copybook
+  private val copybook =
+    """       01  RECORD.
+      |           05  A1       PIC X(1).
+      |           05  A2       PIC X(5).
+      |           05  A3       PIC X(10).
+      |""".stripMargin
+
+  // Fixed-length ASCII text file
+  private val cobolContent: String = "1Tes  01234567892 est2 SomeText 3None Data¡3    4 on      Data 4"
+
+  private val asciiCharset = StandardCharsets.ISO_8859_1
+
+  private val schema = StructType(Seq(
+    StructField("A1", StringType, nullable = true),
+    StructField("A2", StringType, nullable = true),
+    StructField("A3", StringType, nullable = true)))
+
+  private val dataSet = Dataset("FixedLength", 1, None, "", "", "FixedLength", 1, conformance = Nil)
+
+  private val argumentsBase =
+    ("--dataset-name FixedLength --dataset-version 1 --report-date 2019-07-23 --report-version 1 " +
+      "--menas-auth-keytab src/test/resources/user.keytab.example " +
+      "--raw-format cobol --cobol-encoding ascii").split(' ')
+
+  def withFixture(test: OneArgTest): Outcome = {
+    val tmpFile = createTempFile(tmpFilePrefix, tmpFileSuffix, asciiCharset, cobolContent)
+    test(tmpFile.getAbsolutePath)
+  }
+
+  /** Creates a dataframe from an input file name path and command line arguments to Standardization */
+  private def getTestDataFrame(tmpFileName: String,
+                               args: Array[String]
+                              ): DataFrame = {
+    val cmd: StdCmdConfig = StdCmdConfig.getCmdLineArguments(argumentsBase ++ args)
+    val cobolReader = StandardizationJob.getFormatSpecificReader(cmd, dataSet, schema.fields.length)
+    cobolReader
+      .option("copybook_contents", copybook)
+      .load(tmpFileName)
+  }
+
+  test("Test ASCII COBOL file having ISO-8851-1 charset with trimming=none") { tmpFileName =>
+    val args = ("--charset ISO-8859-1 --cobol-trimming-policy none").split(" ")
+
+    val expected =
+      """{"A1":"1","A2":"Tes  ","A3":"0123456789"}
+        |{"A1":"2","A2":" est2","A3":" SomeText "}
+        |{"A1":"3","A2":"None ","A3":"Data¡3    "}
+        |{"A1":"4","A2":" on  ","A3":"    Data 4"}""".stripMargin.replace("\r\n", "\n")
+
+    val df = getTestDataFrame(tmpFileName, args)
+    val actual = df.toJSON.collect.mkString("\n")
+
+    assert(actual == expected)
+  }
+
+  test("Test ASCII COBOL file with trimming=left") { tmpFileName =>
+    val args = ("--cobol-trimming-policy left").split(" ")
+
+    val expected =
+      """{"A1":"1","A2":"Tes  ","A3":"0123456789"}
+        |{"A1":"2","A2":"est2","A3":"SomeText "}
+        |{"A1":"3","A2":"None ","A3":"Data 3    "}
+        |{"A1":"4","A2":"on  ","A3":"Data 4"}""".stripMargin.replace("\r\n", "\n")
+
+    val df = getTestDataFrame(tmpFileName, args)
+    val actual = df.toJSON.collect.mkString("\n")
+
+    assert(actual == expected)
+  }
+
+  test("Test ASCII COBOL file with trimming=right") { tmpFileName =>
+    val args = ("--cobol-trimming-policy right").split(" ")
+
+    val expected =
+      """{"A1":"1","A2":"Tes","A3":"0123456789"}
+        |{"A1":"2","A2":" est2","A3":" SomeText"}
+        |{"A1":"3","A2":"None","A3":"Data 3"}
+        |{"A1":"4","A2":" on","A3":"    Data 4"}""".stripMargin.replace("\r\n", "\n")
+
+    val df = getTestDataFrame(tmpFileName, args)
+    val actual = df.toJSON.collect.mkString("\n")
+
+    assert(actual == expected)
+  }
+
+  test("Test ASCII COBOL file having ISO-8851-1 charset with trimming=both") { tmpFileName =>
+    val args = ("--charset ISO-8859-1").split(" ")
+
+    val expected =
+      """{"A1":"1","A2":"Tes","A3":"0123456789"}
+        |{"A1":"2","A2":"est2","A3":"SomeText"}
+        |{"A1":"3","A2":"None","A3":"Data¡3"}
+        |{"A1":"4","A2":"on","A3":"Data 4"}""".stripMargin.replace("\r\n", "\n")
+
+    val df = getTestDataFrame(tmpFileName, args)
+    val actual = df.toJSON.collect.mkString("\n")
+
+    assert(actual == expected)
+  }
+
+}

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolAsciiSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolAsciiSuite.scala
@@ -77,7 +77,7 @@ class StandardizationCobolAsciiSuite extends fixture.FunSuite with SparkTestBase
   }
 
   test("Test ASCII COBOL file having ISO-8851-1 charset with trimming=none") { tmpFileName =>
-    val args = ("--charset ISO-8859-1 --cobol-trimming-policy none").split(" ")
+    val args = "--charset ISO-8859-1 --cobol-trimming-policy none".split(" ")
 
     val expected =
       """{"A1":"1","A2":"Tes  ","A3":"0123456789"}
@@ -92,7 +92,7 @@ class StandardizationCobolAsciiSuite extends fixture.FunSuite with SparkTestBase
   }
 
   test("Test ASCII COBOL file with trimming=left") { tmpFileName =>
-    val args = ("--cobol-trimming-policy left").split(" ")
+    val args = "--cobol-trimming-policy left".split(" ")
 
     val expected =
       """{"A1":"1","A2":"Tes  ","A3":"0123456789"}
@@ -107,7 +107,7 @@ class StandardizationCobolAsciiSuite extends fixture.FunSuite with SparkTestBase
   }
 
   test("Test ASCII COBOL file with trimming=right") { tmpFileName =>
-    val args = ("--cobol-trimming-policy right").split(" ")
+    val args = "--cobol-trimming-policy right".split(" ")
 
     val expected =
       """{"A1":"1","A2":"Tes","A3":"0123456789"}
@@ -122,7 +122,7 @@ class StandardizationCobolAsciiSuite extends fixture.FunSuite with SparkTestBase
   }
 
   test("Test ASCII COBOL file having ISO-8851-1 charset with trimming=both") { tmpFileName =>
-    val args = ("--charset ISO-8859-1").split(" ")
+    val args = "--charset ISO-8859-1".split(" ")
 
     val expected =
       """{"A1":"1","A2":"Tes","A3":"0123456789"}
@@ -134,6 +134,22 @@ class StandardizationCobolAsciiSuite extends fixture.FunSuite with SparkTestBase
     val actual = df.toJSON.collect.mkString("\n")
 
     assert(actual == expected)
+  }
+
+  test("Test COBOL source throws when a bogus trimming policy is provided") { tmpFileName =>
+    val args = "--cobol-trimming-policy bogus".split(" ")
+
+    intercept[IllegalArgumentException] {
+      getTestDataFrame(tmpFileName, args)
+    }
+  }
+
+  test("Test COBOL source throws when a bogus charset is provided") { tmpFileName =>
+    val args = "--charset bogus".split(" ")
+
+    intercept[IllegalArgumentException] {
+      getTestDataFrame(tmpFileName, args)
+    }
   }
 
 }

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolEbcdicSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolEbcdicSuite.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.standardization
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Outcome, fixture}
+import za.co.absa.enceladus.dao.MenasDAO
+import za.co.absa.enceladus.model.Dataset
+import za.co.absa.enceladus.standardization.fixtures.TempFileFixture
+import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+
+class StandardizationCobolEbcdicSuite extends fixture.FunSuite with SparkTestBase with TempFileFixture with MockitoSugar {
+
+  type FixtureParam = String
+
+  private implicit val dao: MenasDAO = mock[MenasDAO]
+
+  private val tmpFilePrefix = "cobol-fix-ebcdic-"
+  private val tmpFileSuffix = ".dat"
+
+  // Copybook
+  private val copybook =
+    """       01  RECORD.
+      |           05  A1       PIC X(1).
+      |           05  A2       PIC X(5).
+      |           05  A3       PIC X(10).
+      |""".stripMargin
+
+  // Fixed-length EBCDIC file
+  private val cobolContent = Array[Byte](
+    0xF1.toByte, 0xE3.toByte, 0x85.toByte, 0xA2.toByte,
+    0x40.toByte, 0x40.toByte, 0x40.toByte, 0xF1.toByte,
+    0xF2.toByte, 0xE1.toByte, 0xF4.toByte, 0xF5.toByte,
+    0xF6.toByte, 0xF7.toByte, 0xF8.toByte, 0x40.toByte
+  )
+
+  private val schema = StructType(Seq(
+    StructField("A1", StringType, nullable = true),
+    StructField("A2", StringType, nullable = true),
+    StructField("A3", StringType, nullable = true)))
+
+  private val dataSet = Dataset("FixedLength", 1, None, "", "", "FixedLength", 1, conformance = Nil)
+
+  private val argumentsBase =
+    ("--dataset-name FixedLength --dataset-version 1 --report-date 2019-07-23 --report-version 1 " +
+      "--menas-auth-keytab src/test/resources/user.keytab.example " +
+      "--raw-format cobol").split(' ')
+
+  def withFixture(test: OneArgTest): Outcome = {
+    val tmpFile = createTempBinFile(tmpFilePrefix, tmpFileSuffix, cobolContent)
+    test(tmpFile.getAbsolutePath)
+  }
+
+  /** Creates a dataframe from an input file name path and command line arguments to Standardization */
+  private def getTestDataFrame(tmpFileName: String,
+                               args: Array[String]
+                              ): DataFrame = {
+    val cmd: StdCmdConfig = StdCmdConfig.getCmdLineArguments(argumentsBase ++ args)
+    val cobolReader = StandardizationJob.getFormatSpecificReader(cmd, dataSet, schema.fields.length)
+    cobolReader
+      .option("copybook_contents", copybook)
+      .load(tmpFileName)
+  }
+
+  test("Test EBCDIC common trimming=none") { tmpFileName =>
+    val args = ("--charset common --cobol-trimming-policy none").split(" ")
+    val expected = """{"A1":"1","A2":"Tes  ","A3":" 12 45678 "}""".stripMargin.replace("\r\n", "\n")
+    val df = getTestDataFrame(tmpFileName, args)
+    val actual = df.toJSON.collect.mkString("\n")
+
+    assert(actual == expected)
+  }
+
+  test("Test EBCDIC common trimming=left") { tmpFileName =>
+    val args = ("--charset common --cobol-trimming-policy left").split(" ")
+    val expected = """{"A1":"1","A2":"Tes  ","A3":"12 45678 "}""".stripMargin.replace("\r\n", "\n")
+    val df = getTestDataFrame(tmpFileName, args)
+    val actual = df.toJSON.collect.mkString("\n")
+
+    assert(actual == expected)
+  }
+
+  test("Test EBCDIC cp037 trimming=right") { tmpFileName =>
+    val args = ("--charset cp037 --cobol-trimming-policy right").split(" ")
+    val expected = """{"A1":"1","A2":"Tes","A3":" 12÷45678"}""".stripMargin.replace("\r\n", "\n")
+    val df = getTestDataFrame(tmpFileName, args)
+    val actual = df.toJSON.collect.mkString("\n")
+
+    assert(actual == expected)
+  }
+
+  test("Test EBCDIC cp037 trimming=both") { tmpFileName =>
+    val args = ("--charset cp037").split(" ")
+    val expected = """{"A1":"1","A2":"Tes","A3":"12÷45678"}""".stripMargin.replace("\r\n", "\n")
+    val df = getTestDataFrame(tmpFileName, args)
+    val actual = df.toJSON.collect.mkString("\n")
+
+    assert(actual == expected)
+  }
+
+}

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolEbcdicSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolEbcdicSuite.scala
@@ -113,4 +113,12 @@ class StandardizationCobolEbcdicSuite extends fixture.FunSuite with SparkTestBas
     assert(actual == expected)
   }
 
+  test("Test COBOL source throws when a bogus encoding is provided") { tmpFileName =>
+    val args = "--cobol-encoding bogus".split(" ")
+
+    intercept[IllegalArgumentException] {
+      getTestDataFrame(tmpFileName, args)
+    }
+  }
+
 }

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/fixtures/TempFileFixture.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/fixtures/TempFileFixture.scala
@@ -17,7 +17,6 @@ package za.co.absa.enceladus.standardization.fixtures
 
 import java.io.{DataOutputStream, File, FileOutputStream}
 import java.nio.charset.Charset
-import java.nio.file.FileSystems
 
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import za.co.absa.commons.io.{TempDirectory, TempFile}
@@ -39,6 +38,21 @@ trait TempFileFixture {
     * @return The full path to the temporary file
     */
   def createTempFile(prefix: String, suffix: String, charset: Charset, content: String, deleteOnExit: Boolean = true): File = {
+    createTempBinFile(prefix, suffix, content.getBytes(charset), deleteOnExit)
+  }
+
+  /**
+   * Creates a temporary binary file and returns the full path to it
+   *
+   * @param prefix       The prefix string to be used in generating the file's name
+   *                     must be at least three characters long
+   * @param suffix       The suffix string to be used in generating the file's name
+   *                     may be <code>null</code>, in which case the suffix <code>".tmp"</code> will be used
+   * @param content      A contents to put to the file
+   * @param deleteOnExit If true the file will be deleted when not referenced anymore
+   * @return The full path to the temporary file
+   */
+  def createTempBinFile(prefix: String, suffix: String, content: Array[Byte], deleteOnExit: Boolean = true): File = {
     val tempFile = TempFile(prefix, suffix)
     if (deleteOnExit) {
       tempFile.deleteOnExit()
@@ -46,7 +60,7 @@ trait TempFileFixture {
     val result = tempFile.path.toFile
     val ostream = new DataOutputStream(new FileOutputStream(result))
     try {
-      ostream.write(content.getBytes(charset))
+      ostream.write(content)
     } finally {
       ostream.close()
     }


### PR DESCRIPTION
This adds the support of fixed-width text files when using 'cobol' as raw format.
The only thing that needs to be provided is a copybook. But it is easy for such formats:
```
       01  RECORD.
           05  A        PIC X(1).
           05  B        PIC X(5).
           05  C        PIC X(10).
           05  FILLER   PIC X(1).
```
Each field defines just the size.

In order to load ASCII files you need to use `--cobol-encoding ascii` (`ebcdic` is Cobrix default). You can specify the charset the normal way using `--charset`.

Since fixed-with text files contain a lot of leading or trailing spaces, users want to control how these spaces will be handled. Use `--cobol-trimming-policy` for that. It can be `none`, `left`, `right` or `both` (Cobrix default).
