### PR TITLE
#1235 BinaryType support in enceladus

### DIFF
--- a/menas/ui/components/dataset/conformanceRule/ConformanceRuleForm.js
+++ b/menas/ui/components/dataset/conformanceRule/ConformanceRuleForm.js
@@ -165,7 +165,8 @@ class CastingConformanceRuleForm extends ConformanceRuleForm {
       {type: "decimal(38,18)"},
       {type: "string"},
       {type: "date"},
-      {type: "timestamp"}
+      {type: "timestamp"},
+      {type: "binary"},
     ]
   }
 

--- a/menas/ui/components/dataset/conformanceRule/ConformanceRuleForm.js
+++ b/menas/ui/components/dataset/conformanceRule/ConformanceRuleForm.js
@@ -166,7 +166,7 @@ class CastingConformanceRuleForm extends ConformanceRuleForm {
       {type: "string"},
       {type: "date"},
       {type: "timestamp"},
-      {type: "binary"},
+      {type: "binary"}
     ]
   }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -27,8 +27,9 @@ import org.apache.spark.sql.types._
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.enceladus.standardization.interpreter.dataTypes.ParseOutput
 import za.co.absa.enceladus.utils.error.ErrorMessage
-import za.co.absa.enceladus.utils.schema.{MetadataKeys, SchemaUtils}
+import za.co.absa.enceladus.utils.schema.{MetadataKeys, MetadataValues, SchemaUtils}
 import za.co.absa.enceladus.utils.schema.SchemaUtils.FieldWithSource
+import za.co.absa.enceladus.utils.implicits.StructFieldImplicits._
 import za.co.absa.enceladus.utils.time.DateTimePattern
 import za.co.absa.enceladus.utils.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.enceladus.utils.types.TypedStructField._
