### PR TITLE
#1666: `overrideMappingTableOwnFilter` in `MappingConformanceRule` makes its old serialization incompatible

### DIFF
--- a/data-model/src/main/scala/za/co/absa/enceladus/model/Dataset.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/Dataset.scala
@@ -74,13 +74,13 @@ case class Dataset(name: String,
    * @return a dataset with it's mapping conformance rule attributeMappings where the dots are
    *         <MappingConformanceRule.DOT_REPLACEMENT_SYMBOL>
    */
-  def encode: Dataset = substituteMappingConformanceRuleCharacter(this, '.', MappingConformanceRule.DOT_REPLACEMENT_SYMBOL)
+  def encode: Dataset = substituteMappingConformanceRuleCharacter(this, '.', MappingConformanceRule.DotReplacementSymbol)
 
   /**
    * @return a dataset with it's mapping conformance rule attributeMappings where the
    *         <MappingConformanceRule.DOT_REPLACEMENT_SYMBOL> are dots
    */
-  def decode: Dataset = substituteMappingConformanceRuleCharacter(this, MappingConformanceRule.DOT_REPLACEMENT_SYMBOL, '.')
+  def decode: Dataset = substituteMappingConformanceRuleCharacter(this, MappingConformanceRule.DotReplacementSymbol, '.')
 
   override val createdMessage: AuditTrailEntry = AuditTrailEntry(
     menasRef = MenasReference(collection = None, name = name, version = version),

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/conformanceRule/package.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/conformanceRule/package.scala
@@ -18,7 +18,7 @@ package za.co.absa.enceladus.model
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import za.co.absa.enceladus.model.dataFrameFilter.DataFrameFilter
-import za.co.absa.enceladus.model.conformanceRule.MappingConformanceRule.DEFAULT_OVERRIDE_MAPPING_TABLE_OWN_FILTER
+import za.co.absa.enceladus.model.conformanceRule.MappingConformanceRule.DefaultOverrideMappingTableOwnFilter
 
 package object conformanceRule {
 
@@ -83,7 +83,7 @@ package object conformanceRule {
                                     outputColumn: String,
                                     isNullSafe: Boolean = false,
                                     mappingTableFilter: Option[DataFrameFilter] = None,
-                                    overrideMappingTableOwnFilter: Option[Boolean] = Some(DEFAULT_OVERRIDE_MAPPING_TABLE_OWN_FILTER)
+                                    overrideMappingTableOwnFilter: Option[Boolean] = Some(DefaultOverrideMappingTableOwnFilter)
                                    ) extends ConformanceRule {
     override def withUpdatedOrder(newOrder: Int): MappingConformanceRule = copy(order = newOrder)
 
@@ -92,7 +92,7 @@ package object conformanceRule {
     )
 
     def getOverrideMappingTableOwnFilter: Boolean = {
-      overrideMappingTableOwnFilter.getOrElse(DEFAULT_OVERRIDE_MAPPING_TABLE_OWN_FILTER)
+      overrideMappingTableOwnFilter.getOrElse(DefaultOverrideMappingTableOwnFilter)
     }
   }
 
@@ -157,8 +157,8 @@ package object conformanceRule {
 
   object MappingConformanceRule {
     // attributeMappings property has key's with dot's that mongo doesn't accept; this symbol is used to replace the dots
-    final val DOT_REPLACEMENT_SYMBOL: Char = '^'
-    final val DEFAULT_OVERRIDE_MAPPING_TABLE_OWN_FILTER: Boolean = false
+    final val DotReplacementSymbol: Char = '^'
+    final val DefaultOverrideMappingTableOwnFilter: Boolean = false
   }
 
 }

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/conformanceRule/package.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/conformanceRule/package.scala
@@ -18,6 +18,7 @@ package za.co.absa.enceladus.model
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import za.co.absa.enceladus.model.dataFrameFilter.DataFrameFilter
+import za.co.absa.enceladus.model.conformanceRule.MappingConformanceRule.DEFAULT_OVERRIDE_MAPPING_TABLE_OWN_FILTER
 
 package object conformanceRule {
 
@@ -73,7 +74,6 @@ package object conformanceRule {
     override def withUpdatedOrder(newOrder: Int): LiteralConformanceRule = copy(order = newOrder)
   }
 
-
   case class MappingConformanceRule(order: Int,
                                     controlCheckpoint: Boolean,
                                     mappingTable: String,
@@ -83,13 +83,17 @@ package object conformanceRule {
                                     outputColumn: String,
                                     isNullSafe: Boolean = false,
                                     mappingTableFilter: Option[DataFrameFilter] = None,
-                                    overrideMappingTableOwnFilter: Boolean = false
+                                    overrideMappingTableOwnFilter: Option[Boolean] = Some(DEFAULT_OVERRIDE_MAPPING_TABLE_OWN_FILTER)
                                    ) extends ConformanceRule {
     override def withUpdatedOrder(newOrder: Int): MappingConformanceRule = copy(order = newOrder)
 
     override def connectedEntities: Seq[ConnectedEntity] = Seq(
       ConnectedMappingTable(mappingTable, mappingTableVersion)
     )
+
+    def getOverrideMappingTableOwnFilter: Boolean = {
+      overrideMappingTableOwnFilter.getOrElse(DEFAULT_OVERRIDE_MAPPING_TABLE_OWN_FILTER)
+    }
   }
 
   case class NegationConformanceRule(order: Int,
@@ -153,7 +157,8 @@ package object conformanceRule {
 
   object MappingConformanceRule {
     // attributeMappings property has key's with dot's that mongo doesn't accept; this symbol is used to replace the dots
-    val DOT_REPLACEMENT_SYMBOL: Char = '^'
+    final val DOT_REPLACEMENT_SYMBOL: Char = '^'
+    final val DEFAULT_OVERRIDE_MAPPING_TABLE_OWN_FILTER: Boolean = false
   }
 
 }

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/properties/propertyType/package.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/properties/propertyType/package.scala
@@ -34,13 +34,13 @@ package object propertyType {
   }
 
   case class StringPropertyType(suggestedValue: String = "") extends PropertyType {
-    override def isValueConforming(value: String): Try[Unit] = Success()
+    override def isValueConforming(value: String): Try[Unit] = Success(Unit)
   }
 
   case class EnumPropertyType(allowedValues: Set[String], suggestedValue: String) extends PropertyType {
     override def isValueConforming(value: String): Try[Unit] = {
       if (allowedValues.contains(value)) {
-        Success()
+        Success(Unit)
       } else {
         Failure(new IllegalArgumentException(s"Value '$value' is not one of the allowed values (${allowedValues.mkString(", ")})."))
       }

--- a/data-model/src/test/scala/za/co/absa/enceladus/model/conformanceRule/ConformanceRuleTest.scala
+++ b/data-model/src/test/scala/za/co/absa/enceladus/model/conformanceRule/ConformanceRuleTest.scala
@@ -18,6 +18,7 @@ package za.co.absa.enceladus.model.conformanceRule
 import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.scalatest.{Matchers, WordSpec}
+import za.co.absa.enceladus.model.dataFrameFilter.IsNullFilter
 
 class ConformanceRuleTest extends WordSpec with Matchers {
 
@@ -53,12 +54,22 @@ class ConformanceRuleTest extends WordSpec with Matchers {
   }
 
   "MappingConformanceRule" should {
+    val filter = IsNullFilter("country")
     val rule = MappingConformanceRule(order = 5, controlCheckpoint = true, outputColumn = "conformed_country",
       mappingTable = "country", mappingTableVersion = 0, attributeMappings = Map("country_code" -> "country"),
-      targetAttribute = "country_name")
-    val json = """{"_t":"MappingConformanceRule","order":5,"controlCheckpoint":true,"mappingTable":"country","mappingTableVersion":0,"attributeMappings":{"country_code":"country"},"targetAttribute":"country_name","outputColumn":"conformed_country","isNullSafe":false,"mappingTableFilter":null,"overrideMappingTableOwnFilter":false}"""
+      targetAttribute = "country_name", mappingTableFilter = Option(filter), overrideMappingTableOwnFilter = Option(true))
+    val json = """{"_t":"MappingConformanceRule","order":5,"controlCheckpoint":true,"mappingTable":"country","mappingTableVersion":0,"attributeMappings":{"country_code":"country"},"targetAttribute":"country_name","outputColumn":"conformed_country","isNullSafe":false,"mappingTableFilter":{"_t":"IsNullFilter","columnName":"country"},"overrideMappingTableOwnFilter":true}"""
     assertSerDe(rule, json)
   }
+
+  "MappingConformanceRule without filter (old MappingConformanceRule)" should {
+    val rule = MappingConformanceRule(order = 5, controlCheckpoint = true, outputColumn = "conformed_country",
+      mappingTable = "country", mappingTableVersion = 0, attributeMappings = Map("country_code" -> "country"),
+      targetAttribute = "country_name", overrideMappingTableOwnFilter = None)
+    val json = """{"_t":"MappingConformanceRule","order":5,"controlCheckpoint":true,"mappingTable":"country","mappingTableVersion":0,"attributeMappings":{"country_code":"country"},"targetAttribute":"country_name","outputColumn":"conformed_country","isNullSafe":false}"""
+    assertDeserialization(rule, json)
+  }
+
 
   "NegationConformanceRule" should {
     val rule = NegationConformanceRule(order = 6, controlCheckpoint = true, outputColumn = "conformed_col", inputColumn = "asd")
@@ -98,15 +109,21 @@ class ConformanceRuleTest extends WordSpec with Matchers {
   }
 
   private def assertSerDe(rule: ConformanceRule, json: String): Unit = {
+    assertSerialization(rule, json)
+    assertDeserialization(rule, json)
+  }
+
+  private def assertSerialization(rule: ConformanceRule, json: String): Unit = {
     "serialize to a typed JSON" in {
       val serializedRule = objectMapper.writeValueAsString(rule)
       serializedRule shouldBe json
     }
+  }
 
+  private def assertDeserialization(rule: ConformanceRule, json: String): Unit = {
     "deserialize polymorphically from a typed JSON" in {
       val deserializedRule = objectMapper.readValue(json, classOf[ConformanceRule])
       deserializedRule shouldBe rule
     }
   }
-
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/DatasetMongoRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/DatasetMongoRepository.scala
@@ -93,7 +93,7 @@ class DatasetMongoRepository @Autowired()(mongoDb: MongoDatabase)
   }
 
   private val ORIGINAL_DELIMETER = '.'
-  private val REPLACEMENT_DELIMETER = MappingConformanceRule.DOT_REPLACEMENT_SYMBOL
+  private val REPLACEMENT_DELIMETER = MappingConformanceRule.DotReplacementSymbol
 
   private def replaceForWrite(key: String): String = key.replace(ORIGINAL_DELIMETER, REPLACEMENT_DELIMETER)
 

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/repositories/DatasetRepositoryIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/repositories/DatasetRepositoryIntegrationSuite.scala
@@ -96,7 +96,7 @@ class DatasetRepositoryIntegrationSuite extends BaseRepositoryTest {
     DatasetFactory.getDummyMappingRule(order = 3, targetAttribute = "ab",
       attributeMappings = Map("ab" -> "ab")),
     DatasetFactory.getDummyMappingRule(order = 4, targetAttribute = "a.b",
-      attributeMappings = Map(s"a${MappingConformanceRule.DOT_REPLACEMENT_SYMBOL}b" -> "a.b"))
+      attributeMappings = Map(s"a${MappingConformanceRule.DotReplacementSymbol}b" -> "a.b"))
   )
 
   val materializedMappingConformanceRules = List(

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/CommonMappingRuleInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/CommonMappingRuleInterpreter.scala
@@ -61,7 +61,7 @@ trait CommonMappingRuleInterpreter {
       // This is a workaround until UI supports filter definition. Until then, the filters can be set via configuration.
       FilterFromConfig.loadFilter(rule.mappingTable)
     }
-    val mappingTableFilter = mappingTableDef.filter.filterNot(_ => rule.overrideMappingTableOwnFilter)
+    val mappingTableFilter = mappingTableDef.filter.filterNot(_ => rule.getOverrideMappingTableOwnFilter)
     // find the data frame from the mapping table
     val filter: Option[DataFrameFilter] = (ruleFilter, mappingTableFilter) match {
       case (Some(a), Some(b)) => Option(a and b)


### PR DESCRIPTION
* `overrideMappingTableOwnFilter` made optional
* added UT testing the old serialization
* fixed a few compilation warnings
Fixes #1666 

Release notes:
`overrideMappingTableOwnFilter` was made optional in `MappingConformanceRule` de-/serialization so old serializations of conformance rules without the property are still readable.