### PR TITLE
menas config unification

### DIFF
--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -147,7 +147,7 @@ menas.oozie.splineMongoURL=mongodb://localhost:27017
 #----------- Schema Registry
 # URL of schema registry [optional]:
 # when unset, the ability to load schema by subject name from the schema repository will not be present
-# menas.schemaRegistryBaseUrl=https://localhost:8081
+#menas.schemaRegistry.baseUrl=https://localhost:8081
 
 # When schema registry is used and unsecured, there will be log warnings unless switched to false: (default=true)
 #menas.schemaRegistry.warnUnsecured=true

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/SchemaRegistryService.scala
@@ -156,7 +156,7 @@ class SchemaRegistryService @Autowired()() {
 
 object SchemaRegistryService {
 
-  val SchemaRegistryUrlConfigKey = "menas.schemaRegistryBaseUrl"
+  val SchemaRegistryUrlConfigKey = "menas.schemaRegistry.baseUrl"
   val SchemaRegsitryWarnUnsecureKey = "menas.schemaRegistry.warnUnsecured"
 
   private val defaultStoreType = "JKS"

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -78,4 +78,4 @@ timezone=UTC
 menas.monitoring.fetch.limit=500
 
 #----------- Schema Registry
-menas.schemaRegistryBaseUrl=http://localhost:8877
+menas.schemaRegistry.baseUrl=http://localhost:8877

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiFeaturesIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiFeaturesIntegrationSuite.scala
@@ -48,7 +48,7 @@ import scala.collection.immutable.HashMap
 @ActiveProfiles(Array("withEmbeddedMongo"))
 class SchemaApiFeaturesIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll {
 
-  private val port = 8877 // same  port as in test/resources/application.conf in the `menas.schemaRegistryBaseUrl` key
+  private val port = 8877 // same  port as in test/resources/application.conf in the `menas.schemaRegistry.baseUrl` key
   private val wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(port))
 
   override def beforeAll(): Unit = {
@@ -1061,7 +1061,7 @@ class SchemaApiFeaturesIntegrationSuite extends BaseRestApiTest with BeforeAndAf
           assert(response.getStatusCode == HttpStatus.OK)
           val responseBody = response.getBody
 
-          // test-config contains populated menas.schemaRegistryBaseUrl
+          // test-config contains populated menas.schemaRegistry.baseUrl
           assert(responseBody == SchemaApiFeatures(registry = true))
         }
       }


### PR DESCRIPTION
Menas config key change:
 - `menas.schemaRegistryBaseUrl` => `menas.schemaRegistry.baseUrl`

(the underlying reason is explained in the issue #1565 - to conform to other key(s) in the `menas.*` config space)