@@ -417,18 +418,18 @@ object TypeParser {
                                        (implicit defaults: Defaults) extends PrimitiveParser[Array[Byte]] {
     override protected def assemblePrimitiveCastLogic: Column = {
       origType match {
-        case BinaryType => column.cast(BinaryType) // binary: just cast
+        case BinaryType => column
         case StringType =>
-          if (field.structField.metadata.contains(MetadataKeys.Encoding)) {
-            val encoding = field.structField.metadata.getString(MetadataKeys.Encoding)
-            encoding.toLowerCase match {
-              case "base64" => org.apache.spark.sql.functions.unbase64(column).cast(BinaryType)
-              case _ => throw new IllegalStateException(s"Unsupported encoding for Binary field ${field.structField.name}: '$encoding'")
-            }
+          val encoding = field.structField.getMetadataString(MetadataKeys.Encoding).map(_.toLowerCase)
 
-          } else {
-            logger.info(s"Binary field ${field.structField.name} does not have encoding setup in metadata. Reading as-is using 'getBytes'")
-            column.cast(field.dataType) // no metadata, just cast
+          encoding match {
+            case Some(MetadataValues.Encoding.Base64) => unbase64(column)
+            case Some(MetadataValues.Encoding.None) | None =>
+              if (encoding.isEmpty) {
+                logger.info(s"Binary field ${field.structField.name} does not have encoding setup in metadata. Reading as-is.")
+              }
+              column.cast(field.dataType) // use as-is
+            case _ => throw new IllegalStateException(s"Unsupported encoding for Binary field ${field.structField.name}: '${encoding.get}'")
           }
         case _ => throw new IllegalStateException(s"Unsupported conversion from BinaryType to ${field.dataType}")
       }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -168,6 +168,7 @@ object TypeParser {
       case _: DoubleType    => FractionalParser(TypedStructField.asNumericTypeStructField[Double](field), _, _, _, _, _)
       case _: DecimalType   => DecimalParser(TypedStructField.asNumericTypeStructField[BigDecimal](field), _, _, _, _, _)
       case _: StringType    => StringParser(TypedStructField(field), _, _, _, _, _)
+      case _: BinaryType    => BinaryParser(TypedStructField(field), _, _, _, _, _)
       case _: BooleanType   => BooleanParser(TypedStructField(field), _, _, _, _, _)
       case _: DateType      => DateParser(TypedStructField.asDateTimeTypeStructField(field), _, _, _, _, _)
       case _: TimestampType => TimestampParser(TypedStructField.asDateTimeTypeStructField(field), _, _, _, _, _)
@@ -406,6 +407,14 @@ object TypeParser {
                                         failOnInputNotPerSchema: Boolean,
                                         isArrayElement: Boolean)
                                        (implicit defaults: Defaults) extends ScalarParser[String]
+
+  private final case class BinaryParser(field: TypedStructField,
+                                        path: String,
+                                        column: Column,
+                                        origType: DataType,
+                                        failOnInputNotPerSchema: Boolean,
+                                        isArrayElement: Boolean)
+                                       (implicit defaults: Defaults) extends ScalarParser[Array[Byte]]
 
   private final case class BooleanParser(field: TypedStructField,
                                          path: String,

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -53,7 +53,7 @@ import scala.util.{Random, Try}
   *         NumericParser !
   *         StringParser !
   *         BooleanParser !
- *        BinaryParser !
+  *       BinaryParser !
   *       DateTimeParser
   *         TimestampParser !
   *         DateParser !

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -425,7 +425,7 @@ object TypeParser {
             case Some(MetadataValues.Encoding.Base64) => callUDF(UDFNames.binaryUnbase64, column)
             case Some(MetadataValues.Encoding.None) | None =>
               if (field.normalizedEncoding.isEmpty) {
-                logger.info(s"Binary field ${field.structField.name} does not have encoding setup in metadata. Reading as-is.")
+                logger.warn(s"Binary field ${field.structField.name} does not have encoding setup in metadata. Reading as-is.")
               }
               column.cast(field.dataType) // use as-is
             case _ => throw new IllegalStateException(s"Unsupported encoding for Binary field ${field.structField.name}:" +

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.standardization.interpreter
+
+import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
+import org.scalatest.{FunSuite, Matchers}
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
+import za.co.absa.enceladus.utils.udf.UDFLibrary
+
+class StandardizationInterpreter_BinarySuite extends FunSuite with SparkTestBase with LoggerTestBase with Matchers {
+
+  import spark.implicits._
+
+  private implicit val udfLib: UDFLibrary = new UDFLibrary
+
+  private val fieldName = "binaryField"
+
+  test("byteArray") {
+    val seq = Seq(
+      Array(1, 2, 3).map(_.toByte),
+      Array('a', 'b', 'c').map(_.toByte)
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, BinaryType, nullable = false)
+    ))
+    val expected = Seq(
+      BinaryRow(Array(1, 2, 3).map(_.toByte)),
+      BinaryRow(Array(97, 98, 99).map(_.toByte))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    val result = std.as[BinaryRow].collect().toList
+
+    expected.map(_.simpleFields) should contain theSameElementsAs result.map(_.simpleFields)
+  }
+
+}

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
@@ -20,6 +20,7 @@ import org.scalatest.{FunSuite, Matchers}
 import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
+import za.co.absa.enceladus.utils.validation.ValidationException
 
 class StandardizationInterpreter_BinarySuite extends FunSuite with SparkTestBase with LoggerTestBase with Matchers {
 
@@ -83,11 +84,12 @@ class StandardizationInterpreter_BinarySuite extends FunSuite with SparkTestBase
     ))
 
     val src = seq.toDF(fieldName)
-    val caught = intercept[IllegalStateException](
+    val caught = intercept[ValidationException](
       StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
     )
 
-    caught.getMessage should startWith("Unsupported encoding")
+    caught.errors.length shouldBe 1
+    caught.errors.head should include ("Unsupported encoding for Binary field binaryField: 'bogus'")
   }
 
   // behavior of explicit metadata "none" and lacking metadata should behave identically

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
@@ -15,8 +15,9 @@
 
 package za.co.absa.enceladus.standardization.interpreter
 
-import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
+import org.apache.spark.sql.types.{BinaryType, MetadataBuilder, StructField, StructType}
 import org.scalatest.{FunSuite, Matchers}
+import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, SparkTestBase}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 
@@ -28,7 +29,7 @@ class StandardizationInterpreter_BinarySuite extends FunSuite with SparkTestBase
 
   private val fieldName = "binaryField"
 
-  test("byteArray") {
+  test("byteArray to Binary") {
     val seq = Seq(
       Array(1, 2, 3).map(_.toByte),
       Array('a', 'b', 'c').map(_.toByte)
@@ -42,12 +43,101 @@ class StandardizationInterpreter_BinarySuite extends FunSuite with SparkTestBase
     )
 
     val src = seq.toDF(fieldName)
-
     val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
     logDataFrameContent(std)
 
     val result = std.as[BinaryRow].collect().toList
+    expected.map(_.simpleFields) should contain theSameElementsAs result.map(_.simpleFields)
+  }
 
+  test("Binary from string with base64 encoding") {
+    val seq = Seq(
+      "MTIz",
+      "YWJjZA=="
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, BinaryType, nullable = false,
+        new MetadataBuilder().putString("encoding", "base64").build)
+    ))
+
+    val expected = Seq(
+      BinaryRow(Array(49, 50, 51).map(_.toByte)), // "123"
+      BinaryRow(Array(97, 98, 99, 100).map(_.toByte)) // "abcd"
+    )
+
+    val src = seq.toDF(fieldName)
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    val result = std.as[BinaryRow].collect().toList
+    expected.map(_.simpleFields) should contain theSameElementsAs result.map(_.simpleFields)
+  }
+
+  test("Binary from string with bogus encoding") {
+    val seq = Seq(
+      "does not matter"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, BinaryType, nullable = false,
+        new MetadataBuilder().putString("encoding", "bogus").build)
+    ))
+
+    val src = seq.toDF(fieldName)
+    val caught = intercept[IllegalStateException] (
+      StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    )
+
+    caught.getMessage should startWith ("Unsupported encoding")
+  }
+
+  test("Binary from string with no encoding") {
+    val seq = Seq(
+      "abc",
+      "1234"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, BinaryType, nullable = false)
+    ))
+
+    val expected = Seq(
+      BinaryRow(Array(97, 98, 99).map(_.toByte)), // "123"
+      BinaryRow(Array(49, 50, 51,52).map(_.toByte)) // "abcd"
+    )
+
+    val src = seq.toDF(fieldName)
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    val result = std.as[BinaryRow].collect().toList
+    expected.map(_.simpleFields) should contain theSameElementsAs result.map(_.simpleFields)
+  }
+
+  test("Binary with defaultValue always uses base64") {
+    val seq = Seq[Option[String]](
+      Some("MTIz"),
+      None
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, BinaryType, nullable = false, new MetadataBuilder()
+        .putString("encoding", "base64")
+        .putString("default", "ZW1wdHk=") // "empty"
+          .build)
+    ))
+
+    val expected = Seq(
+      BinaryRow(Array(49, 50, 51).map(_.toByte)), // "123"
+      // ^ std error is written into the errCol and the default (fallback) value "(binary) empty" is used.
+      BinaryRow(Array('e', 'm', 'p', 't', 'y').map(_.toByte),
+        Seq(ErrorMessage("stdNullError", "E00002", "Standardization Error - Null detected in non-nullable attribute",
+          "binaryField", rawValues = Seq("null"), mappings = Seq()))
+      )
+    )
+
+    val src = seq.toDF(fieldName)
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    logDataFrameContent(std)
+
+    val result = std.as[BinaryRow].collect().toList
     expected.map(_.simpleFields) should contain theSameElementsAs result.map(_.simpleFields)
   }
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/standardizationInterpreter_RowTypes.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/standardizationInterpreter_RowTypes.scala
@@ -122,3 +122,11 @@ case class DateRow(
                     dateField: Date,
                     errCol: Seq[ErrorMessage] = Seq.empty
                   )
