### PR TITLE
1474 Fix conf not logging at the start

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
@@ -56,10 +56,7 @@ trait CommonJobExecution {
 
   protected val log: Logger = LoggerFactory.getLogger(this.getClass)
   protected val conf: Config = ConfigFactory.load()
-
-  private val confReader: ConfigReader = new ConfigReader(conf)
-  confReader.logEffectiveConfigProps(Constants.ConfigKeysToRedact)
-
+  protected val confReader: ConfigReader = new ConfigReader(conf)
   protected val menasBaseUrls: List[String] = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
 
   protected def obtainSparkSession[T](jobName: String)(implicit cmd: JobConfigParser[T]): SparkSession = {
@@ -84,6 +81,8 @@ trait CommonJobExecution {
                               cmd: JobConfigParser[T],
                               fsUtils: FileSystemVersionUtils,
                               spark: SparkSession): PreparationResult = {
+    confReader.logEffectiveConfigProps(Constants.ConfigKeysToRedact)
+
     dao.authenticate()
     val dataset = dao.getDataset(cmd.datasetName, cmd.datasetVersion)
     val reportVersion = getReportVersion(cmd, dataset)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
@@ -56,7 +56,6 @@ trait CommonJobExecution {
 
   protected val log: Logger = LoggerFactory.getLogger(this.getClass)
   protected val conf: Config = ConfigFactory.load()
-  protected val confReader: ConfigReader = new ConfigReader(conf)
   protected val menasBaseUrls: List[String] = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
 
   protected def obtainSparkSession[T](jobName: String)(implicit cmd: JobConfigParser[T]): SparkSession = {
@@ -81,6 +80,7 @@ trait CommonJobExecution {
                               cmd: JobConfigParser[T],
                               fsUtils: FileSystemVersionUtils,
                               spark: SparkSession): PreparationResult = {
+    val confReader: ConfigReader = new ConfigReader(conf)
     confReader.logEffectiveConfigProps(Constants.ConfigKeysToRedact)
 
     dao.authenticate()

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
@@ -33,7 +33,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.rest.MenasConnectionStringParser
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.plugins.builtin.errorsender.params.ErrorSenderPluginParams
-import za.co.absa.enceladus.utils.config.SecureConfig
+import za.co.absa.enceladus.utils.config.{ConfigReader, SecureConfig}
 import za.co.absa.enceladus.utils.fs.FileSystemVersionUtils
 import za.co.absa.enceladus.utils.general.ProjectMetadataTools
 import za.co.absa.enceladus.utils.modules.SourcePhase
@@ -56,6 +56,10 @@ trait CommonJobExecution {
 
   protected val log: Logger = LoggerFactory.getLogger(this.getClass)
   protected val conf: Config = ConfigFactory.load()
+
+  private val confReader: ConfigReader = new ConfigReader(conf)
+  confReader.logEffectiveConfigProps(Constants.ConfigKeysToRedact)
+
   protected val menasBaseUrls: List[String] = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
 
   protected def obtainSparkSession[T](jobName: String)(implicit cmd: JobConfigParser[T]): SparkSession = {


### PR DESCRIPTION
Returns the `logEffectiveConfigProps` 

Fixes #1474 

RN: Fixes properties logging at the start of each spark job