### PR TITLE
#1382 Change event-time based enceladus_info_date population strategy.

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -21,6 +21,7 @@ import java.util.Date
 import org.apache.commons.configuration2.Configuration
 import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.DateType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.enceladus.common.Constants._
@@ -64,8 +65,8 @@ class HyperConformance (implicit cmd: ConfCmdConfig,
     val infoDateColumn = infoDateFactory.getInfoDateColumn(rawDf)
 
     val conformedDf = DynamicInterpreter.interpret(conformance, rawDf)
-      .withColumnIfDoesNotExist(InfoDateColumn, infoDateColumn)
-      .withColumnIfDoesNotExist(InfoDateColumnString, date_format(infoDateColumn, "yyyy-MM-dd"))
+      .withColumnIfDoesNotExist(InfoDateColumn, coalesce(infoDateColumn, current_timestamp().cast(DateType)))
+      .withColumnIfDoesNotExist(InfoDateColumnString, coalesce(date_format(infoDateColumn,"yyyy-MM-dd"), lit("")))
       .withColumnIfDoesNotExist(InfoVersionColumn, lit(reportVersion))
     conformedDf
   }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -65,7 +65,7 @@ class HyperConformance (implicit cmd: ConfCmdConfig,
     val infoDateColumn = infoDateFactory.getInfoDateColumn(rawDf)
 
     val conformedDf = DynamicInterpreter.interpret(conformance, rawDf)
-      .withColumnIfDoesNotExist(InfoDateColumn, coalesce(infoDateColumn, current_timestamp().cast(DateType)))
+      .withColumnIfDoesNotExist(InfoDateColumn, coalesce(infoDateColumn, current_date()))
       .withColumnIfDoesNotExist(InfoDateColumnString, coalesce(date_format(infoDateColumn,"yyyy-MM-dd"), lit("")))
       .withColumnIfDoesNotExist(InfoVersionColumn, lit(reportVersion))
     conformedDf

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactory.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/streaming/InfoDateFactory.scala
@@ -45,7 +45,7 @@ class InfoDateLiteralFactory(infoDate: String) extends InfoDateFactory {
 class InfoDateFromColumnFactory(columnName: String, pattern: String) extends InfoDateFactory {
   override def getInfoDateColumn(df: DataFrame): Column = {
     val dt = SchemaUtils.getFieldType(columnName, df.schema)
-    val eventDate = dt match {
+    dt match {
       case Some(TimestampType) =>
         col(columnName).cast(DateType)
       case Some(DateType) =>
@@ -57,7 +57,6 @@ class InfoDateFromColumnFactory(columnName: String, pattern: String) extends Inf
       case None =>
         throw new IllegalArgumentException(s"The specified event time column does not exist: $columnName")
     }
-    coalesce(eventDate, current_timestamp().cast(DateType))
   }
 }
 


### PR DESCRIPTION
* So that we can identify records in the published topic where casting
  of event time column to date has failed. 'enceladus_info_date' will
  be empty in this case.