### PR TITLE
#1393 Add new fixed width project

### DIFF
--- a/spark-jobs/pom.xml
+++ b/spark-jobs/pom.xml
@@ -56,8 +56,8 @@
         </dependency>
         <dependency>
             <groupId>za.co.absa</groupId>
-            <artifactId>enceladus-fixedWidth</artifactId>
-            <version>1.7.0</version>
+            <artifactId>fixed-width_${scala.compat.version}</artifactId>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>za.co.absa.cobrix</groupId>

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationPropertiesProvider.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationPropertiesProvider.scala
@@ -109,7 +109,12 @@ class StandardizationPropertiesProvider {
 
   private def getFixedWidthOptions[T](cmd: StandardizationConfigParser[T]): HashMap[String, Option[RawFormatParameter]] = {
     if (cmd.rawFormat.equalsIgnoreCase("fixed-width")) {
-      HashMap("trimValues" -> cmd.fixedWidthTrimValues.map(BooleanParameter))
+      HashMap(
+        "trimValues" -> cmd.fixedWidthTrimValues.map(BooleanParameter),
+        "treatEmptyValuesAsNulls" -> cmd.fixedWidthTreatEmptyValuesAsNulls.map(BooleanParameter),
+        "nullValue" -> cmd.fixedWidthNullValue.map(StringParameter),
+        "charset" -> cmd.charset.map(StringParameter)
+      )
     } else {
       HashMap()
     }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/config/StandardizationConfig.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/config/StandardizationConfig.scala
@@ -78,7 +78,9 @@ case class StandardizationConfig(rawFormat: String = "xml",
   override def withPerformanceMetricsFile(value: Option[String]): StandardizationConfig = copy(performanceMetricsFile = value)
   override def withFolderPrefix(value: Option[String]): StandardizationConfig = copy(folderPrefix = value)
   override def withPersistStorageLevel(value: Option[StorageLevel]): StandardizationConfig = copy(persistStorageLevel = value)
-  override def withFixedWidthTreatEmptyValuesAsNulls(value: Option[Boolean]): StandardizationConfig = copy(fixedWidthTreatEmptyValuesAsNulls = value)
+  override def withFixedWidthTreatEmptyValuesAsNulls(value: Option[Boolean]): StandardizationConfig = {
+    copy(fixedWidthTreatEmptyValuesAsNulls = value)
+  }
   override def withFixedWidthNullValue(value: Option[String]): StandardizationConfig = copy(fixedWidthNullValue = value)
 }
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/config/StandardizationConfig.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/config/StandardizationConfig.scala
@@ -37,7 +37,7 @@ case class StandardizationConfig(rawFormat: String = "xml",
                                  csvQuote: Option[String] = None,
                                  csvEscape: Option[String] = None,
                                  cobolOptions: Option[CobolOptions] = None,
-                                 fixedWidthTrimValues: Option[Boolean] = Some(false),
+                                 fixedWidthTrimValues: Option[Boolean] = None,
                                  rawPathOverride: Option[String] = None,
                                  failOnInputNotPerSchema: Boolean = false,
                                  datasetName: String = "",
@@ -49,7 +49,9 @@ case class StandardizationConfig(rawFormat: String = "xml",
                                  folderPrefix: Option[String] = None,
                                  persistStorageLevel: Option[StorageLevel] = None,
                                  credsFile: Option[String] = None,
-                                 keytabFile: Option[String] = None)
+                                 keytabFile: Option[String] = None,
+                                 fixedWidthTreatEmptyValuesAsNulls: Option[Boolean] = None,
+                                 fixedWidthNullValue: Option[String] = None)
   extends StandardizationConfigParser[StandardizationConfig]{
   override def withRawFormat(value: String): StandardizationConfig = copy(rawFormat = value)
   override def withCharset(value: Option[String]): StandardizationConfig = copy(charset = value)
@@ -76,6 +78,8 @@ case class StandardizationConfig(rawFormat: String = "xml",
   override def withPerformanceMetricsFile(value: Option[String]): StandardizationConfig = copy(performanceMetricsFile = value)
   override def withFolderPrefix(value: Option[String]): StandardizationConfig = copy(folderPrefix = value)
   override def withPersistStorageLevel(value: Option[StorageLevel]): StandardizationConfig = copy(persistStorageLevel = value)
+  override def withFixedWidthTreatEmptyValuesAsNulls(value: Option[Boolean]): StandardizationConfig = copy(fixedWidthTreatEmptyValuesAsNulls = value)
+  override def withFixedWidthNullValue(value: Option[String]): StandardizationConfig = copy(fixedWidthNullValue = value)
 }
 
 object StandardizationConfig {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/config/StandardizationConformanceConfig.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/config/StandardizationConformanceConfig.scala
@@ -61,10 +61,12 @@ case class StandardizationConformanceConfig(datasetName: String = "",
 
   override def withPublishPathOverride(value: Option[String]): StandardizationConformanceConfig = copy(publishPathOverride = value)
   override def withExperimentalMappingRule(value: Option[Boolean]): StandardizationConformanceConfig = copy(experimentalMappingRule = value)
-  override def withIsCatalystWorkaroundEnabled(value: Option[Boolean]): StandardizationConformanceConfig = copy(isCatalystWorkaroundEnabled = value) //scalastyle:ignore
-  //better readability than multiline
-  override def withAutocleanStandardizedFolder(value: Option[Boolean]): StandardizationConformanceConfig = copy(autocleanStandardizedFolder = value) //scalastyle:ignore
-  //better readability than multiline
+  override def withIsCatalystWorkaroundEnabled(value: Option[Boolean]): StandardizationConformanceConfig = {
+    copy(isCatalystWorkaroundEnabled = value) //scalastyle:ignore
+  }
+  override def withAutocleanStandardizedFolder(value: Option[Boolean]): StandardizationConformanceConfig = {
+    copy(autocleanStandardizedFolder = value) //scalastyle:ignore
+  }
   override def withDatasetName(value: String): StandardizationConformanceConfig = copy(datasetName = value)
   override def withDatasetVersion(value: Int): StandardizationConformanceConfig = copy(datasetVersion = value)
   override def withReportDate(value: String): StandardizationConformanceConfig = copy(reportDate = value)
@@ -84,7 +86,9 @@ case class StandardizationConformanceConfig(datasetName: String = "",
   override def withFixedWidthTrimValues(value: Option[Boolean]): StandardizationConformanceConfig = copy(fixedWidthTrimValues = value)
   override def withRawPathOverride(value: Option[String]): StandardizationConformanceConfig = copy(rawPathOverride = value)
   override def withFailOnInputNotPerSchema(value: Boolean): StandardizationConformanceConfig = copy(failOnInputNotPerSchema = value)
-  override def withFixedWidthTreatEmptyValuesAsNulls(value: Option[Boolean]): StandardizationConformanceConfig = copy(fixedWidthTreatEmptyValuesAsNulls = value)
+  override def withFixedWidthTreatEmptyValuesAsNulls(value: Option[Boolean]): StandardizationConformanceConfig = {
+    copy(fixedWidthTreatEmptyValuesAsNulls = value)
+  }
   override def withFixedWidthNullValue(value: Option[String]): StandardizationConformanceConfig = copy(fixedWidthNullValue = value)
 
   override def withCredsFile(value: Option[String], menasCredentialsFactory: MenasCredentialsFactory): StandardizationConformanceConfig = {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/config/StandardizationConformanceConfig.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/config/StandardizationConformanceConfig.scala
@@ -48,9 +48,11 @@ case class StandardizationConformanceConfig(datasetName: String = "",
                                             csvQuote: Option[String] = None,
                                             csvEscape: Option[String] = None,
                                             cobolOptions: Option[CobolOptions] = None,
-                                            fixedWidthTrimValues: Option[Boolean] = Some(false),
+                                            fixedWidthTrimValues: Option[Boolean] = None,
                                             rawPathOverride: Option[String] = None,
                                             failOnInputNotPerSchema: Boolean = false,
+                                            fixedWidthTreatEmptyValuesAsNulls: Option[Boolean] = None,
+                                            fixedWidthNullValue: Option[String] = None,
 
                                             credsFile: Option[String] = None,
                                             keytabFile: Option[String] = None)
@@ -82,6 +84,8 @@ case class StandardizationConformanceConfig(datasetName: String = "",
   override def withFixedWidthTrimValues(value: Option[Boolean]): StandardizationConformanceConfig = copy(fixedWidthTrimValues = value)
   override def withRawPathOverride(value: Option[String]): StandardizationConformanceConfig = copy(rawPathOverride = value)
   override def withFailOnInputNotPerSchema(value: Boolean): StandardizationConformanceConfig = copy(failOnInputNotPerSchema = value)
+  override def withFixedWidthTreatEmptyValuesAsNulls(value: Option[Boolean]): StandardizationConformanceConfig = copy(fixedWidthTreatEmptyValuesAsNulls = value)
+  override def withFixedWidthNullValue(value: Option[String]): StandardizationConformanceConfig = copy(fixedWidthNullValue = value)
 
   override def withCredsFile(value: Option[String], menasCredentialsFactory: MenasCredentialsFactory): StandardizationConformanceConfig = {
     copy(credsFile = value, menasCredentialsFactory = menasCredentialsFactory)

--- a/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_data.txt
+++ b/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_data.txt
@@ -3,4 +3,4 @@
 3  Griff            Leaning
 4  Klarrisa           Corps
 5  Cornie         Hewertson
-6  Maybeeeeeeeeeee        a
+6                         a

--- a/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_expected_non_trimmed.txt
+++ b/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_expected_non_trimmed.txt
@@ -6,7 +6,7 @@
 |0  |Griff          |  Leaning|[[stdCastError, E00000, Standardization Error - Type cast, id, [3  ], []]]|
 |0  |Klarrisa       |    Corps|[[stdCastError, E00000, Standardization Error - Type cast, id, [4  ], []]]|
 |0  |Cornie         |Hewertson|[[stdCastError, E00000, Standardization Error - Type cast, id, [5  ], []]]|
-|0  |Maybeeeeeeeeeee|        a|[[stdCastError, E00000, Standardization Error - Type cast, id, [6  ], []]]|
+|0  |               |        a|[[stdCastError, E00000, Standardization Error - Type cast, id, [6  ], []]]|
 +---+---------------+---------+--------------------------------------------------------------------------+
 
 

--- a/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_expected_with_nulls.txt
+++ b/spark-jobs/src/test/resources/data/standardization_fixed_width_suite_expected_with_nulls.txt
@@ -6,7 +6,7 @@
 |3  |Griff     |Leaning  |[]    |
 |4  |Klarrisa  |Corps    |[]    |
 |5  |Cornie    |Hewertson|[]    |
-|6  |          |a        |[]    |
+|6  |null      |a        |[]    |
 +---+----------+---------+------+
 
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
@@ -30,7 +30,7 @@ import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancem
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationFixedWidthSuite extends FunSuite with SparkTestBase with MockitoSugar{
-  private implicit val udfLibrary:UDFLibrary = new UDFLibrary()
+  private implicit val udfLibrary: UDFLibrary = new UDFLibrary()
   private val log: Logger = LoggerFactory.getLogger(this.getClass)
   private val argsBase = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
     "--menas-auth-keytab src/test/resources/user.keytab.example " +
@@ -60,11 +60,11 @@ class StandardizationFixedWidthSuite extends FunSuite with SparkTestBase with Mo
     val destDF = StandardizationInterpreter.standardize(sourceDF, baseSchema, cmd.rawFormat)
 
     val actual = destDF.dataAsString(truncate = false)
-    assert(actual == expected)
+    assert(expected == actual)
   }
 
   test("Reading data from FixedWidth input trimmed") {
-    val cmd = StandardizationConfig.getFromArguments(argsBase ++ Array("--trimValues", "true"))
+    val cmd = StandardizationConfig.getFromArguments(argsBase ++ Array("--trimValues", "true", "--empty-values-as-nulls", "false", "--null-value", "alfa"))
 
     val fixedWidthReader = new StandardizationPropertiesProvider().getFormatSpecificReader(cmd, dataSet)
 
@@ -79,6 +79,25 @@ class StandardizationFixedWidthSuite extends FunSuite with SparkTestBase with Mo
     val destDF = StandardizationInterpreter.standardize(sourceDF, baseSchema, cmd.rawFormat)
 
     val actual = destDF.dataAsString(truncate = false)
-    assert(actual == expected)
+    assert(expected == actual)
+  }
+
+  test("Reading data from FixedWidth input treating empty as null") {
+    val cmd = StandardizationConfig.getFromArguments(argsBase ++ Array("--trimValues", "true", "--empty-values-as-nulls", "true"))
+
+    val fixedWidthReader = new StandardizationPropertiesProvider().getFormatSpecificReader(cmd, dataSet)
+
+    val inputSchema = PlainSchemaGenerator.generateInputSchema(baseSchema)
+    val reader = fixedWidthReader.schema(inputSchema)
+
+    val sourceDF = reader.load("src/test/resources/data/standardization_fixed_width_suite_data.txt")
+
+    val expected = FileReader.readFileAsString("src/test/resources/data/standardization_fixed_width_suite_expected_with_nulls.txt")
+      .replace("\r\n", "\n")
+
+    val destDF = StandardizationInterpreter.standardize(sourceDF, baseSchema, cmd.rawFormat)
+
+    val actual = destDF.dataAsString(truncate = false)
+    assert(expected == actual)
   }
 }

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
@@ -31,7 +31,6 @@ import za.co.absa.enceladus.utils.udf.UDFLibrary
 
 class StandardizationFixedWidthSuite extends FunSuite with SparkTestBase with MockitoSugar{
   private implicit val udfLibrary: UDFLibrary = new UDFLibrary()
-  private val log: Logger = LoggerFactory.getLogger(this.getClass)
   private val argsBase = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
     "--menas-auth-keytab src/test/resources/user.keytab.example " +
     "--raw-format fixed-width").split(" ")


### PR DESCRIPTION
Implementation of new FixedWidth project in Enceladus

Added charset, treatEmptyValuesAsNulls and nullValue as spark-job switches

Fixes #1393 

RN: Update version of FIxedWidth and add charset, treatEmptyValuesAsNulls and nullValue options.