### PR TITLE
#1538 postProcessing reread output - normalization

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
@@ -110,6 +110,9 @@ trait CommonJobExecution {
     }
   }
 
+  /**
+   * Post processing rereads the data from a path on FS (based on `sourcePhase`)
+   */
   protected def runPostProcessing[T](sourcePhase: SourcePhase, preparationResult: PreparationResult, jobCmdConfig: JobConfigParser[T])
                                     (implicit spark: SparkSession, fileSystemVersionUtils: FileSystemVersionUtils): Unit = {
     val outputPath = sourcePhase match {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -43,6 +43,7 @@ object DynamicConformanceJob extends ConformanceExecution {
     try {
       val result = conform(inputData, preparationResult)
       processConformanceResult(args, result, preparationResult, menasCredentials)
+      // post processing deliberately rereads the output to make sure that outputted data is stable #1538
       runPostProcessing(SourcePhase.Conformance, preparationResult, cmd)
     } finally {
       finishJob(cmd)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationExecution.scala
@@ -162,7 +162,7 @@ trait StandardizationExecution extends CommonJobExecution {
                                                 cmd: StandardizationConfigParser[T],
                                                 menasCredentials: MenasCredentials)
                                                (implicit spark: SparkSession,
-                                                fsUtils: FileSystemVersionUtils): DataFrame = {
+                                                fsUtils: FileSystemVersionUtils): Unit = {
     import za.co.absa.atum.AtumImplicits._
     val fieldRenames = SchemaUtils.getRenamesInSchema(schema)
     fieldRenames.foreach {
@@ -199,7 +199,6 @@ trait StandardizationExecution extends CommonJobExecution {
     standardizedDF.writeInfoFile(preparationResult.pathCfg.standardizationPath)
     writePerformanceMetrics(preparationResult.performance, cmd)
     log.info(s"$sourceId finished successfully")
-    standardizedDF
   }
 
   //scalastyle:off parameter.number

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -43,6 +43,7 @@ object StandardizationJob extends StandardizationExecution {
     try {
       val result = standardize(inputData, schema, cmd)
       processStandardizationResult(args, result, preparationResult, schema, cmd, menasCredentials)
+      // post processing deliberately rereads the output to make sure that outputted data is stable #1538
       runPostProcessing(SourcePhase.Standardization, preparationResult, cmd)
     } finally {
       finishJob(cmd)


### PR DESCRIPTION
This change directly addresses #1538 - now both `process*Result` methods return `Unit` and thus make any further post-processing routines to reload data from FS as originally intended. (i.e. prohibit using "returned" dataframe to be used)

The rereading is deliberate to ensure that the same data that is being post-processed are already written to the output location and the postProcessing could not be affected by any kind of plan-rerun that could result in newly computed data (this is especially a concern if the output is unstable).