### PR TITLE
Upgrade to Hyperdrive v4.0.0

### DIFF
--- a/spark-jobs/pom.xml
+++ b/spark-jobs/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>
-        <hyperdrive.version>3.0.0</hyperdrive.version>
+        <hyperdrive.version>4.0.0</hyperdrive.version>
         <commons.version>0.0.10</commons.version>
         <spark.sql.kafka.version>2.4.5</spark.sql.kafka.version>
     </properties>

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -88,22 +88,21 @@ class HyperConformance (implicit cmd: ConformanceConfig,
 /**
  * This is the definition of Dynamic Conformance as a component of Hyperdrive.
  *
- * In order to use it in hyperdrive the component needs to be configured in 'ingestion.properties' as follows:
+ * See https://github.com/AbsaOSS/hyperdrive#configuration for instructions how the component needs to be configured in Hyperdrive.
+ * Example values are given below:
  * {{{
- * component.transformer.id.1=[hyperconformance]
- * component.transformer.class.[hyperconformance]=za.co.absa.enceladus.conformance.HyperConformance
- * transformer.[hyperconformance].menas.rest.uri=http://localhost:8080
- * transformer.[hyperconformance].dataset.name=example
- * transformer.[hyperconformance].dataset.version=1
- * transformer.[hyperconformance].report.date=2020-01-29
- * transformer.[hyperconformance].report.version=1
- * transformer.[hyperconformance].event.timestamp.column=EV_TIME
+ * menas.rest.uri=http://localhost:8080
+ * dataset.name=example
+ * dataset.version=1
+ * report.date=2020-01-29
+ * report.version=1
+ * event.timestamp.column=EV_TIME
  *
  * # Either plain credentials
- * transformer.[hyperconformance].menas.credentials.file=/path/menas.credentials
+ * menas.credentials.file=/path/menas.credentials
  *
  * # Or a keytab
- * transformer.[hyperconformance].menas.auth.keytab=/path/to/keytab
+ * menas.auth.keytab=/path/to/keytab
  * }}}
  */
 object HyperConformance extends StreamTransformerFactory with HyperConformanceAttributes {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -90,18 +90,20 @@ class HyperConformance (implicit cmd: ConformanceConfig,
  *
  * In order to use it in hyperdrive the component needs to be configured in 'ingestion.properties' as follows:
  * {{{
- * transformer.hyperconformance.menas.rest.uri=http://localhost:8080
- * transformer.hyperconformance.dataset.name=example
- * transformer.hyperconformance.dataset.version=1
- * transformer.hyperconformance.report.date=2020-01-29
- * transformer.hyperconformance.report.version=1
- * transformer.hyperconformance.event.timestamp.column=EV_TIME
+ * component.transformer.id.1=[hyperconformance]
+ * component.transformer.class.[hyperconformance]=za.co.absa.enceladus.conformance.HyperConformance
+ * transformer.[hyperconformance].menas.rest.uri=http://localhost:8080
+ * transformer.[hyperconformance].dataset.name=example
+ * transformer.[hyperconformance].dataset.version=1
+ * transformer.[hyperconformance].report.date=2020-01-29
+ * transformer.[hyperconformance].report.version=1
+ * transformer.[hyperconformance].event.timestamp.column=EV_TIME
  *
  * # Either plain credentials
- * transformer.hyperconformance.menas.credentials.file=/path/menas.credentials
+ * transformer.[hyperconformance].menas.credentials.file=/path/menas.credentials
  *
  * # Or a keytab
- * transformer.hyperconformance.menas.auth.keytab=/path/to/keytab
+ * transformer.[hyperconformance].menas.auth.keytab=/path/to/keytab
  * }}}
  */
 object HyperConformance extends StreamTransformerFactory with HyperConformanceAttributes {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
@@ -18,18 +18,17 @@ package za.co.absa.enceladus.conformance
 import za.co.absa.hyperdrive.ingestor.api.{HasComponentAttributes, PropertyMetadata}
 
 object HyperConformanceAttributes {
-  val keysPrefix = "transformer.hyperconformance"
 
   // Configuration keys expected to be set up when running Conformance as a Transformer component for Hyperdrive
-  val menasUriKey = s"$keysPrefix.menas.rest.uri"
-  val menasCredentialsFileKey = s"$keysPrefix.menas.credentials.file"
-  val menasAuthKeytabKey = s"$keysPrefix.menas.auth.keytab"
-  val datasetNameKey = s"$keysPrefix.dataset.name"
-  val datasetVersionKey = s"$keysPrefix.dataset.version"
-  val reportDateKey = s"$keysPrefix.report.date"
-  val reportVersionKey = s"$keysPrefix.report.version"
-  val eventTimestampColumnKey = s"$keysPrefix.event.timestamp.column"
-  val eventTimestampPatternKey = s"$keysPrefix.event.timestamp.pattern"
+  val menasUriKey = "menas.rest.uri"
+  val menasCredentialsFileKey = "menas.credentials.file"
+  val menasAuthKeytabKey = "menas.auth.keytab"
+  val datasetNameKey = "dataset.name"
+  val datasetVersionKey = "dataset.version"
+  val reportDateKey = "report.date"
+  val reportVersionKey = "report.version"
+  val eventTimestampColumnKey = "event.timestamp.column"
+  val eventTimestampPatternKey = "event.timestamp.pattern"
 }
 
 trait HyperConformanceAttributes extends HasComponentAttributes {

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/streaming/HyperConformanceSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/streaming/HyperConformanceSuite.scala
@@ -34,7 +34,7 @@ class HyperConformanceSuite extends FlatSpec with Matchers {
 
   behavior of "Service Provider Interface (META-INF/services)"
 
-  it should "load ColumnSelectorStreamTransformer" in {
+  it should "load HyperConformanceTransformer" in {
     val factoryProviders = loadServices[StreamTransformerFactoryProvider, StreamTransformerFactory]()
     factoryProviders should contain only HyperConformance
   }


### PR DESCRIPTION
Hyperdrive v4.0.0 introduced multiple transformers (https://github.com/AbsaOSS/hyperdrive/issues/82). With 4.0.0, a transformer component only sees its subset of the configuration, i.e. `HyperConformance` doesn't need to prepend the prefix `transformer.hyperconformance` to its properties anymore.

It's up to the user of hyperdrive to make sure the prefix is unique in the global configuration.