### PR TITLE
1409 Fix fixed width format

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -298,11 +298,14 @@ object StandardizationJob {
                                dao: MenasDAO): DataFrame = {
     val numberOfColumns = schema.fields.length
     val dfReaderConfigured = getFormatSpecificReader(cmd, dataset, numberOfColumns)
-    val dfWithSchema = (if (!cmd.rawFormat.equalsIgnoreCase("parquet")
+    val dfWithSchema = (if (cmd.rawFormat.equalsIgnoreCase("fixed-width")) {
+      val inputSchema = PlainSchemaGenerator.generateInputSchema(schema)
+      dfReaderConfigured.schema(inputSchema)
+    } else if (!cmd.rawFormat.equalsIgnoreCase("parquet")
       && !cmd.rawFormat.equalsIgnoreCase("cobol")) {
       // SparkUtils.setUniqueColumnNameOfCorruptRecord is called even if result is not used to avoid conflict
       val columnNameOfCorruptRecord = SparkUtils.setUniqueColumnNameOfCorruptRecord(spark, schema)
-      val optColumnNameOfCorruptRecord = if (cmd.failOnInputNotPerSchema) {
+      val optColumnNameOfCorruptRecord: Option[String] = if (cmd.failOnInputNotPerSchema) {
         None
       } else {
         Option(columnNameOfCorruptRecord)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -298,24 +298,29 @@ object StandardizationJob {
                                dao: MenasDAO): DataFrame = {
     val numberOfColumns = schema.fields.length
     val dfReaderConfigured = getFormatSpecificReader(cmd, dataset, numberOfColumns)
-    val dfWithSchema = (if (cmd.rawFormat.equalsIgnoreCase("fixed-width")) {
-      val inputSchema = PlainSchemaGenerator.generateInputSchema(schema)
-      dfReaderConfigured.schema(inputSchema)
-    } else if (!cmd.rawFormat.equalsIgnoreCase("parquet")
-      && !cmd.rawFormat.equalsIgnoreCase("cobol")) {
-      // SparkUtils.setUniqueColumnNameOfCorruptRecord is called even if result is not used to avoid conflict
-      val columnNameOfCorruptRecord = SparkUtils.setUniqueColumnNameOfCorruptRecord(spark, schema)
-      val optColumnNameOfCorruptRecord: Option[String] = if (cmd.failOnInputNotPerSchema) {
-        None
-      } else {
-        Option(columnNameOfCorruptRecord)
-      }
-      val inputSchema = PlainSchemaGenerator.generateInputSchema(schema, optColumnNameOfCorruptRecord)
-      dfReaderConfigured.schema(inputSchema)
-    } else {
-      dfReaderConfigured
-    }).load(s"$path/*")
+
+    val readerWithOptSchema = cmd.rawFormat.toLowerCase() match {
+      case "parquet" | "cobol" =>
+        dfReaderConfigured
+      case _ =>
+        val optColumnNameOfCorruptRecord = getColumnNameOfCorruptRecord(schema, cmd)
+        val inputSchema = PlainSchemaGenerator.generateInputSchema(schema, optColumnNameOfCorruptRecord)
+        dfReaderConfigured.schema(inputSchema)
+    }
+
+    val dfWithSchema = readerWithOptSchema.load(s"$path/*")
     ensureSplittable(dfWithSchema, path, schema)
+  }
+
+  private def getColumnNameOfCorruptRecord(schema: StructType, cmd: StdCmdConfig)
+                                          (implicit spark: SparkSession): Option[String] = {
+    // SparkUtils.setUniqueColumnNameOfCorruptRecord is called even if result is not used to avoid conflict
+    val columnNameOfCorruptRecord = SparkUtils.setUniqueColumnNameOfCorruptRecord(spark, schema)
+    if (cmd.rawFormat.equalsIgnoreCase("fixed-width")  || cmd.failOnInputNotPerSchema) {
+      None
+    } else {
+      Option(columnNameOfCorruptRecord)
+    }
   }
 
   //scalastyle:off parameter.number

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/PlainSchemaGenerator.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/PlainSchemaGenerator.scala
@@ -31,7 +31,7 @@ object PlainSchemaGenerator {
       // If the meta data value sourcecolumn is set override the field name
       val fieldName = field.getMetadataString(MetadataKeys.SourceColumn).getOrElse(field.name)
       val dataType = inputSchemaAsStringTypes(field.dataType)
-      StructField(fieldName, dataType, nullable = true, field.metadata) //metadata not needed to be transferred
+      StructField(fieldName, dataType, nullable = true, field.metadata)
     }
   }
 
@@ -47,6 +47,7 @@ object PlainSchemaGenerator {
     val inputSchema = structTypeFieldsConversion(structType.fields)
     val corruptRecordField = corruptRecordFieldName.map(StructField(_, StringType)).toArray
     StructType(inputSchema ++ corruptRecordField)
+
   }
 
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/PlainSchemaGenerator.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/PlainSchemaGenerator.scala
@@ -31,7 +31,7 @@ object PlainSchemaGenerator {
       // If the meta data value sourcecolumn is set override the field name
       val fieldName = field.getMetadataString(MetadataKeys.SourceColumn).getOrElse(field.name)
       val dataType = inputSchemaAsStringTypes(field.dataType)
-      StructField(fieldName, dataType, nullable = true) //metadata not needed to be transferred
+      StructField(fieldName, dataType, nullable = true, field.metadata) //metadata not needed to be transferred
     }
   }
 

--- a/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_data.txt
+++ b/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_data.txt
@@ -1,0 +1,6 @@
+1  Georgina        Richardt
+2  Seamus             Klaes
+3  Griff            Leaning
+4  Klarrisa           Corps
+5  Cornie         Hewertson
+6  Maybeeeeeeeeeee        a

--- a/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_expected_non_trimmed.txt
+++ b/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_expected_non_trimmed.txt
@@ -1,0 +1,12 @@
++---+---------------+---------+--------------------------------------------------------------------------+
+|id |first_name     |last_name|errCol                                                                    |
++---+---------------+---------+--------------------------------------------------------------------------+
+|0  |Georgina       | Richardt|[[stdCastError, E00000, Standardization Error - Type cast, id, [1  ], []]]|
+|0  |Seamus         |    Klaes|[[stdCastError, E00000, Standardization Error - Type cast, id, [2  ], []]]|
+|0  |Griff          |  Leaning|[[stdCastError, E00000, Standardization Error - Type cast, id, [3  ], []]]|
+|0  |Klarrisa       |    Corps|[[stdCastError, E00000, Standardization Error - Type cast, id, [4  ], []]]|
+|0  |Cornie         |Hewertson|[[stdCastError, E00000, Standardization Error - Type cast, id, [5  ], []]]|
+|0  |Maybeeeeeeeeeee|        a|[[stdCastError, E00000, Standardization Error - Type cast, id, [6  ], []]]|
++---+---------------+---------+--------------------------------------------------------------------------+
+
+

--- a/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_expected_trimmed.txt
+++ b/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_expected_trimmed.txt
@@ -1,0 +1,12 @@
++---+---------------+---------+------+
+|id |first_name     |last_name|errCol|
++---+---------------+---------+------+
+|1  |Georgina       |Richardt |[]    |
+|2  |Seamus         |Klaes    |[]    |
+|3  |Griff          |Leaning  |[]    |
+|4  |Klarrisa       |Corps    |[]    |
+|5  |Cornie         |Hewertson|[]    |
+|6  |Maybeeeeeeeeeee|a        |[]    |
++---+---------------+---------+------+
+
+

--- a/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_schema.json
+++ b/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_schema.json
@@ -1,0 +1,19 @@
+{
+  "type" : "struct",
+  "fields" : [ {
+    "name" : "id",
+    "type" : "long",
+    "nullable" : false,
+    "metadata" : { "width" : "3" }
+  }, {
+    "name" : "first_name",
+    "type" : "string",
+    "nullable" : true,
+    "metadata" : { "width" : "15" }
+  }, {
+    "name" : "last_name",
+    "type" : "string",
+    "nullable" : false,
+    "metadata" : { "width" : "9" }
+  } ]
+}

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
@@ -1,0 +1,77 @@
+package za.co.absa.enceladus.standardization
+
+import org.apache.spark.sql.types.{DataType, StructType}
+import org.scalatest.FunSuite
+import org.scalatest.mockito.MockitoSugar
+import za.co.absa.enceladus.dao.MenasDAO
+import za.co.absa.enceladus.model.Dataset
+import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
+import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
+import za.co.absa.enceladus.utils.fs.FileReader
+import za.co.absa.enceladus.utils.testUtils.SparkTestBase
+import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
+import za.co.absa.enceladus.utils.udf.UDFLibrary
+
+class StandardizationFixedWidthSuite extends FunSuite with SparkTestBase with MockitoSugar{
+  private implicit val udfLibrary:UDFLibrary = new UDFLibrary()
+
+  test("Reading data from FixedWidth input") {
+
+    implicit val dao: MenasDAO = mock[MenasDAO]
+
+    val args = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
+      "--menas-auth-keytab src/test/resources/user.keytab.example " +
+      "--raw-format fixed-width").split(" ")
+
+    val dataSet = Dataset("Foo", 1, None, "", "", "SpecialChars", 1, conformance = Nil)
+    val cmd = StdCmdConfig.getCmdLineArguments(args)
+
+    val fixedWidthReader = StandardizationJob.getFormatSpecificReader(cmd, dataSet)
+
+    val baseSchema: StructType = DataType.fromJson(
+      FileReader.readFileAsString("src/test/resources/data/standardization_fixed_width_suite_schema.json")
+    ).asInstanceOf[StructType]
+    val inputSchema = PlainSchemaGenerator.generateInputSchema(baseSchema)
+    val reader = fixedWidthReader.schema(inputSchema)
+
+    val sourceDF = reader.load("src/test/resources/data/standardization_fixed_width_suite_data.txt")
+
+    val expected = FileReader.readFileAsString("src/test/resources/data/standardization_fixed_width_suite_expected_non_trimmed.txt")
+      .replace("\r\n", "\n")
+
+    val destDF = StandardizationInterpreter.standardize(sourceDF, baseSchema, cmd.rawFormat)
+
+    val actual = destDF.dataAsString(truncate = false)
+    assert(actual == expected)
+  }
+
+  test("Reading data from FixedWidth input trimmed") {
+
+    implicit val dao: MenasDAO = mock[MenasDAO]
+
+    val args = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
+      "--menas-auth-keytab src/test/resources/user.keytab.example " +
+      "--raw-format fixed-width --trimValues true").split(" ")
+
+    val dataSet = Dataset("Foo", 1, None, "", "", "SpecialChars", 1, conformance = Nil)
+    val cmd = StdCmdConfig.getCmdLineArguments(args)
+
+    val fixedWidthReader = StandardizationJob.getFormatSpecificReader(cmd, dataSet)
+
+    val baseSchema: StructType = DataType.fromJson(
+      FileReader.readFileAsString("src/test/resources/data/standardization_fixed_width_suite_schema.json")
+    ).asInstanceOf[StructType]
+    val inputSchema = PlainSchemaGenerator.generateInputSchema(baseSchema)
+    val reader = fixedWidthReader.schema(inputSchema)
+
+    val sourceDF = reader.load("src/test/resources/data/standardization_fixed_width_suite_data.txt")
+
+    val expected = FileReader.readFileAsString("src/test/resources/data/standardization_fixed_width_suite_expected_trimmed.txt")
+      .replace("\r\n", "\n")
+
+    val destDF = StandardizationInterpreter.standardize(sourceDF, baseSchema, cmd.rawFormat)
+
+    val actual = destDF.dataAsString(truncate = false)
+    assert(actual == expected)
+  }
+}

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
@@ -15,22 +15,23 @@ import za.co.absa.enceladus.utils.udf.UDFLibrary
 class StandardizationFixedWidthSuite extends FunSuite with SparkTestBase with MockitoSugar{
   private implicit val udfLibrary:UDFLibrary = new UDFLibrary()
 
+  private val argsBase = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
+    "--menas-auth-keytab src/test/resources/user.keytab.example " +
+    "--raw-format fixed-width").split(" ")
+
+  private implicit val dao: MenasDAO = mock[MenasDAO]
+
+  private val dataSet = Dataset("Foo", 1, None, "", "", "SpecialChars", 1, conformance = Nil)
+
+  private val baseSchema: StructType = DataType.fromJson(
+    FileReader.readFileAsString("src/test/resources/data/standardization_fixed_width_suite_schema.json")
+  ).asInstanceOf[StructType]
+
   test("Reading data from FixedWidth input") {
-
-    implicit val dao: MenasDAO = mock[MenasDAO]
-
-    val args = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
-      "--menas-auth-keytab src/test/resources/user.keytab.example " +
-      "--raw-format fixed-width").split(" ")
-
-    val dataSet = Dataset("Foo", 1, None, "", "", "SpecialChars", 1, conformance = Nil)
-    val cmd = StdCmdConfig.getCmdLineArguments(args)
+    val cmd = StdCmdConfig.getCmdLineArguments(argsBase)
 
     val fixedWidthReader = StandardizationJob.getFormatSpecificReader(cmd, dataSet)
 
-    val baseSchema: StructType = DataType.fromJson(
-      FileReader.readFileAsString("src/test/resources/data/standardization_fixed_width_suite_schema.json")
-    ).asInstanceOf[StructType]
     val inputSchema = PlainSchemaGenerator.generateInputSchema(baseSchema)
     val reader = fixedWidthReader.schema(inputSchema)
 
@@ -46,21 +47,10 @@ class StandardizationFixedWidthSuite extends FunSuite with SparkTestBase with Mo
   }
 
   test("Reading data from FixedWidth input trimmed") {
-
-    implicit val dao: MenasDAO = mock[MenasDAO]
-
-    val args = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
-      "--menas-auth-keytab src/test/resources/user.keytab.example " +
-      "--raw-format fixed-width --trimValues true").split(" ")
-
-    val dataSet = Dataset("Foo", 1, None, "", "", "SpecialChars", 1, conformance = Nil)
-    val cmd = StdCmdConfig.getCmdLineArguments(args)
+    val cmd = StdCmdConfig.getCmdLineArguments(argsBase ++ Array("--trimValues", "true"))
 
     val fixedWidthReader = StandardizationJob.getFormatSpecificReader(cmd, dataSet)
 
-    val baseSchema: StructType = DataType.fromJson(
-      FileReader.readFileAsString("src/test/resources/data/standardization_fixed_width_suite_schema.json")
-    ).asInstanceOf[StructType]
     val inputSchema = PlainSchemaGenerator.generateInputSchema(baseSchema)
     val reader = fixedWidthReader.schema(inputSchema)
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/PlainSchemaGeneratorSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/PlainSchemaGeneratorSuite.scala
@@ -37,14 +37,14 @@ class PlainSchemaGeneratorSuite extends FunSuite with SparkTestBase {
 
   private val expectedSchemaSeq = Seq(
     StructField("a", StringType, nullable = true),
-    StructField("b", StringType, nullable = true),
-    StructField("override_c", StringType, nullable = true),
+    StructField("b", StringType, nullable = true, new MetadataBuilder().putString("meta", "data").build),
+    StructField("override_c", StringType, nullable = true, new MetadataBuilder().putString("sourcecolumn", "override_c").build),
     StructField("d", ArrayType(StructType(Seq(
       StructField("e", StructType(Seq(
         StructField("f", ArrayType(StructType(Seq(
           StructField("g", StringType, nullable = true),
-          StructField("h", StringType, nullable = true),
-          StructField("override_i", StringType, nullable = true)
+          StructField("h", StringType, nullable = true, new MetadataBuilder().putString("meta", "data").build),
+          StructField("override_i", StringType, nullable = true, new MetadataBuilder().putString("sourcecolumn", "override_i").build)
         ))))
       )))
     ))))


### PR DESCRIPTION
This PR should fix the previously working `fixed-width` format. It is just adding metadata to a stringified schema and adding `columnNameOfCorruptRecord`. Current `fixed-width` does not support that, it can be added when we revive the library.

NB: The expected files have 2 extra new lines because `.show` generates 2 extra newlines.

Closes #1409

RN Comment: Fixed-width format works again.