### PR TITLE
#1653 HDFS browser doesn't work with EMR HDFS

### DIFF
--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -91,6 +91,12 @@
             <version>${hadoop.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!-- Fix for #1653 - HDFS browser doesn't work on EMR HDFS -->
+        <dependency>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core</artifactId>
+            <version>${htrace.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>


### PR DESCRIPTION
Adds htrace dependency to menas. Without this, HDFS browser throws an exception when trying to list folders on EMR HDFS.