### PR TITLE
1638 Fix validation of conformance rules on import entity

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/services/DatasetService.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/services/DatasetService.scala
@@ -208,7 +208,7 @@ class DatasetService @Autowired() (datasetMongoRepository: DatasetMongoRepositor
                                                   cr: C): RuleValidationsAndFields = {
     val withOutputValidated = validateOutputColumn(fields, cr.outputColumn)
     val validationInputFields = validateInputColumn(fields, cr.inputColumn)
-    withOutputValidated.update(validationInputFields)
+    validationInputFields.update(withOutputValidated)
   }
 
   def validateMappingTable(fields: Future[Set[String]],


### PR DESCRIPTION
Just switch the order of update `RuleValidationsAndFields` so that the proper fields are "dominant"

Fixes #1638 

RN: Fix the validation of conformance rules on import and the evolving schema