### PR TITLE
1525 Fix FillNull Conformance Rule view

### DIFF
--- a/menas/ui/components/dataset/conformanceRule/ConformanceRuleForm.js
+++ b/menas/ui/components/dataset/conformanceRule/ConformanceRuleForm.js
@@ -309,7 +309,7 @@ class LiteralConformanceRuleForm extends ConformanceRuleForm {
 class FillNullsConformanceRuleForm extends ConformanceRuleForm {
 
   constructor() {
-    super("FillNullsConformanceRule", false)
+    super("FillNullsConformanceRule", true)
   }
 
   get fillNullsValueControl() {

--- a/menas/ui/components/dataset/conformanceRule/FillNullsConformanceRule/add.fragment.xml
+++ b/menas/ui/components/dataset/conformanceRule/FillNullsConformanceRule/add.fragment.xml
@@ -17,6 +17,5 @@
     <core:Fragment type="XML" fragmentName="components.dataset.conformanceRule.add.commonRuleFields"/>
     <Label text="Value"/>
     <Input type="Text" id="fillNullsValue" placeholder="literal value" width="100%" value="{/newRule/value}"/>
-    <Label text="Input Column"/>
-    <core:Fragment fragmentName="components.schemaFieldSelector" type="XML"/>
+    <core:Fragment type="XML" fragmentName="components.dataset.conformanceRule.add.inputColumn"/>
 </core:FragmentDefinition>

--- a/menas/ui/components/dataset/conformanceRule/FillNullsConformanceRule/display.fragment.xml
+++ b/menas/ui/components/dataset/conformanceRule/FillNullsConformanceRule/display.fragment.xml
@@ -18,6 +18,7 @@
         <form:SimpleForm adjustLabelSpan="true" editable="false">
             <form:content>
                 <core:Fragment type="XML" fragmentName="components.dataset.conformanceRule.display.commonRuleFields"/>
+                <core:Fragment type="XML" fragmentName="components.dataset.conformanceRule.display.inputColumn"/>
                 <Label text="Value"/>
                 <Text text="{value}"/>
             </form:content>


### PR DESCRIPTION
- input column now is shown in rule view
- input column pre-selected in rule edit
- general add.inputColumn now used

Fixes #1525 

RN: FillNulls conformance rule now shows an input column and when being edited the input column is preselected. 

---
**Code run and verified - @benedeki**