### PR TITLE
1669 Add Admin Role based authorization for property def

### DIFF
--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -40,7 +40,7 @@ menas.auth.jwt.lifespan.hours=8
 menas.auth.mechanism=inmemory
 # Must be defined and non empty
 menas.auth.admin.role=ROLE_ADMIN
-#menas.auth.roles.regex=^[A-Za-z]+_ADMIN$
+#menas.auth.roles.regex=^[A-z]+_ADMIN$
 
 #menas.auth.kerberos.debug=false
 #menas.auth.kerberos.krb5conf=/etc/krb5.conf
@@ -162,4 +162,3 @@ menas.oozie.splineMongoURL=mongodb://localhost:27017
 #javax.net.ssl.trustStorePassword=somePassword
 #javax.net.ssl.keyStore=/path/to/keystore.jks
 #javax.net.ssl.keyStorePassword=somePassword
-

--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -39,6 +39,7 @@ menas.auth.jwt.lifespan.hours=8
 # How will users authenticate to menas. Available options: inmemory, kerberos
 menas.auth.mechanism=inmemory
 menas.auth.admin.role=ROLE_ADMIN
+#menas.auth.roles.regex=^[A-Za-z]+_ADMIN$
 
 #menas.auth.kerberos.debug=false
 #menas.auth.kerberos.krb5conf=/etc/krb5.conf

--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -38,6 +38,7 @@ menas.auth.jwt.lifespan.hours=8
 
 # How will users authenticate to menas. Available options: inmemory, kerberos
 menas.auth.mechanism=inmemory
+# Must be defined and non empty
 menas.auth.admin.role=ROLE_ADMIN
 #menas.auth.roles.regex=^[A-Za-z]+_ADMIN$
 

--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -50,8 +50,8 @@ menas.auth.mechanism=inmemory
 
 menas.auth.inmemory.user=user
 menas.auth.inmemory.password=changeme
-menas.auth.inmemory.admin.user=admin
-menas.auth.inmemory.admin.password=admin
+menas.auth.inmemory.admin.user=menas_admin
+menas.auth.inmemory.admin.password=admin123
 
 
 # Define how menas authenticates to Hadoop. Supported options are:

--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -38,6 +38,7 @@ menas.auth.jwt.lifespan.hours=8
 
 # How will users authenticate to menas. Available options: inmemory, kerberos
 menas.auth.mechanism=inmemory
+menas.auth.admin.role=ROLE_ADMIN
 
 #menas.auth.kerberos.debug=false
 #menas.auth.kerberos.krb5conf=/etc/krb5.conf
@@ -52,7 +53,6 @@ menas.auth.inmemory.user=user
 menas.auth.inmemory.password=changeme
 menas.auth.inmemory.admin.user=menas_admin
 menas.auth.inmemory.admin.password=admin123
-
 
 # Define how menas authenticates to Hadoop. Supported options are:
 #  "default" -> will use the default authentication or kerberos ticket from the system

--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -50,6 +50,9 @@ menas.auth.mechanism=inmemory
 
 menas.auth.inmemory.user=user
 menas.auth.inmemory.password=changeme
+menas.auth.inmemory.admin.user=admin
+menas.auth.inmemory.admin.password=admin
+
 
 # Define how menas authenticates to Hadoop. Supported options are:
 #  "default" -> will use the default authentication or kerberos ticket from the system

--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -161,5 +161,3 @@ menas.oozie.splineMongoURL=mongodb://localhost:27017
 #javax.net.ssl.keyStore=/path/to/keystore.jks
 #javax.net.ssl.keyStorePassword=somePassword
 
