### PR TITLE
Feature/1496 SSR key/cert select

### DIFF
--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -150,6 +150,9 @@ menas.oozie.splineMongoURL=mongodb://localhost:27017
 # when unset, the ability to load schema by subject name from the schema repository will not be present
 # menas.schemaRegistryBaseUrl=https://localhost:8081
 
+# When schema registry is used and unsecured, there will be log warnings unless switched to false: (default=true)
+#menas.schemaRegistry.warnUnsecured=true
+
 # When using secure schema registry, following paths and passwords must be specified
 #javax.net.ssl.trustStore=/path/to/truststore.jks
 #javax.net.ssl.trustStorePassword=somePassword

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/models/rest/errors/RemoteSchemaRetrievalError.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/models/rest/errors/RemoteSchemaRetrievalError.scala
@@ -20,16 +20,19 @@ import za.co.absa.enceladus.menas.models.rest.exceptions.RemoteSchemaRetrievalEx
 import za.co.absa.enceladus.menas.utils.SchemaType
 
 /**
-  * This error is produced when an incorrect schema format is provided.
-  */
+ * This error is produced when an incorrect schema format is provided.
+ */
 case class RemoteSchemaRetrievalError(
-                              errorType: String,
-                              schemaType: SchemaType.Value
-                            ) extends ResponseError
+                                       errorType: String,
+                                       schemaType: SchemaType.Value,
+                                       causeDesc: Option[String]
+                                     ) extends ResponseError
 
 object RemoteSchemaRetrievalError {
   def fromException(ex: RemoteSchemaRetrievalException): RemoteSchemaRetrievalError = RemoteSchemaRetrievalError(
     errorType = "schema_retrieval_error",
-    schemaType = ex.schemaType)
+    schemaType = ex.schemaType,
+    causeDesc = Some(ex.cause).map { cause => s"${cause.getClass.toString}: ${cause.getMessage}" }
+  )
 }
 

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
@@ -73,8 +73,11 @@ class SchemaRegistryService @Autowired()() {
       val trustStore = KeyStore.getInstance(defaultStoreType)
 
       val tsInputStream = new FileInputStream(config.getString(SecureConfig.Keys.javaxNetSslTrustStore))
-      trustStore.load(tsInputStream, config.getString(SecureConfig.Keys.javaxNetSslTrustStorePassword).toCharArray)
-      tsInputStream.close()
+      try {
+        trustStore.load(tsInputStream, config.getString(SecureConfig.Keys.javaxNetSslTrustStorePassword).toCharArray)
+      } finally {
+        tsInputStream.close()
+      }
 
       val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
       tmf.init(trustStore)
@@ -94,8 +97,11 @@ class SchemaRegistryService @Autowired()() {
       val ks = KeyStore.getInstance(defaultStoreType)
 
       val ksInputStream = new FileInputStream(config.getString(SecureConfig.Keys.javaxNetSslKeyStore))
-      ks.load(ksInputStream, config.getString(SecureConfig.Keys.javaxNetSslKeyStorePassword).toCharArray)
-      ksInputStream.close()
+      try {
+        ks.load(ksInputStream, config.getString(SecureConfig.Keys.javaxNetSslKeyStorePassword).toCharArray)
+      } finally {
+        ksInputStream.close()
+      }
 
       val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
       kmf.init(ks, config.getString(SecureConfig.Keys.javaxNetSslKeyStorePassword).toCharArray)

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
@@ -148,8 +148,7 @@ class SchemaRegistryService @Autowired()() {
       SchemaResponse(fileContent, mimeType, url)
     } catch {
       case NonFatal(e) =>
-        throw RemoteSchemaRetrievalException(SchemaType.Avro, s"Could not retrieve a schema file from $remoteUrl. " +
-          s"Please check the correctness of the URL and a presence of the schema at the mentioned endpoint", e)
+        throw RemoteSchemaRetrievalException(SchemaType.Avro, s"Could not retrieve a schema file from $remoteUrl.", e)
     }
   }
 

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
@@ -43,11 +43,6 @@ class SchemaRegistryService @Autowired()() {
   private val defaultStoreType = "JKS"
   private val defaultSslContextProtocol = "TLS"
 
-  if (SecureConfig.hasKeyStoreProperties(config) && SecureConfig.hasTrustStoreProperties(config)) {
-    //SecureConfig.setKeyStoreProperties(config)
-    SecureConfig.setTrustStoreProperties(config)
-  }
-
   lazy val schemaRegistryBaseUrl: Option[String] = {
     config.getOptionString(SchemaRegistryUrlConfigKey)
   }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
@@ -115,11 +115,11 @@ class SchemaRegistryService @Autowired()() {
   def loadSchemaByUrl(remoteUrl: String): SchemaResponse = {
     try {
       if (keyManagerFactory.isEmpty) {
-        logger.warn("keyManagerFactory is not, secure schema registry integration may not function properly. " +
+        logger.warn("keyManagerFactory is not defined, secure schema registry integration may not function properly. " +
           s"Set ${SecureConfig.Keys.javaxNetSslKeyStore} and ${SecureConfig.Keys.javaxNetSslKeyStorePassword} to fix the issue.")
       }
       if (trustManagerFactory.isEmpty) {
-        logger.warn("trustManagerFactory is not, secure schema registry integration may not function properly. " +
+        logger.warn("trustManagerFactory is not defined, secure schema registry integration may not function properly. " +
           s"Set ${SecureConfig.Keys.javaxNetSslTrustStore} and ${SecureConfig.Keys.javaxNetSslTrustStorePassword} to fix the issue.")
       }
 

--- a/menas/ui/components/schema/schemaDetail.controller.js
+++ b/menas/ui/components/schema/schemaDetail.controller.js
@@ -291,18 +291,22 @@ sap.ui.define([
       } else if (status === 400) {
         const errorMessage = ajaxResponse.responseJSON.message;
         const errorMessageDetails = errorMessage ? `\n\nDetails:\n${errorMessage}` : "";
+
+        const errorCause = ajaxResponse.responseJSON.error.causeDesc;
+        const errorMessageCause = errorCause ? `\n\nCaused by:\n${errorCause}` : "";
+
         const errorType = ajaxResponse.responseJSON.error.errorType;
 
         let msg;
         if (errorType === "schema_retrieval_error") {
           if (source === "remote") {
-            msg = `Error retrieving the schema file from "${this.byId("remoteUrl").getValue()}".${errorMessageDetails}`
+            msg = `Error retrieving the schema file from "${this.byId("remoteUrl").getValue()}".${errorMessageDetails}${errorMessageCause}`
           } else {
-            msg = `Error retrieving the schema file by topic-name stem "${this.byId("subjectName").getValue()}".${errorMessageDetails}`
+            msg = `Error retrieving the schema file by topic-name stem "${this.byId("subjectName").getValue()}".${errorMessageDetails}${errorMessageCause}`
           }
         } else {
           msg = `Error parsing the schema file. Ensure that the file is a valid avro schema and ` +
-            `try again.${errorMessageDetails}`
+            `try again.${errorMessageDetails}${errorMessageCause}`
         }
 
         MessageBox.error(msg)

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/config/ConfigUtils.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/config/ConfigUtils.scala
@@ -17,7 +17,7 @@ package za.co.absa.enceladus.utils.config
 
 import java.nio.file.{Files, Paths}
 
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigValueFactory}
 import org.slf4j.LoggerFactory
 
 object ConfigUtils {
@@ -95,6 +95,12 @@ object ConfigUtils {
         None
       }
     }
+
+    /** Handy shorthand of frequent `config.withValue(key, ConfigValueFactory.fromAnyRef(value))` */
+    def withAnyRefValue(key: String, value: AnyRef) : Config = {
+      config.withValue(key, ConfigValueFactory.fromAnyRef(value))
+    }
+
   }
 
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/config/SecureConfig.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/config/SecureConfig.scala
@@ -16,6 +16,7 @@
 package za.co.absa.enceladus.utils.config
 
 import com.typesafe.config.Config
+import za.co.absa.enceladus.utils.config.ConfigUtils.ConfigImplicits
 
 object SecureConfig {
   object Keys {
@@ -25,6 +26,8 @@ object SecureConfig {
     val javaxNetSslKeyStore = "javax.net.ssl.keyStore"
     val javaxNetSslKeyStorePassword = "javax.net.ssl.keyStorePassword"
   }
+
+  case class StoreDef(path: String, password: Option[String])
 
   /**
    * Moves Kafka security configuration from the config to system properties
@@ -69,5 +72,32 @@ object SecureConfig {
     conf.hasPath(Keys.javaxNetSslKeyStore) &&
       conf.hasPath(Keys.javaxNetSslKeyStorePassword)
   }
+
+  /** Common logic to retrieve any store path with its optional password */
+  private def getStoreProperties(conf: Config, storePathKey: String, storePasswordKey: String): Option[StoreDef] = {
+    conf.getOptionString(storePathKey).map { storePath: String =>
+      val optPassword = conf.getOptionString(storePasswordKey)
+
+      StoreDef(storePath, optPassword)
+    }
+  }
+
+  /**
+   * Will yield optional KeyStore definition from `conf` from `Keys.javaxNetSslKeyStore` and
+   * `Keys.javaxNetSslKeyStorePassword` (password is optional)
+   * @param conf config
+   * @return Defined KeyStore definition if `Keys.javaxNetSslKeyStore` exists
+   */
+  def getKeyStoreProperties(conf: Config): Option[StoreDef] =
+    getStoreProperties(conf, Keys.javaxNetSslKeyStore, Keys.javaxNetSslKeyStorePassword)
+
+  /**
+   * Will yield optional TrustStore definition from `conf` from `Keys.javaxNetSslTrustStore` and
+   * `Keys.javaxNetSslTrustStorePassword` (password is optional)
+   * @param conf config
+   * @return Defined TrustStore definition if `Keys.javaxNetSslKeyStore` exists
+   */
+  def getTrustStoreProperties(conf: Config): Option[StoreDef] =
+    getStoreProperties(conf, Keys.javaxNetSslTrustStore, Keys.javaxNetSslTrustStorePassword)
 
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/config/SecureConfigSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/config/SecureConfigSuite.scala
@@ -22,12 +22,12 @@ import za.co.absa.enceladus.utils.config.SecureConfig.StoreDef
 
 class SecureConfigSuite extends FlatSpec with Matchers {
 
-  val emptyConfig = ConfigFactory.empty()
-  val keyStoreNoPassConfig = emptyConfig.withAnyRefValue("javax.net.ssl.keyStore", "/path/to/keystore")
-  val keyStoreConfig = keyStoreNoPassConfig.withAnyRefValue("javax.net.ssl.keyStorePassword", "ksPwd1")
+  private val emptyConfig = ConfigFactory.empty()
+  private val keyStoreNoPassConfig = emptyConfig.withAnyRefValue("javax.net.ssl.keyStore", "/path/to/keystore")
+  private val keyStoreConfig = keyStoreNoPassConfig.withAnyRefValue("javax.net.ssl.keyStorePassword", "ksPwd1")
 
-  val trustStoreNoPassConfig = emptyConfig.withAnyRefValue("javax.net.ssl.trustStore", "/path/to/trustStore")
-  val trustStoreConfig = trustStoreNoPassConfig.withAnyRefValue("javax.net.ssl.trustStorePassword", "tsPwd1")
+  private val trustStoreNoPassConfig = emptyConfig.withAnyRefValue("javax.net.ssl.trustStore", "/path/to/trustStore")
+  private val trustStoreConfig = trustStoreNoPassConfig.withAnyRefValue("javax.net.ssl.trustStorePassword", "tsPwd1")
 
   "SecureConfig" should "load keyStoreProperties from config" in {
     SecureConfig.getKeyStoreProperties(emptyConfig) shouldBe None

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/config/SecureConfigSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/config/SecureConfigSuite.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{FlatSpec, Matchers}
+import za.co.absa.enceladus.utils.config.ConfigUtils.ConfigImplicits
+import za.co.absa.enceladus.utils.config.SecureConfig.StoreDef
+
+class SecureConfigSuite extends FlatSpec with Matchers {
+
+  val emptyConfig = ConfigFactory.empty()
+  val keyStoreNoPassConfig = emptyConfig.withAnyRefValue("javax.net.ssl.keyStore", "/path/to/keystore")
+  val keyStoreConfig = keyStoreNoPassConfig.withAnyRefValue("javax.net.ssl.keyStorePassword", "ksPwd1")
+
+  val trustStoreNoPassConfig = emptyConfig.withAnyRefValue("javax.net.ssl.trustStore", "/path/to/trustStore")
+  val trustStoreConfig = trustStoreNoPassConfig.withAnyRefValue("javax.net.ssl.trustStorePassword", "tsPwd1")
+
+  "SecureConfig" should "load keyStoreProperties from config" in {
+    SecureConfig.getKeyStoreProperties(emptyConfig) shouldBe None
+    SecureConfig.getKeyStoreProperties(trustStoreConfig) shouldBe None
+
+    SecureConfig.getKeyStoreProperties(keyStoreNoPassConfig) shouldBe Some(StoreDef("/path/to/keystore", None))
+    SecureConfig.getKeyStoreProperties(keyStoreConfig) shouldBe Some(StoreDef("/path/to/keystore", Some("ksPwd1")))
+  }
+
+  it should "load trustStoreProperties from config" in {
+    SecureConfig.getTrustStoreProperties(emptyConfig) shouldBe None
+    SecureConfig.getTrustStoreProperties(keyStoreConfig) shouldBe None
+
+    SecureConfig.getTrustStoreProperties(trustStoreNoPassConfig) shouldBe Some(StoreDef("/path/to/trustStore", None))
+    SecureConfig.getTrustStoreProperties(trustStoreConfig) shouldBe Some(StoreDef("/path/to/trustStore", Some("tsPwd1")))
+  }
+}


### PR DESCRIPTION
The schema registry connection is now explicitly supplying its SSL context created from the in-config referenced trustStore and keyStore JKS files without relying on the automatic mechanism from the environment variables.

Tested on Menas-dev on premise where the problems manifesting with the current `develop` version, the issue seems to be resolved - a schema from the SSR can be actually loaded. Big thanks to @hamc17 who was willing to deploy the test artifacts to the environment which I do not have access to, presently.

There is a standing question if this approach, albeit usable in this case, is the general way to go for similar cases. The choice generally goes down to:
 - multiple smaller key/trust stores and picking up what is needed (this PRs approach)
 - having one bigger key/trust store and using aliasing to pick the keys to be used (I expect this is possible, too)

There are some warnings for cases where trustStore/keyStore is not set, these warning can be suppressed by `menas.schemaRegistry.warnUnsecured=false` (default: `true`) in Menas's config.