+
+case class BinaryRow(
+                    binaryField: Array[Byte],
+                    errCol: Seq[ErrorMessage] = Seq.empty
+                  ) {
+
+  def simpleFields = (binaryField.toSeq, errCol)
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/MetadataKeys.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/MetadataKeys.scala
@@ -31,4 +31,6 @@ object MetadataKeys {
   val AllowInfinity = "allow_infinity"
   // integral types
   val Radix = "radix"
+  // binary
+  val Encoding = "encoding"
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/schema/MetadataKeys.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/schema/MetadataKeys.scala
@@ -34,3 +34,10 @@ object MetadataKeys {
   // binary
   val Encoding = "encoding"
 }
+
+object MetadataValues {
+  object Encoding {
+    val Base64 = "base64"
+    val None = "none"
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
@@ -52,7 +52,7 @@ object GlobalDefaults extends Defaults {
       case _: DoubleType    => 0.0d
       case _: LongType      => 0L
       case _: StringType    => ""
-      case _: BinaryType    => Array[Byte]()
+      case _: BinaryType    => Array.empty[Byte]
       case _: DateType      => new Date(0) //linux epoch
       case _: TimestampType => new Timestamp(0)
       case _: BooleanType   => false

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/Defaults.scala
@@ -52,6 +52,7 @@ object GlobalDefaults extends Defaults {
       case _: DoubleType    => 0.0d
       case _: LongType      => 0L
       case _: StringType    => ""
+      case _: BinaryType    => Array[Byte]()
       case _: DateType      => new Date(0) //linux epoch
       case _: TimestampType => new Timestamp(0)
       case _: BooleanType   => false

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -197,7 +197,7 @@ object TypedStructField {
     }
 
     override def validate(): Seq[ValidationIssue] = {
-      ScalarFieldValidator.validate(this)
+      BinaryFieldValidator.validate(this)
     }
   }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -136,8 +136,7 @@ object TypedStructField {
   def apply(structField: StructField)(implicit defaults: Defaults): TypedStructField = {
     structField.dataType match {
       case _: StringType    => new StringTypeStructField(structField)
-      case _: BinaryType    =>
-        new BinaryTypeStructField(structField, structField.getMetadataString(MetadataKeys.Encoding))
+      case _: BinaryType    => new BinaryTypeStructField(structField)
       case _: BooleanType   => new BooleanTypeStructField(structField)
       case _: ByteType      => new ByteTypeStructField(structField)
       case _: ShortType     => new ShortTypeStructField(structField)
@@ -185,18 +184,18 @@ object TypedStructField {
   }
 
   // BinaryTypeStructField
-  final class BinaryTypeStructField private[TypedStructField](structField: StructField, encoding: Option[String])
+  final class BinaryTypeStructField private[TypedStructField](structField: StructField)
                                                              (implicit defaults: Defaults)
     extends TypedStructFieldTagged[Array[Byte]](structField) {
-
-    def normalizedEncoding: Option[String] = encoding.map(_.toLowerCase)
+    val normalizedEncoding = structField.getMetadataString(MetadataKeys.Encoding).map(_.toLowerCase)
 
     // used to convert the default value from metadata's [[MetadataKeys.DefaultValue]]
     override protected def convertString(string: String): Try[Array[Byte]] = {
       normalizedEncoding match {
         case Some(MetadataValues.Encoding.Base64) => Try(Base64.getDecoder.decode(string))
-        case Some(MetadataValues.Encoding.None) | None => Try{string.getBytes} // use as-is
-        case _ => throw new IllegalStateException(s"Unsupported encoding for Binary field ${structField.name}: '${encoding.get}'")
+        case Some(MetadataValues.Encoding.None) | None => Success(string.getBytes) // use as-is
+        case _ =>
+          Failure(new IllegalStateException(s"Unsupported encoding for Binary field ${structField.name}: '${normalizedEncoding.get}'"))
       }
     }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -162,6 +162,8 @@ object TypedStructField {
     TypedStructField(structField).asInstanceOf[ArrayTypeStructField]
   def asStructTypeStructField(structField: StructField)(implicit defaults: Defaults): StructTypeStructField =
     TypedStructField(structField).asInstanceOf[StructTypeStructField]
+  def asBinaryTypeStructField(structField: StructField)(implicit defaults: Defaults): BinaryTypeStructField =
+    TypedStructField(structField).asInstanceOf[BinaryTypeStructField]
 
   def unapply[T](typedStructField: TypedStructField): Option[StructField] = Some(typedStructField.structField)
 
@@ -187,9 +189,11 @@ object TypedStructField {
                                                              (implicit defaults: Defaults)
     extends TypedStructFieldTagged[Array[Byte]](structField) {
 
+    def normalizedEncoding: Option[String] = encoding.map(_.toLowerCase)
+
     // used to convert the default value from metadata's [[MetadataKeys.DefaultValue]]
     override protected def convertString(string: String): Try[Array[Byte]] = {
-      encoding.map(_.toLowerCase) match {
+      normalizedEncoding match {
         case Some(MetadataValues.Encoding.Base64) => Try(Base64.getDecoder.decode(string))
         case Some(MetadataValues.Encoding.None) | None => Try{string.getBytes} // use as-is
         case _ => throw new IllegalStateException(s"Unsupported encoding for Binary field ${structField.name}: '${encoding.get}'")

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -187,7 +187,7 @@ object TypedStructField {
   final class BinaryTypeStructField private[TypedStructField](structField: StructField)
                                                              (implicit defaults: Defaults)
     extends TypedStructFieldTagged[Array[Byte]](structField) {
-    val normalizedEncoding = structField.getMetadataString(MetadataKeys.Encoding).map(_.toLowerCase)
+    val normalizedEncoding: Option[String] = structField.getMetadataString(MetadataKeys.Encoding).map(_.toLowerCase)
 
     // used to convert the default value from metadata's [[MetadataKeys.DefaultValue]]
     override protected def convertString(string: String): Try[Array[Byte]] = {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -19,10 +19,9 @@ import java.sql.{Date, Timestamp}
 import java.util.Base64
 
 import org.apache.spark.sql.types._
-import org.slf4j.LoggerFactory
 import za.co.absa.enceladus.utils.implicits.StructFieldImplicits.StructFieldEnhancements
 import za.co.absa.enceladus.utils.numeric._
-import za.co.absa.enceladus.utils.schema.MetadataKeys
+import za.co.absa.enceladus.utils.schema.{MetadataKeys, MetadataValues}
 import za.co.absa.enceladus.utils.time.DateTimePattern
 import za.co.absa.enceladus.utils.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.enceladus.utils.types.parsers._
@@ -126,8 +125,6 @@ sealed abstract class TypedStructField(structField: StructField)(implicit defaul
 }
 
 object TypedStructField {
-  private val logger = LoggerFactory.getLogger(this.getClass)
-
   /**
    * This is to be the only accessible constructor for TypedStructField sub-classes
    * The point is, that sub-classes have private constructors to prevent their instantiation outside this apply
@@ -139,7 +136,8 @@ object TypedStructField {
   def apply(structField: StructField)(implicit defaults: Defaults): TypedStructField = {
     structField.dataType match {
       case _: StringType    => new StringTypeStructField(structField)
-      case _: BinaryType    => new BinaryTypeStructField(structField)
+      case _: BinaryType    =>
+        new BinaryTypeStructField(structField, structField.getMetadataString(MetadataKeys.Encoding))
       case _: BooleanType   => new BooleanTypeStructField(structField)
       case _: ByteType      => new ByteTypeStructField(structField)
       case _: ShortType     => new ShortTypeStructField(structField)
@@ -185,14 +183,17 @@ object TypedStructField {
   }
 
   // BinaryTypeStructField
-  final class BinaryTypeStructField private[TypedStructField](structField: StructField)
+  final class BinaryTypeStructField private[TypedStructField](structField: StructField, encoding: Option[String])
                                                              (implicit defaults: Defaults)
     extends TypedStructFieldTagged[Array[Byte]](structField) {
 
     // used to convert the default value from metadata's [[MetadataKeys.DefaultValue]]
     override protected def convertString(string: String): Try[Array[Byte]] = {
-      //binary's default value is always expected to be in base64
-      Try(Base64.getDecoder.decode(string))
+      encoding.map(_.toLowerCase) match {
+        case Some(MetadataValues.Encoding.Base64) => Try(Base64.getDecoder.decode(string))
+        case Some(MetadataValues.Encoding.None) | None => Try{string.getBytes} // use as-is
+        case _ => throw new IllegalStateException(s"Unsupported encoding for Binary field ${structField.name}: '${encoding.get}'")
+      }
     }
 
     override def validate(): Seq[ValidationIssue] = {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -167,10 +167,23 @@ object TypedStructField {
   }
   // StringTypeStructField
   final class StringTypeStructField private[TypedStructField](structField: StructField)
-                                                              (implicit defaults: Defaults)
+                                                             (implicit defaults: Defaults)
     extends TypedStructFieldTagged[String](structField) {
     override protected def convertString(string: String): Try[String] = {
       Success(string)
+    }
+
+    override def validate(): Seq[ValidationIssue] = {
+      ScalarFieldValidator.validate(this)
+    }
+  }
+
+  // BinaryTypeStructField
+  final class BinaryTypeStructField private[TypedStructField](structField: StructField)
+                                                             (implicit defaults: Defaults)
+    extends TypedStructFieldTagged[Array[Byte]](structField) {
+    override protected def convertString(string: String): Try[Array[Byte]] = {
+      Success(string.getBytes)
     }
 
     override def validate(): Seq[ValidationIssue] = {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
@@ -75,7 +75,7 @@ class UDFLibrary()(implicit val spark: SparkSession) {
       Base64.getDecoder.decode(stringVal)
     } match {
       case Success(decoded) => decoded
-      case Failure(_) => null
+      case Failure(_) => null //scalastyle:ignore null
     }})
 }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFLibrary.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus.utils.udf
 
-import java.util.UUID
+import java.util.Base64
 
 import org.apache.spark.sql.api.java._
 import org.apache.spark.sql.types._
@@ -24,6 +24,7 @@ import za.co.absa.enceladus.utils.error.{ErrorMessage, Mapping}
 import za.co.absa.enceladus.utils.udf.UDFNames._
 
 import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
 
 class UDFLibrary()(implicit val spark: SparkSession) {
 
@@ -67,6 +68,15 @@ class UDFLibrary()(implicit val spark: SparkSession) {
   spark.udf.register(errorColumnAppend,
                      UDFLibrary.errorColumnAppend,
                      ArrayType.apply(ErrorMessage.errorColSchema, containsNull = false))
+
+
+  spark.udf.register(binaryUnbase64,
+    {stringVal: String => Try {
+      Base64.getDecoder.decode(stringVal)
+    } match {
+      case Success(decoded) => decoded
+      case Failure(_) => null
+    }})
 }
 
 object UDFLibrary {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/udf/UDFNames.scala
@@ -28,4 +28,6 @@ object UDFNames {
   final val arrayDistinctErrors = "arrayDistinctErrors"
   final val cleanErrCol = "cleanErrCol"
   final val errorColumnAppend = "errorColumnAppend"
+
+  final val binaryUnbase64 = "binaryUnbase64"
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/SchemaPathValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/SchemaPathValidator.scala
@@ -89,7 +89,7 @@ object SchemaPathValidator {
     */
   def validateSchemaPathPrimitive(schema: StructType, fieldPath: String): Seq[ValidationIssue] = {
     validateSchemaPathType(schema, fieldPath) {
-      case _: NumericType | _: StringType | _: BooleanType | _: DateType | _: TimestampType => Seq.empty[ValidationIssue]
+      case _: NumericType | _: StringType | _: BooleanType | _: DateType | _: TimestampType | _: BinaryType => Seq.empty[ValidationIssue]
       case k => Seq(ValidationError(s"The datatype '${k.typeName}' of '$fieldPath' field is not a primitive type"))
     }
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/ValidationException.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/ValidationException.scala
@@ -15,7 +15,8 @@
 
 package za.co.absa.enceladus.utils.validation
 
-class ValidationException(val msg: String, val errors: Seq[String]) extends Exception(msg)
+class ValidationException(val msg: String, val errors: Seq[String])
+  extends Exception(s"$msg Due to errors: ${errors.mkString(",")}")
 
 object ValidationException {
   def unapply(arg: ValidationException): Option[(String, Seq[String])] = Some(arg.msg, arg.errors)

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/BinaryFieldValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/BinaryFieldValidator.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.validation.field
+
+import java.util.Base64
+
+import za.co.absa.enceladus.utils.implicits.StructFieldImplicits._
+import za.co.absa.enceladus.utils.schema.{MetadataKeys, MetadataValues}
+import za.co.absa.enceladus.utils.types.TypedStructField
+import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue}
+
+import scala.util.{Failure, Success, Try}
+
+object BinaryFieldValidator extends BinaryFieldValidator
+
+class BinaryFieldValidator extends FieldValidator {
+  private def encodingForField(field: TypedStructField): Option[String] =
+    field.structField.getMetadataString(MetadataKeys.Encoding)
+
+  private def validateDefaultValue(field: TypedStructField): Seq[ValidationIssue] = {
+    tryToValidationIssues(field.defaultValueWithGlobal)
+  }
+
+  private def validateExplicitDefaultValue(field: TypedStructField): Seq[ValidationIssue] = {
+    val defaultValue = field.structField.getMetadataString(MetadataKeys.DefaultValue)
+    val encoding: Option[String] = encodingForField(field)
+
+    (for {
+      enc <- encoding if enc == MetadataValues.Encoding.Base64
+      value <- defaultValue
+    } yield {
+      // only base64 and explicit default value could result in validation issues here:
+      Try {
+        Base64.getDecoder.decode(value)
+      } match {
+        case Success(_) => Seq.empty
+        case Failure(_) => Seq(ValidationError(s"Invalid default value $value for Base64 encoding (cannot be decoded)!"))
+      }
+    }).getOrElse(Seq.empty)
+  }
+
+  private def validateEncoding(field: TypedStructField): Seq[ValidationIssue] = {
+    val encoding: Option[String] = encodingForField(field)
+
+    encoding.map(_.toLowerCase) match {
+      case Some(MetadataValues.Encoding.Base64) | Some(MetadataValues.Encoding.None) =>
+        Seq.empty
+      case None => Seq.empty
+      case _ => Seq(ValidationError(s"Unsupported encoding for Binary field ${field.structField.name}: '${encoding.get}'"))
+    }
+  }
+
+  override def validate(field: TypedStructField): Seq[ValidationIssue] = {
+    super.validate(field) ++ validateDefaultValue(field) ++ validateExplicitDefaultValue(field) ++ validateEncoding(field)
+  }
+}

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/BinaryFieldValidator.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/field/BinaryFieldValidator.scala
@@ -37,12 +37,13 @@ object BinaryFieldValidator extends FieldValidator {
     (field.normalizedEncoding, defaultValue) match {
       case (None, Some(encodedDefault)) =>
         Seq(ValidationWarning(s"Default value of '$encodedDefault' found, but no encoding is specified. Assuming 'none'."))
-      case (Some(MetadataValues.Encoding.Base64), Some(encodedValue)) => Try {
-        Base64.getDecoder.decode(encodedValue)
-      } match {
-        case Success(_) => Seq.empty
-        case Failure(_) => Seq(ValidationError(s"Invalid default value $encodedValue for Base64 encoding (cannot be decoded)!"))
-      }
+      case (Some(MetadataValues.Encoding.Base64), Some(encodedValue)) =>
+        Try {
+          Base64.getDecoder.decode(encodedValue)
+        } match {
+          case Success(_) => Seq.empty
+          case Failure(_) => Seq(ValidationError(s"Invalid default value $encodedValue for Base64 encoding (cannot be decoded)!"))
+        }
       case _ => Seq.empty
     }
   }

--- a/utils/src/test/scala/za/co/absa/enceladus/SchemaPathValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/SchemaPathValidatorSuite.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus
 
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{StructField, _}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.validation.{SchemaPathValidator, ValidationError, ValidationIssue, ValidationWarning}
 
@@ -29,7 +29,9 @@ class SchemaPathValidatorSuite extends FunSuite {
       StructField("id", StringType),
       StructField("person", StructType(Array(
         StructField("firstName", DateType),
-        StructField("lastName", DateType)))),
+        StructField("lastName", DateType),
+        StructField("data", BinaryType)
+      ))),
       StructField("orders", ArrayType(StructType(Array(
         StructField("orderdate", DateType),
         StructField("deliverdate", DateType),
@@ -51,6 +53,7 @@ class SchemaPathValidatorSuite extends FunSuite {
     // These should pass the validation
     assert(SchemaPathValidator.validateSchemaPath(schema, "id").isEmpty)
     assert(SchemaPathValidator.validateSchemaPath(schema, "person.firstName").isEmpty)
+    assert(SchemaPathValidator.validateSchemaPath(schema, "person.data").isEmpty)
     assert(SchemaPathValidator.validateSchemaPath(schema, "orders.orderdate").isEmpty)
     assert(SchemaPathValidator.validateSchemaPath(schema, "orders.deliverdate").isEmpty)
     assert(SchemaPathValidator.validateSchemaPath(schema, "orders.payment.due").isEmpty)
@@ -97,6 +100,7 @@ class SchemaPathValidatorSuite extends FunSuite {
     // These should pass the validation
     assert(SchemaPathValidator.validateSchemaPathPrimitive(schema, "id").isEmpty)
     assert(SchemaPathValidator.validateSchemaPathPrimitive(schema, "person.firstName").isEmpty)
+    assert(SchemaPathValidator.validateSchemaPathPrimitive(schema, "person.data").isEmpty)
     assert(SchemaPathValidator.validateSchemaPathPrimitive(schema, "orders.orderdate").isEmpty)
     assert(SchemaPathValidator.validateSchemaPathPrimitive(schema, "orders.payment.due").isEmpty)
     assert(SchemaPathValidator.validateSchemaPathPrimitive(schema, "matrix.bar").isEmpty)

--- a/utils/src/test/scala/za/co/absa/enceladus/SchemaPathValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/SchemaPathValidatorSuite.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus
 
-import org.apache.spark.sql.types.{StructField, _}
+import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.validation.{SchemaPathValidator, ValidationError, ValidationIssue, ValidationWarning}
 

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/TypedStructFieldSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/TypedStructFieldSuite.scala
@@ -81,6 +81,7 @@ class TypedStructFieldSuite extends FunSuite {
       case FloatType      => (field.isInstanceOf[FloatTypeStructField], "FloatTypeStructField")
       case DoubleType     => (field.isInstanceOf[DoubleTypeStructField], "DoubleTypeStructField")
       case StringType     => (field.isInstanceOf[StringTypeStructField], "StringTypeStructField")
+      case BinaryType     => (field.isInstanceOf[BinaryTypeStructField], "BinaryTypeStructField")
       case BooleanType    => (field.isInstanceOf[BooleanTypeStructField], "BooleanTypeStructField")
       case DateType       => (field.isInstanceOf[DateTypeStructField], "DateTypeStructField")
       case TimestampType  => (field.isInstanceOf[TimestampTypeStructField], "TimestampTypeStructField")
@@ -138,6 +139,16 @@ class TypedStructFieldSuite extends FunSuite {
 
   test("String type not nullable, with default defined as null") {
     val fieldType = StringType
+    val nullable = false
+    val field = createField(fieldType, nullable, Some(null)) // scalastyle:ignore null
+    val typed = TypedStructField(field)
+    val errMsg = s"null is not a valid value for field '$fieldName'"
+    val fail = Failure(new IllegalArgumentException(errMsg))
+    checkField(typed, fieldType, fail, fail, nullable, Seq(ValidationError(errMsg)))
+  }
+
+  test("Binary type not nullable, with default defined as null") {
+    val fieldType = BinaryType
     val nullable = false
     val field = createField(fieldType, nullable, Some(null)) // scalastyle:ignore null
     val typed = TypedStructField(field)

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/TypedStructFieldSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/TypedStructFieldSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.types.TypedStructField._
-import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue}
+import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationIssue, ValidationWarning}
 
 import scala.util.{Failure, Success, Try}
 
@@ -153,8 +153,9 @@ class TypedStructFieldSuite extends FunSuite {
     val field = createField(fieldType, nullable, Some(null)) // scalastyle:ignore null
     val typed = TypedStructField(field)
     val errMsg = s"null is not a valid value for field '$fieldName'"
+    val warnMsg ="Default value of 'null' found, but no encoding is specified. Assuming 'none'."
     val fail = Failure(new IllegalArgumentException(errMsg))
-    checkField(typed, fieldType, fail, fail, nullable, Seq(ValidationError(errMsg)))
+    checkField(typed, fieldType, fail, fail, nullable, Seq(ValidationError(errMsg), ValidationWarning(warnMsg)))
   }
 
   test("Byte type not nullable, with default defined as not not-numeric string") {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/BinaryValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/BinaryValidatorSuite.scala
@@ -19,7 +19,7 @@ import org.apache.spark.sql.types.{BinaryType, MetadataBuilder, StructField}
 import org.scalatest.FunSuite
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
-import za.co.absa.enceladus.utils.validation.ValidationError
+import za.co.absa.enceladus.utils.validation.{ValidationError, ValidationWarning}
 
 class BinaryValidatorSuite extends FunSuite {
   private implicit val defaults: Defaults = GlobalDefaults
@@ -37,9 +37,12 @@ class BinaryValidatorSuite extends FunSuite {
   }
 
   test("field with explicit default or explicit non-base64 encoding validates") {
-    assert(BinaryFieldValidator.validate(field(defaultValue = Some("abc"))).isEmpty)
     assert(BinaryFieldValidator.validate(field(defaultValue = Some("abc"), encoding = Some("none"))).isEmpty)
     assert(BinaryFieldValidator.validate(field(encoding = Some("none"))).isEmpty)
+
+    assert(BinaryFieldValidator.validate(field(defaultValue = Some("abc"))) == Seq(
+      ValidationWarning("Default value of 'abc' found, but no encoding is specified. Assuming 'none'.")
+    ))
   }
 
   test("field with base64 encoding and with no or correct defaultValue validates") {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/BinaryValidatorSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/field/BinaryValidatorSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.validation.field
+
+import org.apache.spark.sql.types.{BinaryType, MetadataBuilder, StructField}
+import org.scalatest.FunSuite
+import za.co.absa.enceladus.utils.schema.MetadataKeys
+import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
+import za.co.absa.enceladus.utils.validation.ValidationError
+
+class BinaryValidatorSuite extends FunSuite {
+  private implicit val defaults: Defaults = GlobalDefaults
+
+  private def field(defaultValue: Option[String] = None, encoding: Option[String] = None, nullable: Boolean = true): TypedStructField = {
+    val base = new MetadataBuilder()
+    val builder2 = defaultValue.map(base.putString(MetadataKeys.DefaultValue, _)).getOrElse(base)
+    val builder3 = encoding.map(builder2.putString(MetadataKeys.Encoding, _)).getOrElse(builder2)
+    val result = StructField("test_field", BinaryType, nullable, builder3.build())
+    TypedStructField(result)
+  }
+
+  test("field with no meta validates") {
+    assert(BinaryFieldValidator.validate(field()).isEmpty)
+  }
+
+  test("field with explicit default or explicit non-base64 encoding validates") {
+    assert(BinaryFieldValidator.validate(field(defaultValue = Some("abc"))).isEmpty)
+    assert(BinaryFieldValidator.validate(field(defaultValue = Some("abc"), encoding = Some("none"))).isEmpty)
+    assert(BinaryFieldValidator.validate(field(encoding = Some("none"))).isEmpty)
+  }
+
+  test("field with base64 encoding and with no or correct defaultValue validates") {
+    assert(BinaryFieldValidator.validate(field(encoding = Some("base64"))).isEmpty)
+    // base64("test") => "dGVzdA=="
+    assert(BinaryFieldValidator.validate(field(defaultValue = Some("dGVzdA=="), encoding = Some("base64"))).isEmpty)
+  }
+
+  test("field with base64 encoding and non-base64 default has issues ") {
+    val result = BinaryFieldValidator.validate(field(defaultValue = Some("bogus!@#"), encoding = Some("base64")))
+    assert(result.contains(ValidationError("'bogus!@#' cannot be cast to binary")))
+    assert(result.contains(ValidationError("Invalid default value bogus!@# for Base64 encoding (cannot be decoded)!")))
+  }
+
+}


### PR DESCRIPTION
`BinaryType` support added for Enceladus
 - encoding in metadata added, supported values are `base64` and `none`. No encoding behaves like `none` (taking strings as-is and just casting them to binary)
 - default value follows the encoding set (and is validated to be valid base64 string if base64 encoding is used)
 - test cases extended.
 - Standardization run ok with a custom binary field in the input (as parquet)
 - Conformance UI enriched by allowing `binary` for the _CastingConformanceRule_.
![castingConformanceBinary](https://user-images.githubusercontent.com/4457378/83437738-8be31a00-a440-11ea-8798-5e0ee99b636b.png)

## Test runs
### Binary <-> String
 - Tested Conformance with such a rule to cast "binary <-> string": successfully
![binary-string-vice-versa](https://user-images.githubusercontent.com/4457378/83437792-a9b07f00-a440-11ea-8ae4-4d7c2d9f73d0.png)

### default value from metadata is used
 - default can be provided in the metadata (always encoded as base64):
![default-meta-for-binary1](https://user-images.githubusercontent.com/4457378/83630809-b944da80-a59c-11ea-8c93-f80da46d2e00.png)
 - having input for Standardziation with a `null`-containing binary field and a schema that disallows null for this column in standardization:
```json
{
      "name": "binary1",
      "type": "binary",
      "nullable": false,
      "metadata": {"default" : "dGVzdA==", "encoding":"base64"}
    }
```
(`unbase64("dGVzdA==")` yields `test`)

![std-input-binary1-null](https://user-images.githubusercontent.com/4457378/83630931-f27d4a80-a59c-11ea-94a8-67898b059bf6.png)
 - correctly resulted in the default being applied
![binary-default-applied-in-std](https://user-images.githubusercontent.com/4457378/83631098-4425d500-a59d-11ea-8c53-b57610b3c21a.png)