-# Temporary fix for locking of property definition updates #1673
-# menas.feature.property.definitions.allowUpdate=false

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/MvcConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/MvcConfig.scala
@@ -21,7 +21,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class MvcConfig extends WebMvcConfigurer {
-  def addViewControllers(registry: ViewControllerRegistry) {
+  override def addViewControllers(registry: ViewControllerRegistry) {
     registry.addViewController("/login").setViewName("login")
   }
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
@@ -33,7 +33,10 @@ import za.co.absa.enceladus.menas.auth.kerberos.MenasKerberosAuthentication
 import za.co.absa.enceladus.utils.general.ProjectMetadata
 
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableGlobalMethodSecurity(
+  prePostEnabled = true,
+  securedEnabled = true,
+  jsr250Enabled = true)
 class WebSecurityConfig @Autowired()(beanFactory: BeanFactory,
                                      jwtAuthFilter: JwtAuthenticationFilter,
                                      @Value("${menas.auth.mechanism:}")

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
@@ -32,11 +32,9 @@ import za.co.absa.enceladus.menas.auth.jwt.JwtAuthenticationFilter
 import za.co.absa.enceladus.menas.auth.kerberos.MenasKerberosAuthentication
 import za.co.absa.enceladus.utils.general.ProjectMetadata
 
+
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(
-  prePostEnabled = true,
-  securedEnabled = true,
-  jsr250Enabled = true)
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 class WebSecurityConfig @Autowired()(beanFactory: BeanFactory,
                                      jwtAuthFilter: JwtAuthenticationFilter,
                                      @Value("${menas.auth.mechanism:}")

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.{Autowired, Value}
 import org.springframework.context.annotation.{Bean, Configuration}
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.{EnableWebSecurity, WebSecurityConfigurerAdapter}
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -32,6 +33,7 @@ import za.co.absa.enceladus.menas.auth.kerberos.MenasKerberosAuthentication
 import za.co.absa.enceladus.utils.general.ProjectMetadata
 
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 class WebSecurityConfig @Autowired()(beanFactory: BeanFactory,
                                      jwtAuthFilter: JwtAuthenticationFilter,
                                      @Value("${menas.auth.mechanism:}")

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/AuthConstants.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/AuthConstants.scala
@@ -33,4 +33,12 @@ object AuthConstants {
   val JwtCookieKey: String = "JWT"
   val CsrfTokenKey: String = "X-CSRF-TOKEN"
   val RolesKey: String = "Roles"
+
+  @Value("${menas.auth.roles.regex:}")
+  val RolesRegex: String = ""
+
+  def filterByRolesRegex(roles: Seq[String]): Seq[String] = {
+    if (RolesRegex.isEmpty) { roles }
+    else { roles.filter(authority => authority.matches(RolesRegex)) }
+  }
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/AuthConstants.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/AuthConstants.scala
@@ -33,12 +33,4 @@ object AuthConstants {
   val JwtCookieKey: String = "JWT"
   val CsrfTokenKey: String = "X-CSRF-TOKEN"
   val RolesKey: String = "Roles"
-
-  @Value("${menas.auth.roles.regex:}")
-  val RolesRegex: String = ""
-
-  def filterByRolesRegex(roles: Seq[String]): Seq[String] = {
-    if (RolesRegex.isEmpty) { roles }
-    else { roles.filter(authority => authority.matches(RolesRegex)) }
-  }
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/AuthConstants.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/AuthConstants.scala
@@ -15,10 +15,22 @@
 
 package za.co.absa.enceladus.menas.auth
 
-object AuthConstants {
+import org.springframework.beans.factory.annotation.{Autowired, Value}
+import org.springframework.security.core.{Authentication, GrantedAuthority}
+import org.springframework.stereotype.Component
 
+@Component("authConstants")
+class AuthConstants @Autowired()() {
+  @Value("${menas.auth.admin.role}")
+  val AdminRole: String = ""
+
+  def hasAdminRole(auth: Authentication): Boolean = {
+    auth.getAuthorities.toArray(Array[GrantedAuthority]()).map(auth => auth.getAuthority).contains(AdminRole)
+  }
+}
+
+object AuthConstants {
   val JwtCookieKey: String = "JWT"
   val CsrfTokenKey: String = "X-CSRF-TOKEN"
-  val GroupsKey: String = "groups"
-
+  val RolesKey: String = "Roles"
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/AuthConstants.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/AuthConstants.scala
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component
 @Component("authConstants")
 class AuthConstants @Autowired()() {
   @Value("${menas.auth.admin.role}")
-  val AdminRole: String = ""
+  private val AdminRole: String = ""
 
   def hasAdminRole(auth: Authentication): Boolean = {
     auth.getAuthorities.toArray(Array[GrantedAuthority]()).map(auth => auth.getAuthority).contains(AdminRole)

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/InMemoryMenasAuthentication.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/InMemoryMenasAuthentication.scala
@@ -31,6 +31,8 @@ class InMemoryMenasAuthentication extends MenasAuthentication {
   private val adminUsername: String = ""
   @Value("${menas.auth.inmemory.admin.password:}")
   private val adminPassword: String = ""
+  @Value("${menas.auth.admin.role}") // Spring throws errors if it is not here as well
+  private val adminRole: String = ""
 
   protected val passwordEncoder = new BCryptPasswordEncoder()
 
@@ -58,7 +60,7 @@ class InMemoryMenasAuthentication extends MenasAuthentication {
       .and()
       .withUser(adminUsername)
       .password(passwordEncoder.encode(adminPassword))
-      .authorities("ROLE_ADMIN")
+      .authorities(adminRole)
   }
 
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/InMemoryMenasAuthentication.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/InMemoryMenasAuthentication.scala
@@ -27,6 +27,10 @@ class InMemoryMenasAuthentication extends MenasAuthentication {
   private val username: String = ""
   @Value("${menas.auth.inmemory.password:}")
   private val password: String = ""
+  @Value("${menas.auth.inmemory.admin.user:}")
+  private val adminUsername: String = ""
+  @Value("${menas.auth.inmemory.admin.password:}")
+  private val adminPassword: String = ""
 
   protected val passwordEncoder = new BCryptPasswordEncoder()
 
@@ -51,6 +55,10 @@ class InMemoryMenasAuthentication extends MenasAuthentication {
       .withUser(username)
       .password(passwordEncoder.encode(password))
       .authorities("ROLE_USER")
+      .and()
+      .withUser(adminUsername)
+      .password(passwordEncoder.encode(adminPassword))
+      .authorities("ROLE_ADMIN")
   }
 
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/MenasAuthenticationSuccessHandler.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/MenasAuthenticationSuccessHandler.scala
@@ -46,12 +46,15 @@ class MenasAuthenticationSuccessHandler @Autowired()(jwtFactory: JwtFactory,
     val jwtExpirationTime = DateTime.now(DateTimeZone.forID(timezone)).plus(expiry).toDate
     val cookieLifetime = expiry.getSeconds
 
+    val groups = user.getAuthorities.toArray(Array[GrantedAuthority]()).map(auth => auth.getAuthority).toSeq
+    val filteredGroups = AuthConstants.filterByRolesRegex(groups)
+
     val jwt = jwtFactory
       .jwtBuilder()
       .setSubject(user.getUsername)
       .setExpiration(jwtExpirationTime)
       .claim(CsrfTokenKey, csrfToken)
-      .claim(RolesKey, user.getAuthorities.toArray(Array[GrantedAuthority]()).map(auth => auth.getAuthority))
+      .claim(RolesKey, filteredGroups)
       .compact()
 
     val cookie = new Cookie(JwtCookieKey, jwt)

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/MenasAuthenticationSuccessHandler.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/MenasAuthenticationSuccessHandler.scala
@@ -20,14 +20,12 @@ import java.util.UUID
 import javax.servlet.http.{Cookie, HttpServletRequest, HttpServletResponse}
 import org.joda.time.{DateTime, DateTimeZone, Hours}
 import org.springframework.beans.factory.annotation.{Autowired, Value}
-import org.springframework.security.core.Authentication
+import org.springframework.security.core.{Authentication, GrantedAuthority}
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
 import org.springframework.stereotype.Component
 import za.co.absa.enceladus.menas.auth.AuthConstants._
 import za.co.absa.enceladus.menas.auth.jwt.JwtFactory
-
-import scala.collection.JavaConverters._
 
 @Component
 class MenasAuthenticationSuccessHandler @Autowired()(jwtFactory: JwtFactory,
@@ -53,6 +51,7 @@ class MenasAuthenticationSuccessHandler @Autowired()(jwtFactory: JwtFactory,
       .setSubject(user.getUsername)
       .setExpiration(jwtExpirationTime)
       .claim(CsrfTokenKey, csrfToken)
+      .claim(RolesKey, user.getAuthorities.toArray(Array[GrantedAuthority]()).map(auth => auth.getAuthority))
       .compact()
 
     val cookie = new Cookie(JwtCookieKey, jwt)

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/MenasAuthenticationSuccessHandler.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/MenasAuthenticationSuccessHandler.scala
@@ -54,7 +54,8 @@ class MenasAuthenticationSuccessHandler @Autowired()(jwtFactory: JwtFactory,
     val filteredGroups = if (rolesRegex.isEmpty) {
       groups
     } else {
-      groups.filter(authority => rolesRegex.r.findFirstIn(authority).isDefined)
+      val regex = rolesRegex.r
+      groups.filter(authority => regex.findFirstIn(authority).isDefined)
     }
 
     val jwt = jwtFactory

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/MenasAuthenticationSuccessHandler.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/MenasAuthenticationSuccessHandler.scala
@@ -46,8 +46,8 @@ class MenasAuthenticationSuccessHandler @Autowired()(jwtFactory: JwtFactory,
     val jwtExpirationTime = DateTime.now(DateTimeZone.forID(timezone)).plus(expiry).toDate
     val cookieLifetime = expiry.getSeconds
 
-    val groups = user.getAuthorities.toArray(Array[GrantedAuthority]()).map(auth => auth.getAuthority).toSeq
-    val filteredGroups = AuthConstants.filterByRolesRegex(groups)
+    val groups = user.getAuthorities.toArray(Array[GrantedAuthority]()).map(auth => auth.getAuthority)
+    val filteredGroups = AuthConstants.filterByRolesRegex(groups).toArray
 
     val jwt = jwtFactory
       .jwtBuilder()

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/jwt/JwtAuthenticationFilter.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/jwt/JwtAuthenticationFilter.scala
@@ -20,7 +20,7 @@ import java.util
 import io.jsonwebtoken.Claims
 import javax.servlet.FilterChain
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import org.springframework.beans.factory.annotation.{Autowired, Value}
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.SimpleGrantedAuthority

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/jwt/JwtAuthenticationFilter.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/jwt/JwtAuthenticationFilter.scala
@@ -75,8 +75,7 @@ class JwtAuthenticationFilter @Autowired()(jwtFactory: JwtFactory) extends OnceP
 
   private def parseJwtAuthorities(jwtClaims: Claims): util.List[SimpleGrantedAuthority] = {
     val groups: Seq[String] = Option(jwtClaims.get(RolesKey, classOf[util.List[String]]))
-      .getOrElse(new util.ArrayList[String]())
-      .asScala
+    .fold(Seq.empty[String])(_.asScala.toSeq)
 
     groups.map(k => new SimpleGrantedAuthority(k)).asJava
   }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/jwt/JwtAuthenticationFilter.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/jwt/JwtAuthenticationFilter.scala
@@ -20,7 +20,7 @@ import java.util
 import io.jsonwebtoken.Claims
 import javax.servlet.FilterChain
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.{Autowired, Value}
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -28,7 +28,6 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.User
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
-import za.co.absa.enceladus.menas.auth.AuthConstants
 import za.co.absa.enceladus.menas.auth.AuthConstants._
 
 import scala.collection.JavaConverters._
@@ -79,7 +78,7 @@ class JwtAuthenticationFilter @Autowired()(jwtFactory: JwtFactory) extends OnceP
       .getOrElse(new util.ArrayList[String]())
       .asScala
 
-    AuthConstants.filterByRolesRegex(groups).map(k => new SimpleGrantedAuthority(k)).asJava
+    groups.map(k => new SimpleGrantedAuthority(k)).asJava
   }
 
   private def isCsrfSafe(request: HttpServletRequest, jwtClaims: Claims): Boolean = {

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/jwt/JwtAuthenticationFilter.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/jwt/JwtAuthenticationFilter.scala
@@ -74,7 +74,7 @@ class JwtAuthenticationFilter @Autowired()(jwtFactory: JwtFactory) extends OnceP
   }
 
   private def parseJwtAuthorities(jwtClaims: Claims): util.List[SimpleGrantedAuthority] = {
-    val groups = Option(jwtClaims.get(GroupsKey, classOf[util.List[String]]))
+    val groups = Option(jwtClaims.get(RolesKey, classOf[util.List[String]]))
       .getOrElse(new util.ArrayList[String]()).asScala
 
     groups.map(k => new SimpleGrantedAuthority(k)).asJava

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/kerberos/MenasKerberosAuthentication.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/kerberos/MenasKerberosAuthentication.scala
@@ -128,18 +128,6 @@ class MenasKerberosAuthentication @Autowired()(@Value("${menas.auth.ad.domain:}"
     val originalLogLevel = Logger.getRootLogger.getLevel
     //something here changes the log level to WARN
 
-//    TODO NEEDS DISCUSSION
-//    It is also possible to add a menas_admin user like to the AD connected auth. This is if we do not want to
-//    add new user to AD. Password would then need to be pulled from a setting in tomcat or props
-//
-//    val passwordEncoder = new BCryptPasswordEncoder()
-//    auth
-//      .inMemoryAuthentication()
-//      .passwordEncoder(passwordEncoder)
-//      .withUser("menas_admin")
-//      .password(passwordEncoder.encode("admin123"))
-//      .authorities("ROLE_ADMIN")
-
     auth
       .authenticationProvider(new MenasKerberosAuthenticationProvider(adServer, ldapSearchFilter, ldapSearchBase))
       .authenticationProvider(kerberosServiceAuthenticationProvider())

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/kerberos/MenasKerberosAuthentication.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/kerberos/MenasKerberosAuthentication.scala
@@ -24,7 +24,6 @@ import org.springframework.core.io.FileSystemResource
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.core.AuthenticationException
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.kerberos.authentication.KerberosServiceAuthenticationProvider
 import org.springframework.security.kerberos.authentication.sun.SunJaasKerberosTicketValidator
 import org.springframework.security.kerberos.client.config.SunJaasKrb5LoginConfig
@@ -127,7 +126,6 @@ class MenasKerberosAuthentication @Autowired()(@Value("${menas.auth.ad.domain:}"
     this.validateParams()
     val originalLogLevel = Logger.getRootLogger.getLevel
     //something here changes the log level to WARN
-
     auth
       .authenticationProvider(new MenasKerberosAuthenticationProvider(adServer, ldapSearchFilter, ldapSearchBase))
       .authenticationProvider(kerberosServiceAuthenticationProvider())

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/kerberos/MenasKerberosAuthentication.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/kerberos/MenasKerberosAuthentication.scala
@@ -24,6 +24,7 @@ import org.springframework.core.io.FileSystemResource
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.core.AuthenticationException
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.kerberos.authentication.KerberosServiceAuthenticationProvider
 import org.springframework.security.kerberos.authentication.sun.SunJaasKerberosTicketValidator
 import org.springframework.security.kerberos.client.config.SunJaasKrb5LoginConfig
@@ -126,6 +127,19 @@ class MenasKerberosAuthentication @Autowired()(@Value("${menas.auth.ad.domain:}"
     this.validateParams()
     val originalLogLevel = Logger.getRootLogger.getLevel
     //something here changes the log level to WARN
+
+//    TODO NEEDS DISCUSSION
+//    It is also possible to add a menas_admin user like to the AD connected auth. This is if we do not want to
+//    add new user to AD. Password would then need to be pulled from a setting in tomcat or props
+//
+//    val passwordEncoder = new BCryptPasswordEncoder()
+//    auth
+//      .inMemoryAuthentication()
+//      .passwordEncoder(passwordEncoder)
+//      .withUser("menas_admin")
+//      .password(passwordEncoder.encode("admin123"))
+//      .authorities("ROLE_ADMIN")
+
     auth
       .authenticationProvider(new MenasKerberosAuthenticationProvider(adServer, ldapSearchFilter, ldapSearchBase))
       .authenticationProvider(kerberosServiceAuthenticationProvider())

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
@@ -51,7 +51,7 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
 
   @PostMapping(Array(""))
   @ResponseStatus(HttpStatus.CREATED)
-  @PreAuthorize("'menas_admin' == authentication.name")
+  @PreAuthorize("@authConstants.hasAdminRole(authentication)")
   def createDatasetProperty(@AuthenticationPrincipal principal: UserDetails,
                             @RequestBody item: PropertyDefinition): CompletableFuture[ResponseEntity[PropertyDefinition]] = {
     // basically an alias for /create with Location header response
@@ -82,28 +82,28 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
 
   @PostMapping(Array("/importItem"))
   @ResponseStatus(HttpStatus.CREATED)
-  @PreAuthorize("'menas_admin' == authentication.name")
+  @PreAuthorize("@authConstants.hasAdminRole(authentication)")
   override def importSingleEntity(@AuthenticationPrincipal principal: UserDetails,
                                   @RequestBody importObject: ExportableObject[PropertyDefinition]): CompletableFuture[PropertyDefinition] =
     super.importSingleEntity(principal, importObject)
 
   @RequestMapping(method = Array(RequestMethod.POST, RequestMethod.PUT), path = Array("/edit"))
   @ResponseStatus(HttpStatus.CREATED)
-  @PreAuthorize("'menas_admin' == authentication.name")
+  @PreAuthorize("@authConstants.hasAdminRole(authentication)")
   override def edit(@AuthenticationPrincipal user: UserDetails,
                     @RequestBody item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
     super.edit(user, item)
 
   @DeleteMapping(Array("/disable/{name}", "/disable/{name}/{version}"))
   @ResponseStatus(HttpStatus.OK)
-  @PreAuthorize("'menas_admin' == authentication.name")
+  @PreAuthorize("@authConstants.hasAdminRole(authentication)")
   override def disable(@PathVariable name: String,
                        @PathVariable version: Optional[String]): CompletableFuture[UpdateResult] =
     super.disable(name, version)
 
   @PostMapping(Array("/create"))
   @ResponseStatus(HttpStatus.CREATED)
-  @PreAuthorize("'menas_admin' == authentication.name")
+  @PreAuthorize("@authConstants.hasAdminRole(authentication)")
   override def create(@AuthenticationPrincipal principal: UserDetails,
                       @RequestBody item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
     super.create(principal, item)

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
@@ -55,17 +55,13 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
   @PreAuthorize("@authConstants.hasAdminRole(authentication)")
   def createDatasetProperty(@AuthenticationPrincipal principal: UserDetails,
                             @RequestBody item: PropertyDefinition): CompletableFuture[ResponseEntity[PropertyDefinition]] = {
-    if (enabled){
-      // basically an alias for /create with Location header response
-      logger.info(s"creating new property definition '${item.name}'")
+    // basically an alias for /create with Location header response
+    logger.info(s"creating new property definition '${item.name}'")
 
-      import scala.compat.java8.FutureConverters.CompletionStageOps // implicit wrapper with toScala for CompletableFuture
-      super.create(principal, item).toScala.map{ entity =>
-        val location: URI = new URI(s"/api/properties/datasets/${entity.name}/${entity.version}")
-        ResponseEntity.created(location).body(entity)
-      }
-    } else {
-      throw EndpointDisabled("Endpoint Not Found")
+    import scala.compat.java8.FutureConverters.CompletionStageOps // implicit wrapper with toScala for CompletableFuture
+    super.create(principal, item).toScala.map{ entity =>
+      val location: URI = new URI(s"/api/properties/datasets/${entity.name}/${entity.version}")
+      ResponseEntity.created(location).body(entity)
     }
 
     // TODO: Location header would make sense for the underlying VersionedModelController.create, too. Issue #1611

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
@@ -83,25 +83,28 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
   @PostMapping(Array("/importItem"))
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize("'menas_admin' == authentication.name")
-  override def importSingleEntity(principal: UserDetails,
-                                  importObject: ExportableObject[PropertyDefinition]): CompletableFuture[PropertyDefinition] =
+  override def importSingleEntity(@AuthenticationPrincipal principal: UserDetails,
+                                  @RequestBody importObject: ExportableObject[PropertyDefinition]): CompletableFuture[PropertyDefinition] =
     super.importSingleEntity(principal, importObject)
 
   @RequestMapping(method = Array(RequestMethod.POST, RequestMethod.PUT), path = Array("/edit"))
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize("'menas_admin' == authentication.name")
-  override def edit(user: UserDetails, item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
+  override def edit(@AuthenticationPrincipal user: UserDetails,
+                    @RequestBody item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
     super.edit(user, item)
 
   @DeleteMapping(Array("/disable/{name}", "/disable/{name}/{version}"))
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("'menas_admin' == authentication.name")
-  override def disable(name: String, version: Optional[String]): CompletableFuture[UpdateResult] =
+  override def disable(@PathVariable name: String,
+                       @PathVariable version: Optional[String]): CompletableFuture[UpdateResult] =
     super.disable(name, version)
 
   @PostMapping(Array("/create"))
   @ResponseStatus(HttpStatus.CREATED)
   @PreAuthorize("'menas_admin' == authentication.name")
-  override def create(principal: UserDetails, item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
+  override def create(@AuthenticationPrincipal principal: UserDetails,
+                      @RequestBody item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
     super.create(principal, item)
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
@@ -20,10 +20,12 @@ import java.util.concurrent.CompletableFuture
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.{HttpStatus, ResponseEntity}
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation._
 import za.co.absa.enceladus.menas.services.PropertyDefinitionService
+import za.co.absa.enceladus.model.ExportableObject
 import za.co.absa.enceladus.model.properties.PropertyDefinition
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -42,11 +44,12 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
   @GetMapping(Array(""))
   def getAllDatasetProperties(): CompletableFuture[Seq[PropertyDefinition]] = {
     logger.info("retrieving all dataset properties in full")
-    propertyDefService.getLatestVersions
+    propertyDefService.getLatestVersions()
   }
 
   @PostMapping(Array(""))
   @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize("'menas_admin' == authentication.name")
   def createDatasetProperty(@AuthenticationPrincipal principal: UserDetails,
                             @RequestBody item: PropertyDefinition): CompletableFuture[ResponseEntity[PropertyDefinition]] = {
     // basically an alias for /create with Location header response
@@ -75,4 +78,16 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
     super.getVersionDetail(propertyName, version)
   }
 
+  @PostMapping(Array("/importItem"))
+  @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize("'menas_admin' == authentication.name")
+  override def importSingleEntity(principal: UserDetails,
+                                  importObject: ExportableObject[PropertyDefinition]): CompletableFuture[PropertyDefinition] =
+    super.importSingleEntity(principal, importObject)
+
+  @RequestMapping(method = Array(RequestMethod.POST, RequestMethod.PUT), path = Array("/edit"))
+  @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize("'menas_admin' == authentication.name")
+  override def edit(user: UserDetails, item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
+    super.edit(user, item)
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
@@ -16,8 +16,10 @@
 package za.co.absa.enceladus.menas.controllers
 
 import java.net.URI
+import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
+import com.mongodb.client.result.UpdateResult
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.{HttpStatus, ResponseEntity}
 import org.springframework.security.access.prepost.PreAuthorize
@@ -90,4 +92,16 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
   @PreAuthorize("'menas_admin' == authentication.name")
   override def edit(user: UserDetails, item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
     super.edit(user, item)
+
+  @DeleteMapping(Array("/disable/{name}", "/disable/{name}/{version}"))
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("'menas_admin' == authentication.name")
+  override def disable(name: String, version: Optional[String]): CompletableFuture[UpdateResult] =
+    super.disable(name, version)
+
+  @PostMapping(Array("/create"))
+  @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize("'menas_admin' == authentication.name")
+  override def create(principal: UserDetails, item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
+    super.create(principal, item)
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/PropertyDefinitionController.scala
@@ -44,9 +44,6 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
 
   import za.co.absa.enceladus.menas.utils.implicits._
 
-  @Value("${menas.feature.property.definitions.allowUpdate:false}")
-  private val enabled: Boolean = false
-
   @GetMapping(Array(""))
   def getAllDatasetProperties(): CompletableFuture[Seq[PropertyDefinition]] = {
     logger.info("retrieving all dataset properties in full")
@@ -115,5 +112,5 @@ class PropertyDefinitionController @Autowired()(propertyDefService: PropertyDefi
   override def create(@AuthenticationPrincipal principal: UserDetails,
                       @RequestBody item: PropertyDefinition): CompletableFuture[PropertyDefinition] =
     super.create(principal, item)
-    
+
 }

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -55,6 +55,8 @@ menas.hadoop.auth.krb5.keytab=hdfs.keytab
 
 menas.auth.inmemory.user=user
 menas.auth.inmemory.password=chang< )eme
+menas.auth.inmemory.admin.user=admin
+menas.auth.inmemory.admin.password=chang< )eme2nd
 
 # embedded mongo for integTest will be launched instead on a random free port
 menas.mongo.connection.string=mongodb://not-used-for-testing:12345

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -42,6 +42,7 @@ menas.auth.jwt.lifespan.hours=8
 
 # How will users authenticate to menas. Available options: inmemory, kerberos
 menas.auth.mechanism = inmemory
+menas.auth.admin.role=ROLE_ADMIN
 
 # Define how menas authenticates to Hadoop. Supported options are:
 #  "default" -> will use the default authentication or kerberos ticket from the system

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -41,7 +41,7 @@ menas.auth.jwt.secret=u7w!z%C*F-JaNdRgUkXp2s5v8y/A?D(G+KbPeShVmYq3t6w9z$C&E)H@Mc
 menas.auth.jwt.lifespan.hours=8
 
 # How will users authenticate to menas. Available options: inmemory, kerberos
-menas.auth.mechanism = inmemory
+menas.auth.mechanism=inmemory
 menas.auth.admin.role=ROLE_ADMIN
 
 # Define how menas authenticates to Hadoop. Supported options are:

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -56,7 +56,7 @@ menas.hadoop.auth.krb5.keytab=hdfs.keytab
 menas.auth.inmemory.user=user
 menas.auth.inmemory.password=chang< )eme
 menas.auth.inmemory.admin.user=menas_admin
-menas.auth.inmemory.admin.password=chang< )eme2nd
+menas.auth.inmemory.admin.password=admin123
 
 # embedded mongo for integTest will be launched instead on a random free port
 menas.mongo.connection.string=mongodb://not-used-for-testing:12345

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -83,5 +83,3 @@ menas.monitoring.fetch.limit=500
 
 #----------- Schema Registry
 menas.schemaRegistry.baseUrl=http://localhost:8877
-
-menas.feature.property.definitions.allowUpdate=true

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -55,7 +55,7 @@ menas.hadoop.auth.krb5.keytab=hdfs.keytab
 
 menas.auth.inmemory.user=user
 menas.auth.inmemory.password=chang< )eme
-menas.auth.inmemory.admin.user=admin
+menas.auth.inmemory.admin.user=menas_admin
 menas.auth.inmemory.admin.password=chang< )eme2nd
 
 # embedded mongo for integTest will be launched instead on a random free port

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/PropertyDefinitionApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/PropertyDefinitionApiIntegrationSuite.scala
@@ -64,7 +64,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
         "a PropertyDefinition is created" should {
           "return the created PropertyDefinition" in {
             val propertyDefinition = PropertyDefinitionFactory.getDummyPropertyDefinition()
-            val response = sendPost[PropertyDefinition, PropertyDefinition](urlPattern, bodyOpt = Some(propertyDefinition))
+            val response = sendPostByAdmin[PropertyDefinition, PropertyDefinition](urlPattern, bodyOpt = Some(propertyDefinition))
             assertCreated(response)
             if (locationHeaderSupport) {
               assert(response.getHeaders.getFirst("Location").contains("/api/properties/datasets/dummyName/1"))
@@ -78,7 +78,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
         "a PropertyDefinition is created with most of default values" should {
           "return the created PropertyDefinition" in {
             val propertyDefinition = minimalPdCreatePayload("smallPd", "default1")
-            val response = sendPost[String, PropertyDefinition](urlPattern, bodyOpt = Some(propertyDefinition))
+            val response = sendPostByAdmin[String, PropertyDefinition](urlPattern, bodyOpt = Some(propertyDefinition))
             assertCreated(response)
 
             val actual = response.getBody
@@ -91,7 +91,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
             val propertyDefinition = PropertyDefinitionFactory.getDummyPropertyDefinition(name = "propertyDefinition", version = 1)
             propertyDefinitionFixture.add(propertyDefinition.copy(disabled = true))
 
-            val response = sendPost[PropertyDefinition, PropertyDefinition](urlPattern, bodyOpt = Some(propertyDefinition.setVersion(0)))
+            val response = sendPostByAdmin[PropertyDefinition, PropertyDefinition](urlPattern, bodyOpt = Some(propertyDefinition.setVersion(0)))
             assertCreated(response)
 
             val actual = response.getBody
@@ -105,7 +105,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
           val propertyDefinition = PropertyDefinitionFactory.getDummyPropertyDefinition()
           propertyDefinitionFixture.add(propertyDefinition)
 
-          val response = sendPost[PropertyDefinition, Validation](urlPattern, bodyOpt = Some(propertyDefinition))
+          val response = sendPostByAdmin[PropertyDefinition, Validation](urlPattern, bodyOpt = Some(propertyDefinition))
           assertBadRequest(response)
 
           val actual = response.getBody
@@ -113,7 +113,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
           assert(actual == expected)
         }
         "an invalid PD payload is sent" in {
-          val response = sendPost[String, String](urlPattern, bodyOpt = Some(invalidPayload("somePd1")))
+          val response = sendPostByAdmin[String, String](urlPattern, bodyOpt = Some(invalidPayload("somePd1")))
           assertBadRequest(response)
 
           response.getBody shouldBe "The suggested value invalidOptionC cannot be used: Value 'invalidOptionC' is not one of the allowed values (a, b)."
@@ -130,7 +130,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
           val propertyDefinition2 = PropertyDefinitionFactory.getDummyPropertyDefinition(name = "otherPropertyDefinition", version = 1)
           propertyDefinitionFixture.add(propertyDefinition1, propertyDefinition2)
 
-          val response = sendDelete[PropertyDefinition, String](s"$apiUrl/disable/propertyDefinition")
+          val response = sendDeleteByAdmin[PropertyDefinition, String](s"$apiUrl/disable/propertyDefinition")
 
           assertOk(response)
 
@@ -145,7 +145,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
           val propertyDefinition2 = PropertyDefinitionFactory.getDummyPropertyDefinition(name = "propertyDefinition", version = 2)
           propertyDefinitionFixture.add(propertyDefinition1, propertyDefinition2)
 
-          val response = sendDelete[PropertyDefinition, String](s"$apiUrl/disable/propertyDefinition")
+          val response = sendDeleteByAdmin[PropertyDefinition, String](s"$apiUrl/disable/propertyDefinition")
 
           assertOk(response)
 
@@ -165,7 +165,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
           val propertyDefinition2 = PropertyDefinitionFactory.getDummyPropertyDefinition(name = "otherPropertyDefinition", version = 1)
           propertyDefinitionFixture.add(propertyDefinition1, propertyDefinition2)
 
-          val response = sendDelete[PropertyDefinition, String](s"$apiUrl/disable/propertyDefinition/1")
+          val response = sendDeleteByAdmin[PropertyDefinition, String](s"$apiUrl/disable/propertyDefinition/1")
           assertOk(response)
 
           val actual = response.getBody
@@ -183,7 +183,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
             val propertyDefinition2 = PropertyDefinitionFactory.getDummyPropertyDefinition(name = "propertyDefinition", version = 2)
             propertyDefinitionFixture.add(propertyDefinition1, propertyDefinition2)
 
-            val response = sendDelete[PropertyDefinition, String](deleteUrl)
+            val response = sendDeleteByAdmin[PropertyDefinition, String](deleteUrl)
             assertOk(response)
 
             val actual = response.getBody
@@ -195,7 +195,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
 
       "no PropertyDefinition with the given name exists" should {
         "disable nothing" in {
-          val response = sendDelete[PropertyDefinition, String](s"$apiUrl/disable/propertyDefinition/1")
+          val response = sendDeleteByAdmin[PropertyDefinition, String](s"$apiUrl/disable/propertyDefinition/1")
           assertOk(response)
 
           val actual = response.getBody


### PR DESCRIPTION
Fixes #1669 

RN: 
- Add configuration property `menas.auth.admin.role` to specify an admin role to operate property definitions create and update operations. 
- Remove temporary `menas.feature.property.definitions.allowUpdate` configuration property.
- Fix JWT not holding any roles/authorities
- Add the ability to filter the roles that are going to be used in JWT token and filtration by regex. This regex can be specified in the configuration property  `menas.auth.roles.regex`. 