### PR TITLE
#763 conformed schema in Menas UI

### DIFF
--- a/menas/ui/components/SchemaTable.js
+++ b/menas/ui/components/SchemaTable.js
@@ -20,9 +20,9 @@ class SchemaTable {
     this._parentId = fragmentId;
 
     this._schemaTable = oController.byId(sap.ui.core.Fragment.createId(this._parentId, "schemaFieldsTreeTable"));
-    oController.byId(sap.ui.core.Fragment.createId(this._parentId, "metadataButton")).attachPress(this.metadataPress, this); // worked with "schemaFragment--metadataButton"
+    oController.byId(sap.ui.core.Fragment.createId(this._parentId, "metadataButton")).attachPress(this.metadataPress, this);
 
-    this._oPopoverTemplate = new sap.m.List({})
+    this._oPopoverTemplate = new sap.m.List({});
     this._oPopover = new sap.m.Popover({
       title: "Metadata",
       content: [this._oPopoverTemplate],

--- a/menas/ui/components/SchemaTable.js
+++ b/menas/ui/components/SchemaTable.js
@@ -17,13 +17,7 @@ class SchemaTable {
 
   constructor(oController, fragmentId) {
     this._oController = oController;
-    console.log("oController: ");
-    console.log(oController);
-
     this._parentId = fragmentId;
-
-    console.log("id for schemaFieldsTreeTable: " + sap.ui.core.Fragment.createId(this._parentId, "schemaFieldsTreeTable"));
-    console.log("id for metadataButton: " + sap.ui.core.Fragment.createId(this._parentId, "metadataButton"));
 
     this._schemaTable = oController.byId(sap.ui.core.Fragment.createId(this._parentId, "schemaFieldsTreeTable"));
     oController.byId(sap.ui.core.Fragment.createId(this._parentId, "metadataButton")).attachPress(this.metadataPress, this); // worked with "schemaFragment--metadataButton"

--- a/menas/ui/components/SchemaTable.js
+++ b/menas/ui/components/SchemaTable.js
@@ -15,10 +15,18 @@
 
 class SchemaTable {
 
-  constructor(oController) {
+  constructor(oController, fragmentId) {
     this._oController = oController;
-    this._schemaTable = oController.byId("schemaFieldsTreeTable");
-    oController.byId("metadataButton").attachPress(this.metadataPress, this);
+    console.log("oController: ");
+    console.log(oController);
+
+    this._parentId = fragmentId;
+
+    console.log("id for schemaFieldsTreeTable: " + sap.ui.core.Fragment.createId(this._parentId, "schemaFieldsTreeTable"));
+    console.log("id for metadataButton: " + sap.ui.core.Fragment.createId(this._parentId, "metadataButton"));
+
+    this._schemaTable = oController.byId(sap.ui.core.Fragment.createId(this._parentId, "schemaFieldsTreeTable"));
+    oController.byId(sap.ui.core.Fragment.createId(this._parentId, "metadataButton")).attachPress(this.metadataPress, this); // worked with "schemaFragment--metadataButton"
 
     this._oPopoverTemplate = new sap.m.List({})
     this._oPopover = new sap.m.Popover({
@@ -55,7 +63,8 @@ class SchemaTable {
     if(oSrc !== this._lastMetatadaEvSrc) {
       let binding = oSrc.getBindingContext("schema").getPath() + "/metadata";
       let bindingArr = binding + "Arr";
-      const model = this.oController.byId("schemaFieldsTreeTable").getModel("schema");
+
+      const model = this.oController.byId(sap.ui.core.Fragment.createId(this._parentId, "schemaFieldsTreeTable")).getModel("schema");
       let arrMeta = Formatters.objToKVArray(model.getProperty(binding));
       model.setProperty(bindingArr, arrMeta);
       this._oPopoverTemplate.setModel(model);

--- a/menas/ui/components/dataset/conformanceRule/ConformanceRule.js
+++ b/menas/ui/components/dataset/conformanceRule/ConformanceRule.js
@@ -59,6 +59,7 @@ class ConformanceRule {
       let element = acc.find(field => field.name === path);
       if (!element) {
         element = (index === splitPath.length - 1) ? newField : new SchemaField(path, splitPath.slice(0, index).join(","), "struct", true, []);
+        element.isConformed = true; // marking field as Conformed in order to differentiate it in the ConformedSchema table
         acc.push(element);
       }
       let ch = element.children;

--- a/menas/ui/components/dataset/conformanceRule/ConformanceRule.js
+++ b/menas/ui/components/dataset/conformanceRule/ConformanceRule.js
@@ -58,8 +58,7 @@ class ConformanceRule {
     return splitPath.reduce((acc, path, index) => {
       let element = acc.find(field => field.name === path);
       if (!element) {
-        element = (index === splitPath.length - 1) ? newField : new SchemaField(path, splitPath.slice(0, index).join(","), "struct", true, []);
-        element.isConformed = true; // marking field as Conformed in order to differentiate it in the ConformedSchema table
+        element = (index === splitPath.length - 1) ? newField : new SchemaField(path, splitPath.slice(0, index).join(","), "struct", true, [], true);
         acc.push(element);
       }
       let ch = element.children;
@@ -80,7 +79,7 @@ class CastingConformanceRule extends ConformanceRule {
 
   apply(fields) {
     const inputCol = this.getInputCol(fields);
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, this.rule.outputDataType, inputCol.nullable, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, this.rule.outputDataType, inputCol.nullable, [], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -91,7 +90,7 @@ class ConcatenationConformanceRule extends ConformanceRule {
 
   apply(fields) {
     const isNullable = this.getInputCols(fields).some(field => field.nullable);
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", isNullable, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", isNullable, [], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -126,7 +125,7 @@ class DropConformanceRule extends ConformanceRule {
 class LiteralConformanceRule extends ConformanceRule {
 
   apply(fields) {
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", false, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", false, [], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -137,7 +136,7 @@ class FillNullsConformanceRule extends ConformanceRule {
 
   apply(fields) {
     const inputCol = this.getInputCol(fields);
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, inputCol.type, false, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, inputCol.type, false, [], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -148,7 +147,7 @@ class CoalesceConformanceRule extends ConformanceRule {
 
   apply(fields) {
     const isNullable = this.getInputCols(fields).some(field => field.nullable);
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", isNullable, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", isNullable, [], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -166,7 +165,7 @@ class MappingConformanceRule extends ConformanceRule {
   }
 
   apply(fields) {
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", false, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", false, [], true);
 
     return new MappingTableRestDAO().getByNameAndVersionSync(this.rule.mappingTable, this.rule.mappingTableVersion)
       .then(mappingTable => {
@@ -194,7 +193,7 @@ class NegationConformanceRule extends ConformanceRule {
 
   apply(fields) {
     const inputCol = this.getInputCol(fields);
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, inputCol.type, inputCol.nullable, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, inputCol.type, inputCol.nullable, [], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -205,8 +204,8 @@ class SingleColumnConformanceRule extends ConformanceRule {
 
   apply(fields) {
     const inputCol = this.getInputCol(fields);
-    const child = new SchemaField(this.rule.inputColumnAlias, this.rule.outputColumn, inputCol.type, inputCol.nullable, []);
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "struct", false, [child]);
+    const child = new SchemaField(this.rule.inputColumnAlias, this.rule.outputColumn, inputCol.type, inputCol.nullable, [], true);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "struct", false, [child], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -216,7 +215,7 @@ class SingleColumnConformanceRule extends ConformanceRule {
 class SparkSessionConfConformanceRule extends ConformanceRule {
 
   apply(fields) {
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", false, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", false, [], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -227,7 +226,7 @@ class UppercaseConformanceRule extends ConformanceRule {
 
   apply(fields) {
     const inputCol = this.getInputCol(fields);
-    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", inputCol.nullable, []);
+    const newField = new SchemaField(this.outputCol.name, this.outputCol.path, "string", inputCol.nullable, [], true);
     this.addNewField(fields, newField);
     return fields;
   }
@@ -236,12 +235,13 @@ class UppercaseConformanceRule extends ConformanceRule {
 
 class SchemaField {
 
-  constructor(name, path, type, nullable, children) {
+  constructor(name, path, type, nullable, children, conformed = false) {
     this._name = name;
     this._path = path;
     this._type = type;
     this._nullable = nullable;
     this._children = children;
+    this._conformed = conformed;
   }
 
   get name() {
@@ -282,5 +282,13 @@ class SchemaField {
 
   set children(value) {
     this._children = value;
+  }
+
+  get conformed() {
+    return this._conformed;
+  }
+
+  set conformed(value) {
+    this._conformed = value;
   }
 }

--- a/menas/ui/components/dataset/datasetDetail.controller.js
+++ b/menas/ui/components/dataset/datasetDetail.controller.js
@@ -76,8 +76,9 @@ sap.ui.define([
 
       this._datasetService = new DatasetService(this._model, this._oEventBus);
       this._mappingTableService = new MappingTableService(this._model, this._oEventBus);
-      this._schemaService = new SchemaService(this._model, this._oEventBus)
-      this._schemaTable = new SchemaTable(this, "schemaFragment")
+      this._schemaService = new SchemaService(this._model, this._oEventBus);
+      this._schemaTable = new SchemaTable(this, "schemaFragment");
+      this._conformedSchemaTable = new SchemaTable(this, "conformedSchemaFragment");
 
       this._validator = new Validator();
 
@@ -354,7 +355,9 @@ sap.ui.define([
           this._model.setProperty("/currentDataset/schema", schema);
           this._schemaTable.model = schema;
           transitiveSchemas.push(schema);
-          SchemaManager.getTransitiveSchemas(transitiveSchemas, currentDataset.conformance)
+          SchemaManager.getTransitiveSchemas(transitiveSchemas, currentDataset.conformance);
+
+          this._conformedSchemaTable.model = transitiveSchemas[transitiveSchemas.length-1] // schema has all conf rules applied
         });
 
         this._datasetRestDAO = new DatasetRestDAO();

--- a/menas/ui/components/dataset/datasetDetail.controller.js
+++ b/menas/ui/components/dataset/datasetDetail.controller.js
@@ -357,7 +357,7 @@ sap.ui.define([
           transitiveSchemas.push(schema);
           SchemaManager.getTransitiveSchemas(transitiveSchemas, currentDataset.conformance);
 
-          this._conformedSchemaTable.model = transitiveSchemas[transitiveSchemas.length-1] // schema has all conf rules applied
+          this._conformedSchemaTable.model = transitiveSchemas[transitiveSchemas.length-1] // last schema has all conf rules applied
         });
 
         this._datasetRestDAO = new DatasetRestDAO();

--- a/menas/ui/components/dataset/datasetDetail.controller.js
+++ b/menas/ui/components/dataset/datasetDetail.controller.js
@@ -77,7 +77,7 @@ sap.ui.define([
       this._datasetService = new DatasetService(this._model, this._oEventBus);
       this._mappingTableService = new MappingTableService(this._model, this._oEventBus);
       this._schemaService = new SchemaService(this._model, this._oEventBus)
-      this._schemaTable = new SchemaTable(this)
+      this._schemaTable = new SchemaTable(this, "schemaFragment")
 
       this._validator = new Validator();
 

--- a/menas/ui/components/dataset/datasetDetail.view.xml
+++ b/menas/ui/components/dataset/datasetDetail.view.xml
@@ -35,7 +35,7 @@
                         <core:Fragment type="XML" fragmentName="components.dataset.datasetInfo" />
                     </IconTabFilter>
                     <IconTabFilter id="Schema" icon="sap-icon://tree" key="schemaFields" text="Schema">
-                        <core:Fragment type="XML" fragmentName="components.schemaTable" />
+                        <core:Fragment type="XML" fragmentName="components.schemaTable" id="schemaFragment" />
                     </IconTabFilter>
                     <IconTabFilter id="ConformanceRules" icon="sap-icon://list" key="conformanceRules"
                                    text="Conformance Rules">

--- a/menas/ui/components/dataset/datasetDetail.view.xml
+++ b/menas/ui/components/dataset/datasetDetail.view.xml
@@ -46,6 +46,9 @@
                                         factory: '.conformanceRuleFactory'
                                       }"/>
                     </IconTabFilter>
+                    <IconTabFilter id="ConformedSchema" icon="sap-icon://overview-chart" key="conformedSchemaFields" text="ConformedSchema">
+                        <core:Fragment type="XML" fragmentName="components.schemaTable" id="conformedSchemaFragment" />
+                    </IconTabFilter>
                     <IconTabFilter id="Runs" icon="sap-icon://activities" key="runs" text="Runs">
                         <core:Fragment type="XML" fragmentName="components.dataset.run.runs" />
                     </IconTabFilter>

--- a/menas/ui/components/dataset/datasetDetail.view.xml
+++ b/menas/ui/components/dataset/datasetDetail.view.xml
@@ -46,7 +46,7 @@
                                         factory: '.conformanceRuleFactory'
                                       }"/>
                     </IconTabFilter>
-                    <IconTabFilter id="ConformedSchema" icon="sap-icon://overview-chart" key="conformedSchemaFields" text="ConformedSchema">
+                    <IconTabFilter id="ConformedSchema" icon="sap-icon://activate" key="conformedSchemaFields" text="Conformed Schema">
                         <core:Fragment type="XML" fragmentName="components.schemaTable" id="conformedSchemaFragment" />
                     </IconTabFilter>
                     <IconTabFilter id="Runs" icon="sap-icon://activities" key="runs" text="Runs">

--- a/menas/ui/components/mappingTable/mappingTableDetail.controller.js
+++ b/menas/ui/components/mappingTable/mappingTableDetail.controller.js
@@ -72,7 +72,7 @@ sap.ui.define([
 
       this._mappingTableService = new MappingTableService(this._model, this._oEventBus);
       this._schemaService = new SchemaService(this._model, this._oEventBus);
-      this._schemaTable = new SchemaTable(this);
+      this._schemaTable = new SchemaTable(this, "schemaFragment");
       this._schemaFieldSelector = new SimpleSchemaFieldSelector(this, this._addDefaultDialog)
 
       const auditTable = this.byId("auditTrailTable");

--- a/menas/ui/components/mappingTable/mappingTableDetail.view.xml
+++ b/menas/ui/components/mappingTable/mappingTableDetail.view.xml
@@ -35,7 +35,7 @@
                         <core:Fragment type="XML" fragmentName="components.mappingTable.mappingTableInfo"/>
                     </IconTabFilter>
                     <IconTabFilter id="Schema" icon="sap-icon://tree" key="schemaFields" text="Schema">
-                        <core:Fragment type="XML" fragmentName="components.schemaTable"/>
+                        <core:Fragment type="XML" fragmentName="components.schemaTable"  id="schemaFragment"/>
                     </IconTabFilter>
                     <IconTabFilter id="UsedIn" icon="sap-icon://detail-view" text="Used In">
                         <Panel headerText="Datasets" height="50%">

--- a/menas/ui/components/schema/schemaDetail.controller.js
+++ b/menas/ui/components/schema/schemaDetail.controller.js
@@ -39,7 +39,7 @@ sap.ui.define([
       this._eventBus.subscribe("schemas", "updated", this.onEntityUpdated, this);
 
       this._schemaService = new SchemaService(this._model, this._eventBus);
-      this._schemaTable = new SchemaTable(this);
+      this._schemaTable = new SchemaTable(this, "schemaFragment");
 
       const auditTable = this.byId("auditTrailTable");
       const auditUtils = new AuditTrail(auditTable);

--- a/menas/ui/components/schema/schemaDetail.view.xml
+++ b/menas/ui/components/schema/schemaDetail.view.xml
@@ -35,7 +35,7 @@
                         <core:Fragment type="XML" fragmentName="components.schema.schemaInfo"/>
                     </IconTabFilter>
                     <IconTabFilter id="schemaFields" icon="sap-icon://tree" key="schemaFields" text="Fields">
-                        <core:Fragment type="XML" fragmentName="components.schemaTable"/>
+                        <core:Fragment type="XML" fragmentName="components.schemaTable"  id="schemaFragment"/>
                     </IconTabFilter>
                     <IconTabFilter id="UploadNew" icon="sap-icon://upload" text="Upload new">
                     <VBox width="38em">

--- a/menas/ui/components/schemaTable.fragment.xml
+++ b/menas/ui/components/schemaTable.fragment.xml
@@ -22,7 +22,7 @@
             <table:Column width="60%">
                 <Label text="Fields"/>
                 <table:template>
-                    <Text text="{schema>name}" wrapping="false"/>
+                    <Text text="{schema>name}{= ${schema>isConformed} ? ' (conformed field)' : ''}" wrapping="false"/>
                 </table:template>
             </table:Column>
             <table:Column width="20%">

--- a/menas/ui/components/schemaTable.fragment.xml
+++ b/menas/ui/components/schemaTable.fragment.xml
@@ -14,47 +14,42 @@
   -->
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core"
                          xmlns:table="sap.ui.table">
-    <VBox>
-        <table:TreeTable id="schemaFieldsTreeTable"
-                         rows="{path:'schema>/fields', parameters: {arrayNames:['children']}}"
-                         visibleRowCountMode="Interactive" minAutoRowCount="10" rowHeight="49px"
-                         selectionMode="None">
-            <table:columns>
-                <table:Column width="60%">
-                    <Label text="Fields"/>
-                    <table:template>
-                        <HBox>
-                            <Text text="{schema>name}" wrapping="false" />
-                            <core:Icon src="sap-icon://activate" visible="{path:'schema>isConformed', formatter:'Formatters.isDefinedAndTrue'}"
-                                       class="conformIcon" alt="Conformed Field"
-                                       tooltip="This field is a projected result of the defined conformance rules."/>
-                        </HBox>
-                    </table:template>
-                </table:Column>
-                <table:Column width="20%">
-                    <Label text="Type"/>
-                    <table:template>
-                        <Text text="{schema>type}"/>
-                    </table:template>
-                </table:Column>
-                <table:Column width="10%">
-                    <Label text="Nullable"/>
-                    <table:template>
-                        <CheckBox selected="{schema>nullable}" editable="false"/>
-                    </table:template>
-                </table:Column>
-                <table:Column width="10%">
-                    <Label text="Metadata"/>
-                    <table:template>
-                        <Button id="metadataButton" icon="sap-icon://message-information"
-                                visible="{path:'schema>metadata', formatter:'Formatters.nonEmptyObject'}"/>
-                    </table:template>
-                </table:Column>
-            </table:columns>
-        </table:TreeTable>
-        <HBox>
-            <core:Icon src="sap-icon://activate" class="conformIconLegend" alt="Conformed Field" tooltip="Conformed Field"/>
-            <Text text="Projected field - expected result of conformance"/>
-        </HBox>
-    </VBox>
+    <table:TreeTable id="schemaFieldsTreeTable"
+                     rows="{path:'schema>/fields', parameters: {arrayNames:['children']}}"
+                     visibleRowCountMode="Interactive" minAutoRowCount="10" rowHeight="49px"
+                     selectionMode="None">
+        <table:columns>
+            <table:Column width="60%">
+                <Label text="Fields"/>
+                <table:template>
+                    <HBox>
+                        <Text text="{schema>name}" wrapping="false"/>
+                        <core:Icon src="sap-icon://activate"
+                                   visible="{path:'schema>conformed', formatter:'Formatters.isDefinedAndTrue'}"
+                                   class="conformIcon" alt="Conformed Field"
+                                   tooltip="This field is a projected result of the defined conformance rules."/>
+                    </HBox>
+                </table:template>
+            </table:Column>
+            <table:Column width="20%">
+                <Label text="Type"/>
+                <table:template>
+                    <Text text="{schema>type}"/>
+                </table:template>
+            </table:Column>
+            <table:Column width="10%">
+                <Label text="Nullable"/>
+                <table:template>
+                    <CheckBox selected="{schema>nullable}" editable="false"/>
+                </table:template>
+            </table:Column>
+            <table:Column width="10%">
+                <Label text="Metadata"/>
+                <table:template>
+                    <Button id="metadataButton" icon="sap-icon://message-information"
+                            visible="{path:'schema>metadata', formatter:'Formatters.nonEmptyObject'}"/>
+                </table:template>
+            </table:Column>
+        </table:columns>
+    </table:TreeTable>
 </core:FragmentDefinition>

--- a/menas/ui/components/schemaTable.fragment.xml
+++ b/menas/ui/components/schemaTable.fragment.xml
@@ -14,36 +14,47 @@
   -->
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core"
                          xmlns:table="sap.ui.table">
-    <table:TreeTable id="schemaFieldsTreeTable"
-                     rows="{path:'schema>/fields', parameters: {arrayNames:['children']}}"
-                     visibleRowCountMode="Interactive" minAutoRowCount="10" rowHeight="49px"
-                     selectionMode="None">
-        <table:columns>
-            <table:Column width="60%">
-                <Label text="Fields"/>
-                <table:template>
-                    <Text text="{schema>name}{= ${schema>isConformed} ? ' (conformed field)' : ''}" wrapping="false"/>
-                </table:template>
-            </table:Column>
-            <table:Column width="20%">
-                <Label text="Type"/>
-                <table:template>
-                    <Text text="{schema>type}"/>
-                </table:template>
-            </table:Column>
-            <table:Column width="10%">
-                <Label text="Nullable"/>
-                <table:template>
-                    <CheckBox selected="{schema>nullable}" editable="false"/>
-                </table:template>
-            </table:Column>
-            <table:Column width="10%">
-                <Label text="Metadata"/>
-                <table:template>
-                    <Button id="metadataButton" icon="sap-icon://message-information"
-                        visible="{path:'schema>metadata', formatter:'Formatters.nonEmptyObject'}"/>
-                </table:template>
-            </table:Column>
-        </table:columns>
-    </table:TreeTable>
+    <VBox>
+        <table:TreeTable id="schemaFieldsTreeTable"
+                         rows="{path:'schema>/fields', parameters: {arrayNames:['children']}}"
+                         visibleRowCountMode="Interactive" minAutoRowCount="10" rowHeight="49px"
+                         selectionMode="None">
+            <table:columns>
+                <table:Column width="60%">
+                    <Label text="Fields"/>
+                    <table:template>
+                        <HBox>
+                            <Text text="{schema>name}" wrapping="false" />
+                            <core:Icon src="sap-icon://activate" visible="{path:'schema>isConformed', formatter:'Formatters.isDefinedAndTrue'}"
+                                       class="conformIcon" alt="Conformed Field"
+                                       tooltip="This field is a projected result of the defined conformance rules."/>
+                        </HBox>
+                    </table:template>
+                </table:Column>
+                <table:Column width="20%">
+                    <Label text="Type"/>
+                    <table:template>
+                        <Text text="{schema>type}"/>
+                    </table:template>
+                </table:Column>
+                <table:Column width="10%">
+                    <Label text="Nullable"/>
+                    <table:template>
+                        <CheckBox selected="{schema>nullable}" editable="false"/>
+                    </table:template>
+                </table:Column>
+                <table:Column width="10%">
+                    <Label text="Metadata"/>
+                    <table:template>
+                        <Button id="metadataButton" icon="sap-icon://message-information"
+                                visible="{path:'schema>metadata', formatter:'Formatters.nonEmptyObject'}"/>
+                    </table:template>
+                </table:Column>
+            </table:columns>
+        </table:TreeTable>
+        <HBox>
+            <core:Icon src="sap-icon://activate" class="conformIconLegend" alt="Conformed Field" tooltip="Conformed Field"/>
+            <Text text="Projected field - expected result of conformance"/>
+        </HBox>
+    </VBox>
 </core:FragmentDefinition>

--- a/menas/ui/css/style.css
+++ b/menas/ui/css/style.css
@@ -102,6 +102,7 @@ h5[id$=datasetDetailView--scheduleTimingTitle] {
   margin: 0 3px;
 }
 
+/* Making IconTabBar tabs slightly wider (default is 5rem), so we don't get so many ellipsized labels (e.g. Conformance Rules, Conformed Schema) */
 .sapMITBFilter .sapMITBText, .sapMITBTab {
   width: 7rem;
 }

--- a/menas/ui/css/style.css
+++ b/menas/ui/css/style.css
@@ -98,6 +98,10 @@ h5[id$=datasetDetailView--scheduleTimingTitle] {
 }
 
 /* Conformance indicator styling */
-.conformIcon, .conformIconLegend {
+.conformIcon {
   margin: 0 3px;
+}
+
+.sapMITBFilter .sapMITBText, .sapMITBTab {
+  width: 7rem;
 }

--- a/menas/ui/css/style.css
+++ b/menas/ui/css/style.css
@@ -96,3 +96,8 @@ html, body {
 h5[id$=datasetDetailView--scheduleTimingTitle] {
   margin-top: 1rem !important;
 }
+
+/* Conformance indicator styling */
+.conformIcon, .conformIconLegend {
+  margin: 0 3px;
+}

--- a/menas/ui/generic/formatters.js
+++ b/menas/ui/generic/formatters.js
@@ -80,6 +80,10 @@ var Formatters = new function() {
     return (oObj !== null) && (typeof (oObj) !== "undefined") && (Object.keys(oObj).length !== 0)
   };
 
+  this.isDefinedAndTrue = function(oObj) {
+    return (oObj !== null) && (typeof (oObj) !== "undefined") && oObj == true
+  };
+
   this.objToKVArray = function(oObj) {
     if(oObj === null || typeof(oObj) === "undefined") return []
     else {


### PR DESCRIPTION
This feature allows the user to see what the conformed schema is about to look like (i.e. current schema + conformance rules applied). The result is not saved anywhere, it is in UI only.
There is an icon indication for the to-be-added fields, this also works in depth.

I haven't invented the conf rule application logic, only adjusted the front-end to view it (added one parameter to the logic to distinguish original vs added schema fields. Some other necessary adjustments had to be made to reuse the existing treatable fragment (original clashed on ids when reused).

This is what it looks like:
![conformedRules-preview](https://user-images.githubusercontent.com/4457378/96250096-998fdb00-0fae-11eb-995f-4c466bc944c8.png)
