### PR TITLE
Hdfs browser hiding

### DIFF
--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -32,8 +32,7 @@
                             <!-- HDFS Browser and its label -->
                         	<Input type="Text" id="selectedRawHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}" />
                             <hdfs:HDFSBrowser id="newDatasetRawHDFSBrowser" height="300px" width="100%"
-                                          busyControl="addDatasetDialog"
-                                          pathInput ="selectedRawHDFSPathLabel" restURI="{entity>/hdfsRestUri}"
+                                          busyControl="addDatasetDialog" pathInput ="selectedRawHDFSPathLabel"
                                           HDFSPath="{entity>/hdfsPath}" visible="{entity>/hdfsBrowserEnabled}" />
                             <!-- Simple field as an alternative -->
                             <Input id="newDatasetRawSimplePath" type="Text" placeholder="Dataset raw path" width="100%"
@@ -45,8 +44,7 @@
                             <!-- HDFS Browser and its label -->
                             <Input type="Text" id="selectedPublishHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}" />
                             <hdfs:HDFSBrowser id="newDatasetPublishHDFSBrowser" height="300px" width="100%"
-                                          busyControl="addDatasetDialog"
-                                          pathInput="selectedPublishHDFSPathLabel" restURI="{entity>/hdfsRestUri}"
+                                          busyControl="addDatasetDialog" pathInput="selectedPublishHDFSPathLabel"
                                           HDFSPath="{entity>/hdfsPublishPath}" visible="{entity>/hdfsBrowserEnabled}" />
                             <!-- Simple field as an alternative -->
                             <Input id="newDatasetPublishSimplePath" type="Text" placeholder="Dataset publish path" width="100%"

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -27,7 +27,7 @@
                         <Input id="newDatasetDescription" type="Text" placeholder="Description" width="100%"
                                value="{entity>/description}"/>
                         <core:Fragment type="XML" fragmentName="components.schema.selector.schemaSelector"/>
-                        <Label text="HDFS raw data folder path"/>
+                        <Label text="Raw data folder path"/>
                         <VBox>
                             <HBox>
                                 <!-- HDFS Browser input -->
@@ -52,7 +52,7 @@
                                               busyControl="addDatasetDialog" pathInput="selectedRawHDFSPathLabel"
                                               HDFSPath="{entity>/hdfsPath}" visible="{entity>/hdfsBrowserEnabled}"/>
                         </VBox>
-                        <Label text="HDFS conformed data publish folder path"/>
+                        <Label text="Conformed data publish folder path"/>
                         <VBox>
                             <!-- HDFS Browser and its label -->
                             <Input type="Text" id="selectedPublishHDFSPathLabel"

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -30,28 +30,28 @@
                         <Label text="HDFS raw data folder path"/>
                         <VBox>
                             <!-- HDFS Browser and its label -->
-                        	<Input type="Text" id="selectedRawHDFSPathLabel" visible="{entity>/enableHdfsBrowser}" />
+                        	<Input type="Text" id="selectedRawHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}" />
                             <hdfs:HDFSBrowser id="newDatasetRawHDFSBrowser" height="300px" width="100%"
                                           busyControl="addDatasetDialog"
                                           pathInput ="selectedRawHDFSPathLabel" restURI="api/hdfs/list"
-                                          HDFSPath="{entity>/hdfsPath}" visible="{entity>/enableHdfsBrowser}" />
+                                          HDFSPath="{entity>/hdfsPath}" visible="{entity>/hdfsBrowserEnabled}" />
                             <!-- Simple field as an alternative -->
-                            <Input id="newDatasetRawHdfsPath" type="Text" placeholder="Dataset raw path" width="100%"
+                            <Input id="newDatasetRawSimplePath" type="Text" placeholder="Dataset raw path" width="100%"
                                    value="{entity>/hdfsPath}"
-                                   visible="{path:'entity>/enableHdfsBrowser', formatter:'Formatters.not'}" />
+                                   visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}" />
                         </VBox>
                         <Label text="HDFS conformed data publish folder path"/>
                         <VBox>
                             <!-- HDFS Browser and its label -->
-                            <Input type="Text" id="selectedPublishHDFSPathLabel" visible="{entity>/enableHdfsBrowser}" />
+                            <Input type="Text" id="selectedPublishHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}" />
                             <hdfs:HDFSBrowser id="newDatasetPublishHDFSBrowser" height="300px" width="100%"
                                           busyControl="addDatasetDialog"
                                           pathInput="selectedPublishHDFSPathLabel" restURI="api/hdfs/list"
-                                          HDFSPath="{entity>/hdfsPublishPath}" visible="{entity>/enableHdfsBrowser}" />
+                                          HDFSPath="{entity>/hdfsPublishPath}" visible="{entity>/hdfsBrowserEnabled}" />
                             <!-- Simple field as an alternative -->
-                            <Input id="newDatasetPublishHdfsPath" type="Text" placeholder="Dataset publish path" width="100%"
+                            <Input id="newDatasetPublishSimplePath" type="Text" placeholder="Dataset publish path" width="100%"
                                    value="{entity>/hdfsPublishPath}"
-                                   visible="{path:'entity>/enableHdfsBrowser', formatter:'Formatters.not'}" />
+                                   visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}" />
                         </VBox>
                     </form:content>
                 </form:SimpleForm>

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -29,25 +29,36 @@
                         <core:Fragment type="XML" fragmentName="components.schema.selector.schemaSelector"/>
                         <Label text="HDFS raw data folder path"/>
                         <VBox>
-                        	<Input type="Text" id="selectedRawHDFSPathLabel"/>
+                            <!-- HDFS Browser and its label -->
+                        	<Input type="Text" id="selectedRawHDFSPathLabel" visible="{entity>/enableHdfsBrowser}" />
                             <hdfs:HDFSBrowser id="newDatasetRawHDFSBrowser" height="300px" width="100%"
                                           busyControl="addDatasetDialog"
                                           pathInput ="selectedRawHDFSPathLabel" restURI="api/hdfs/list"
-                                          HDFSPath="{entity>/hdfsPath}"/>
+                                          HDFSPath="{entity>/hdfsPath}" visible="{entity>/enableHdfsBrowser}" />
+                            <!-- Simple field as an alternative -->
+                            <Input id="newDatasetRawHdfsPath" type="Text" placeholder="Dataset raw path" width="100%"
+                                   value="{entity>/hdfsPath}"
+                                   visible="{path:'entity>/enableHdfsBrowser', formatter:'Formatters.not'}" />
                         </VBox>
                         <Label text="HDFS conformed data publish folder path"/>
                         <VBox>
-                            <Input type="Text" id="selectedPublishHDFSPathLabel"/>
+                            <!-- HDFS Browser and its label -->
+                            <Input type="Text" id="selectedPublishHDFSPathLabel" visible="{entity>/enableHdfsBrowser}" />
                             <hdfs:HDFSBrowser id="newDatasetPublishHDFSBrowser" height="300px" width="100%"
                                           busyControl="addDatasetDialog"
                                           pathInput="selectedPublishHDFSPathLabel" restURI="api/hdfs/list"
-                                          HDFSPath="{entity>/hdfsPublishPath}"/>
+                                          HDFSPath="{entity>/hdfsPublishPath}" visible="{entity>/enableHdfsBrowser}" />
+                            <!-- Simple field as an alternative -->
+                            <Input id="newDatasetPublishHdfsPath" type="Text" placeholder="Dataset publish path" width="100%"
+                                   value="{entity>/hdfsPublishPath}"
+                                   visible="{path:'entity>/enableHdfsBrowser', formatter:'Formatters.not'}" />
                         </VBox>
                     </form:content>
                 </form:SimpleForm>
             </VBox>
         </content>
         <buttons>
+            <Button class="hdfsToggleButton" id="toggleHdfsBrowser" text="Toggle HDFS browser/simple input" icon="sap-icon://journey-change"/>
             <Button id="newDatasetAddButton" text="Save" icon="sap-icon://accept"/>
             <Button id="newDatasetCancelButton" text="Cancel" icon="sap-icon://cancel"/>
         </buttons>

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -33,7 +33,7 @@
                         	<Input type="Text" id="selectedRawHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}" />
                             <hdfs:HDFSBrowser id="newDatasetRawHDFSBrowser" height="300px" width="100%"
                                           busyControl="addDatasetDialog"
-                                          pathInput ="selectedRawHDFSPathLabel" restURI="api/hdfs/list"
+                                          pathInput ="selectedRawHDFSPathLabel" restURI="{entity>/hdfsRestUri}"
                                           HDFSPath="{entity>/hdfsPath}" visible="{entity>/hdfsBrowserEnabled}" />
                             <!-- Simple field as an alternative -->
                             <Input id="newDatasetRawSimplePath" type="Text" placeholder="Dataset raw path" width="100%"
@@ -46,7 +46,7 @@
                             <Input type="Text" id="selectedPublishHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}" />
                             <hdfs:HDFSBrowser id="newDatasetPublishHDFSBrowser" height="300px" width="100%"
                                           busyControl="addDatasetDialog"
-                                          pathInput="selectedPublishHDFSPathLabel" restURI="api/hdfs/list"
+                                          pathInput="selectedPublishHDFSPathLabel" restURI="{entity>/hdfsRestUri}"
                                           HDFSPath="{entity>/hdfsPublishPath}" visible="{entity>/hdfsBrowserEnabled}" />
                             <!-- Simple field as an alternative -->
                             <Input id="newDatasetPublishSimplePath" type="Text" placeholder="Dataset publish path" width="100%"

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -29,34 +29,49 @@
                         <core:Fragment type="XML" fragmentName="components.schema.selector.schemaSelector"/>
                         <Label text="HDFS raw data folder path"/>
                         <VBox>
-                            <!-- HDFS Browser and its label -->
-                        	<Input type="Text" id="selectedRawHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}" />
+                            <HBox>
+                                <!-- HDFS Browser input -->
+                                <Input type="Text" id="selectedRawHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}">
+                                    <layoutData>
+                                        <FlexItemData growFactor="5"/>
+                                    </layoutData>
+                                </Input>
+                                <!-- Simple field as an alternative -->
+                                <Input id="newDatasetRawSimplePath" type="Text" placeholder="Dataset raw path"
+                                       value="{entity>/hdfsPath}"
+                                       visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}">
+                                    <layoutData>
+                                        <FlexItemData growFactor="5"/>
+                                    </layoutData>
+                                </Input>
+                                <Button id="toggleHdfsBrowser" icon="sap-icon://journey-change"
+                                        tooltip="{= ${entity>/hdfsBrowserEnabled}? 'Switch to simple path editing' : 'Switch to HDFS Browser editing' }"/>
+                            </HBox>
+
                             <hdfs:HDFSBrowser id="newDatasetRawHDFSBrowser" height="300px" width="100%"
-                                          busyControl="addDatasetDialog" pathInput ="selectedRawHDFSPathLabel"
-                                          HDFSPath="{entity>/hdfsPath}" visible="{entity>/hdfsBrowserEnabled}" />
-                            <!-- Simple field as an alternative -->
-                            <Input id="newDatasetRawSimplePath" type="Text" placeholder="Dataset raw path" width="100%"
-                                   value="{entity>/hdfsPath}"
-                                   visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}" />
+                                              busyControl="addDatasetDialog" pathInput="selectedRawHDFSPathLabel"
+                                              HDFSPath="{entity>/hdfsPath}" visible="{entity>/hdfsBrowserEnabled}"/>
                         </VBox>
                         <Label text="HDFS conformed data publish folder path"/>
                         <VBox>
                             <!-- HDFS Browser and its label -->
-                            <Input type="Text" id="selectedPublishHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}" />
+                            <Input type="Text" id="selectedPublishHDFSPathLabel"
+                                   visible="{entity>/hdfsBrowserEnabled}"/>
                             <hdfs:HDFSBrowser id="newDatasetPublishHDFSBrowser" height="300px" width="100%"
-                                          busyControl="addDatasetDialog" pathInput="selectedPublishHDFSPathLabel"
-                                          HDFSPath="{entity>/hdfsPublishPath}" visible="{entity>/hdfsBrowserEnabled}" />
-                            <!-- Simple field as an alternative -->
-                            <Input id="newDatasetPublishSimplePath" type="Text" placeholder="Dataset publish path" width="100%"
+                                              busyControl="addDatasetDialog" pathInput="selectedPublishHDFSPathLabel"
+                                              HDFSPath="{entity>/hdfsPublishPath}"
+                                              visible="{entity>/hdfsBrowserEnabled}"/>
+                            <!-- Simple field  -->
+                            <Input id="newDatasetPublishSimplePath" type="Text" placeholder="Dataset publish path"
+                                   width="100%"
                                    value="{entity>/hdfsPublishPath}"
-                                   visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}" />
+                                   visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}"/>
                         </VBox>
                     </form:content>
                 </form:SimpleForm>
             </VBox>
         </content>
         <buttons>
-            <Button class="hdfsToggleButton" id="toggleHdfsBrowser" text="Toggle HDFS browser/simple input" icon="sap-icon://journey-change"/>
             <Button id="newDatasetAddButton" text="Save" icon="sap-icon://accept"/>
             <Button id="newDatasetCancelButton" text="Cancel" icon="sap-icon://cancel"/>
         </buttons>

--- a/menas/ui/components/dataset/datasetInfo.fragment.xml
+++ b/menas/ui/components/dataset/datasetInfo.fragment.xml
@@ -25,9 +25,9 @@
                   text="{dataset>/description}"/>
             <Label text="Version"/>
             <Text id="currentDatasetVersion" text="{dataset>/version}"/>
-            <Label text="HDFS raw data folder path"/>
+            <Label text="Raw data folder path"/>
             <Text id="currentDatasetRawPath" text="{dataset>/hdfsPath}"/>
-            <Label text="HDFS conformed data publish folder path"/>
+            <Label text="Conformed data publish folder path"/>
             <Text id="currentDatasetPublishedPath"
                   text="{dataset>/hdfsPublishPath}"/>
             <Label text="Schema"/>

--- a/menas/ui/components/hdfs/HDFSBrowser.js
+++ b/menas/ui/components/hdfs/HDFSBrowser.js
@@ -298,7 +298,7 @@ sap.ui.define([], function() {
         this._setValueState(sap.ui.core.MessageType.Warning, "Path does not exist.");
         this.unselectAll();
       } else {
-        sap.m.MessageBox.error("Failed to retreive the HDFS folder contents for " + sPath + ", please try again later.");
+        this._setValueState(sap.ui.core.MessageType.Error, "Failed to retreive the HDFS folder contents for " + sPath + ", please try again later.");
       }
 
     }.bind(this), oControl)

--- a/menas/ui/components/hdfs/HDFSBrowser.js
+++ b/menas/ui/components/hdfs/HDFSBrowser.js
@@ -278,8 +278,9 @@ sap.ui.define([], function() {
    * Service for retrieving the directory listings
    */
   HDFSBrowser.prototype._getList = function(sPath, sModelPath, oControl, fnSuccCallback) {
-    Functions.ajax(this.getRestURI(), "POST", sPath, function(oData) {
 
+    console.log("hdfsService is being used now");
+    HdfsService.getHdfsList(sPath, function(oData) {
       let original = this._model.getProperty(sModelPath)
 
       let merged = {};

--- a/menas/ui/components/hdfs/HDFSBrowser.js
+++ b/menas/ui/components/hdfs/HDFSBrowser.js
@@ -279,7 +279,6 @@ sap.ui.define([], function() {
    */
   HDFSBrowser.prototype._getList = function(sPath, sModelPath, oControl, fnSuccCallback) {
 
-    console.log("hdfsService is being used now");
     HdfsService.getHdfsList(sPath, function(oData) {
       let original = this._model.getProperty(sModelPath)
 

--- a/menas/ui/components/hdfs/HDFSBrowser.js
+++ b/menas/ui/components/hdfs/HDFSBrowser.js
@@ -40,9 +40,6 @@ sap.ui.define([], function() {
           type : "boolean",
           defaultValue : true
         },
-        "restURI" : {
-          type : "string"
-        },
         "HDFSPath" : {
           type : "string",
           defaultValue : "/"

--- a/menas/ui/components/hdfs/HDFSBrowser.js
+++ b/menas/ui/components/hdfs/HDFSBrowser.js
@@ -298,7 +298,7 @@ sap.ui.define([], function() {
         this._setValueState(sap.ui.core.MessageType.Warning, "Path does not exist.");
         this.unselectAll();
       } else {
-        this._setValueState(sap.ui.core.MessageType.Error, "Failed to retreive the HDFS folder contents for " + sPath + ", please try again later.");
+        this._setValueState(sap.ui.core.MessageType.Error, "Failed to retrieve the HDFS folder contents for " + sPath + ", please try again later.");
       }
 
     }.bind(this), oControl)

--- a/menas/ui/components/mappingTable/addMappingTable.fragment.xml
+++ b/menas/ui/components/mappingTable/addMappingTable.fragment.xml
@@ -31,7 +31,7 @@
                                width="100%"
                                value="{entity>/description}"/>
                         <core:Fragment type="XML" fragmentName="components.schema.selector.schemaSelector"/>
-                        <Label text="HDFS Path"/>
+                        <Label text="Mapping table folder path"/>
                         <VBox>
                             <HBox>
                                 <!-- HDFS Browser input -->

--- a/menas/ui/components/mappingTable/addMappingTable.fragment.xml
+++ b/menas/ui/components/mappingTable/addMappingTable.fragment.xml
@@ -36,7 +36,7 @@
                             <Input type="Text" id="selectedHDFSPathLabel"/>
                             <hdfs:HDFSBrowser id="addMtHDFSBrowser" height="300px" width="100%"
                                               busyControl="addMappingTableDialog"
-                                              pathInput="selectedHDFSPathLabel" restURI="api/hdfs/list"
+                                              pathInput="selectedHDFSPathLabel"
                                               HDFSPath="{entity>/hdfsPath}"/>
                         </VBox>
                     </form:content>

--- a/menas/ui/components/mappingTable/addMappingTable.fragment.xml
+++ b/menas/ui/components/mappingTable/addMappingTable.fragment.xml
@@ -33,17 +33,23 @@
                         <core:Fragment type="XML" fragmentName="components.schema.selector.schemaSelector"/>
                         <Label text="HDFS Path"/>
                         <VBox>
-                            <Input type="Text" id="selectedHDFSPathLabel"/>
+                            <!-- HDFS Browser and its label -->
+                            <Input type="Text" id="selectedHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}"/>
                             <hdfs:HDFSBrowser id="addMtHDFSBrowser" height="300px" width="100%"
-                                              busyControl="addMappingTableDialog"
+                                              busyControl="addMappingTableDialog" visible="{entity>/hdfsBrowserEnabled}"
                                               pathInput="selectedHDFSPathLabel"
                                               HDFSPath="{entity>/hdfsPath}"/>
+                            <!-- Simple field as an alternative -->
+                            <Input id="addMtSimplePath" type="Text" placeholder="Mapping table path" width="100%"
+                                   value="{entity>/hdfsPath}"
+                                   visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}" />
                         </VBox>
                     </form:content>
                 </form:SimpleForm>
             </VBox>
         </content>
         <buttons>
+            <Button class="hdfsToggleButton" id="toggleHdfsBrowser" text="Toggle HDFS browser/simple input" icon="sap-icon://journey-change"/>
             <Button id="newMappingTableAddButton" text="Save" icon="sap-icon://save" press="onMTSubmit"/>
             <Button id="newMappingTableCancelButton" text="Cancel" icon="sap-icon://cancel" press="onMTCancel"/>
         </buttons>

--- a/menas/ui/components/mappingTable/addMappingTable.fragment.xml
+++ b/menas/ui/components/mappingTable/addMappingTable.fragment.xml
@@ -33,23 +33,35 @@
                         <core:Fragment type="XML" fragmentName="components.schema.selector.schemaSelector"/>
                         <Label text="HDFS Path"/>
                         <VBox>
-                            <!-- HDFS Browser and its label -->
-                            <Input type="Text" id="selectedHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}"/>
+                            <HBox>
+                                <!-- HDFS Browser input -->
+                                <Input type="Text" id="selectedHDFSPathLabel" visible="{entity>/hdfsBrowserEnabled}">
+                                    <layoutData>
+                                        <FlexItemData growFactor="5"/>
+                                    </layoutData>
+                                </Input>
+                                <!-- Simple field as an alternative -->
+                                <Input id="addMtSimplePath" type="Text" placeholder="Mapping table path"
+                                       value="{entity>/hdfsPath}"
+                                       visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}">
+                                    <layoutData>
+                                        <FlexItemData growFactor="5"/>
+                                    </layoutData>
+                                </Input>
+                                <Button id="toggleHdfsBrowser" icon="sap-icon://journey-change"
+                                        tooltip="{= ${entity>/hdfsBrowserEnabled}? 'Switch to simple path editing' : 'Switch to HDFS Browser editing' }"/>
+                            </HBox>
                             <hdfs:HDFSBrowser id="addMtHDFSBrowser" height="300px" width="100%"
                                               busyControl="addMappingTableDialog" visible="{entity>/hdfsBrowserEnabled}"
                                               pathInput="selectedHDFSPathLabel"
                                               HDFSPath="{entity>/hdfsPath}"/>
-                            <!-- Simple field as an alternative -->
-                            <Input id="addMtSimplePath" type="Text" placeholder="Mapping table path" width="100%"
-                                   value="{entity>/hdfsPath}"
-                                   visible="{path:'entity>/hdfsBrowserEnabled', formatter:'Formatters.not'}" />
+
                         </VBox>
                     </form:content>
                 </form:SimpleForm>
             </VBox>
         </content>
         <buttons>
-            <Button class="hdfsToggleButton" id="toggleHdfsBrowser" text="Toggle HDFS browser/simple input" icon="sap-icon://journey-change"/>
             <Button id="newMappingTableAddButton" text="Save" icon="sap-icon://save" press="onMTSubmit"/>
             <Button id="newMappingTableCancelButton" text="Cancel" icon="sap-icon://cancel" press="onMTCancel"/>
         </buttons>

--- a/menas/ui/index.html
+++ b/menas/ui/index.html
@@ -74,6 +74,7 @@
             _menasLoadElem("script", "service/RunRestDAO.js", []);
             _menasLoadElem("script", "service/EntityService.js", []);
             _menasLoadElem("script", "service/GenericService.js", []);
+            _menasLoadElem("script", "service/HdfsService.js", []);
             _menasLoadElem("script", "service/MonitoringService.js", []);
             _menasLoadElem("script", "service/RuleService.js", []);
             _menasLoadElem("script", "service/OozieService.js", []);

--- a/menas/ui/service/EntityDialog.js
+++ b/menas/ui/service/EntityDialog.js
@@ -83,11 +83,20 @@ class DatasetDialog extends EntityDialog {
     this.oController.byId("schemaVersionSelect").setValueState(sap.ui.core.ValueState.None);
     this.oController.byId("schemaVersionSelect").setValueStateText("");
 
+    // hdfs browser-based
     this.oController.byId("selectedRawHDFSPathLabel").setValueState(sap.ui.core.ValueState.None);
     this.oController.byId("selectedRawHDFSPathLabel").setValueStateText("");
 
     this.oController.byId("selectedPublishHDFSPathLabel").setValueState(sap.ui.core.ValueState.None);
     this.oController.byId("selectedPublishHDFSPathLabel").setValueStateText("");
+
+    // simple path-based
+    this.oController.byId("newDatasetRawSimplePath").setValueState(sap.ui.core.ValueState.None);
+    this.oController.byId("newDatasetRawSimplePath").setValueStateText("");
+
+    this.oController.byId("newDatasetPublishSimplePath").setValueState(sap.ui.core.ValueState.None);
+    this.oController.byId("newDatasetPublishSimplePath").setValueStateText("");
+
   }
 
   isValid(oDataset) {
@@ -97,17 +106,30 @@ class DatasetDialog extends EntityDialog {
       this.oController.byId("newDatasetName"));
     let hasValidSchema = EntityValidationService.hasValidSchema(oDataset, "Dataset",
         this.oController.byId("schemaVersionSelect"));
-    let hasValidRawHDFSPath = EntityValidationService.hasValidHDFSPath(oDataset.hdfsPath,
-      "Dataset Raw HDFS path",
-      this.oController.byId("selectedRawHDFSPathLabel"));
-    let hasValidPublishHDFSPath = EntityValidationService.hasValidHDFSPath(oDataset.hdfsPublishPath,
-      "Dataset publish HDFS path",
-      this.oController.byId("selectedPublishHDFSPathLabel"));
-    let hasExistingRawHDFSPath = hasValidRawHDFSPath ? this.oController.byId("newDatasetRawHDFSBrowser").validate() : false;
-    let hasExistingPublishHDFSPath = hasValidRawHDFSPath && hasValidPublishHDFSPath ?
-      this.oController.byId("newDatasetPublishHDFSBrowser").validate() : false;
 
-    return hasValidName && hasValidSchema && hasExistingRawHDFSPath && hasExistingPublishHDFSPath;
+    if (oDataset.hdfsBrowserEnabled) {
+      let hasValidRawHDFSPath = EntityValidationService.hasValidHDFSPath(oDataset.hdfsPath,
+        "Dataset Raw HDFS path",
+        this.oController.byId("selectedRawHDFSPathLabel"));
+      let hasValidPublishHDFSPath = EntityValidationService.hasValidHDFSPath(oDataset.hdfsPublishPath,
+        "Dataset publish HDFS path",
+        this.oController.byId("selectedPublishHDFSPathLabel"));
+      let hasExistingRawHDFSPath = hasValidRawHDFSPath ? this.oController.byId("newDatasetRawHDFSBrowser").validate() : false;
+      let hasExistingPublishHDFSPath = hasValidRawHDFSPath && hasValidPublishHDFSPath ?
+        this.oController.byId("newDatasetPublishHDFSBrowser").validate() : false;
+
+      return hasValidName && hasValidSchema && hasExistingRawHDFSPath && hasExistingPublishHDFSPath;
+    } else {
+
+      let hasValidRawSimplePath = EntityValidationService.hasValidSimplePath(oDataset.hdfsPath,
+        "Dataset Raw path",
+        this.oController.byId("newDatasetRawSimplePath"));
+      let hasValidPublishSimplePath = EntityValidationService.hasValidSimplePath(oDataset.hdfsPublishPath,
+        "Dataset publish path",
+        this.oController.byId("newDatasetPublishSimplePath"));
+
+      return hasValidName && hasValidSchema && hasValidRawSimplePath && hasValidPublishSimplePath;
+    }
   }
 
   onNameChange() {
@@ -120,8 +142,8 @@ class DatasetDialog extends EntityDialog {
   }
 
   toggleHdfsBrowser() {
-    let enabled = this.oDialog.getModel("entity").getProperty("/enableHdfsBrowser");
-    this.oDialog.getModel("entity").setProperty("/enableHdfsBrowser", !enabled);
+    let enabled = this.oDialog.getModel("entity").getProperty("/hdfsBrowserEnabled");
+    this.oDialog.getModel("entity").setProperty("/hdfsBrowserEnabled", !enabled);
   }
 
   onSchemaSelect(oEv) {
@@ -152,7 +174,7 @@ class AddDatasetDialog extends DatasetDialog {
         hdfsPublishPath: "/",
         isEdit: false,
         title: "Add",
-        enableHdfsBrowser: true
+        hdfsBrowserEnabled: true
       }), "entity");
     })
   }
@@ -169,6 +191,8 @@ class EditDatasetDialog extends DatasetDialog {
 
       current.isEdit = true;
       current.title = "Edit";
+      current.hdfsBrowserEnabled = true;
+
       this.schemaService.getAllVersions(current.schemaName, this.oController.byId("schemaVersionSelect"));
 
       this.oDialog.setModel(new sap.ui.model.json.JSONModel(jQuery.extend(true, {}, current)), "entity");

--- a/menas/ui/service/EntityDialog.js
+++ b/menas/ui/service/EntityDialog.js
@@ -68,6 +68,8 @@ class DatasetDialog extends EntityDialog {
     oController.byId("newDatasetAddButton").attachPress(this.submit, this);
     oController.byId("newDatasetCancelButton").attachPress(this.cancel, this);
     oController.byId("newDatasetName").attachChange(this.onNameChange, this);
+
+    oController.byId("toggleHdfsBrowser").attachPress(this.toggleHdfsBrowser, this);
   }
 
   get schemaService() {
@@ -117,6 +119,11 @@ class DatasetDialog extends EntityDialog {
     }
   }
 
+  toggleHdfsBrowser() {
+    let enabled = this.oDialog.getModel("entity").getProperty("/enableHdfsBrowser");
+    this.oDialog.getModel("entity").setProperty("/enableHdfsBrowser", !enabled);
+  }
+
   onSchemaSelect(oEv) {
     let sSchemaId = oEv.getParameter("selectedItem").getKey();
     this.schemaService.getAllVersions(sSchemaId, this.oController.byId("schemaVersionSelect"),
@@ -144,7 +151,8 @@ class AddDatasetDialog extends DatasetDialog {
         hdfsPath: "/",
         hdfsPublishPath: "/",
         isEdit: false,
-        title: "Add"
+        title: "Add",
+        enableHdfsBrowser: true
       }), "entity");
     })
   }

--- a/menas/ui/service/EntityDialog.js
+++ b/menas/ui/service/EntityDialog.js
@@ -62,6 +62,8 @@ class EntityDialog {
 
 class DatasetDialog extends EntityDialog {
 
+  get hdfsRestUri() { return "api/hdfs/list"; }
+
   constructor(oDialog, datasetService, schemaService, oController) {
     super(oDialog, datasetService, oController);
     this._schemaService = schemaService;
@@ -70,6 +72,9 @@ class DatasetDialog extends EntityDialog {
     oController.byId("newDatasetName").attachChange(this.onNameChange, this);
 
     oController.byId("toggleHdfsBrowser").attachPress(this.toggleHdfsBrowser, this);
+
+    //todo find out if hdfs paths are ok, if not switch to simple mode:
+    //this.oDialog.getModel("entity").setProperty("/hdfsBrowserEnabled", false);
   }
 
   get schemaService() {
@@ -142,6 +147,9 @@ class DatasetDialog extends EntityDialog {
   }
 
   toggleHdfsBrowser() {
+    // todo remove
+    console.log(`model : ${this.oDialog.getModel("entity").getJSON()}`);
+
     let enabled = this.oDialog.getModel("entity").getProperty("/hdfsBrowserEnabled");
     this.oDialog.getModel("entity").setProperty("/hdfsBrowserEnabled", !enabled);
   }
@@ -174,7 +182,8 @@ class AddDatasetDialog extends DatasetDialog {
         hdfsPublishPath: "/",
         isEdit: false,
         title: "Add",
-        hdfsBrowserEnabled: true
+        hdfsBrowserEnabled: true,
+        hdfsRestUri: this.hdfsRestUri
       }), "entity");
     })
   }
@@ -192,6 +201,7 @@ class EditDatasetDialog extends DatasetDialog {
       current.isEdit = true;
       current.title = "Edit";
       current.hdfsBrowserEnabled = true;
+      current.hdfsRestUri = this.hdfsRestUri;
 
       this.schemaService.getAllVersions(current.schemaName, this.oController.byId("schemaVersionSelect"));
 

--- a/menas/ui/service/EntityDialog.js
+++ b/menas/ui/service/EntityDialog.js
@@ -68,7 +68,7 @@ class EntityDialog {
         console.log(`Successful HDFS listing of '[${hdfsPaths}]' -> HDFS Browser is kept`);
       })
       .catch(() => {
-        console.log(`Switching off HDFS Browser in the dialog due to an unsuccessful HDFS listing of '[${hdfsPaths}]`); // 4xx or 5xx code
+        console.log(`Switching off HDFS Browser in the dialog due to an unsuccessful HDFS listing of '[${hdfsPaths}]'`); // 4xx or 5xx code
         dialog.getModel("entity").setProperty("/hdfsBrowserEnabled", false);
       })
       .finally(() => {
@@ -184,10 +184,8 @@ class DatasetDialog extends EntityDialog {
 class AddDatasetDialog extends DatasetDialog {
 
   onPress() {
-    const dialog = this.oDialog;
-
-    this.schemaService.getList(dialog).then(() => {
-      dialog.setModel(new sap.ui.model.json.JSONModel({
+    this.schemaService.getList(this.oDialog).then(() => {
+      this.oDialog.setModel(new sap.ui.model.json.JSONModel({
         name: "",
         description: "",
         schemaName: "",
@@ -199,7 +197,7 @@ class AddDatasetDialog extends DatasetDialog {
         hdfsBrowserEnabled: true
       }), "entity");
 
-      this.openSimpleOrHdfsBrowsingDialog(dialog, DatasetDialog.hdfsPropertyNames)
+      this.openSimpleOrHdfsBrowsingDialog(this.oDialog, DatasetDialog.hdfsPropertyNames)
     })
   }
 
@@ -208,9 +206,7 @@ class AddDatasetDialog extends DatasetDialog {
 class EditDatasetDialog extends DatasetDialog {
 
   onPress() {
-    const dialog = this.oDialog;
-
-    this.schemaService.getList(dialog).then(() => {
+    this.schemaService.getList(this.oDialog).then(() => {
       let current = this.oController._model.getProperty("/currentDataset");
 
       current.isEdit = true;
@@ -218,9 +214,9 @@ class EditDatasetDialog extends DatasetDialog {
       current.hdfsBrowserEnabled = true;
 
       this.schemaService.getAllVersions(current.schemaName, this.oController.byId("schemaVersionSelect"));
-      dialog.setModel(new sap.ui.model.json.JSONModel(jQuery.extend(true, {}, current)), "entity");
+      this.oDialog.setModel(new sap.ui.model.json.JSONModel(jQuery.extend(true, {}, current)), "entity");
 
-      this.openSimpleOrHdfsBrowsingDialog(dialog, DatasetDialog.hdfsPropertyNames);
+      this.openSimpleOrHdfsBrowsingDialog(this.oDialog, DatasetDialog.hdfsPropertyNames);
     });
   }
 

--- a/menas/ui/service/EntityValidationService.js
+++ b/menas/ui/service/EntityValidationService.js
@@ -34,6 +34,22 @@ var EntityValidationService = new function () {
     return isOk;
   };
 
+  // This is for cases when HDFS browser is disabled: entering an S3 path, etc.
+  this.hasValidSimplePath = function (sHDFSPath, sEntityType, oInput) {
+    let rHDFSPathRegex = /^[^\?\*]+$/;
+    let isOk = rHDFSPathRegex.test(sHDFSPath);
+
+    if (!isOk) {
+      let notOkReason = "must not contain unwanted path chars like ? and *";
+      if (sHDFSPath === "") { notOkReason = "cannot be empty" }
+
+      oInput.setValueState(sap.ui.core.ValueState.Error);
+      oInput.setValueStateText(`${sEntityType} ${notOkReason}`);
+    }
+
+    return isOk;
+  };
+
   this.hasValidName = function (oEntity, sEntityType, oInput) {
     let isOk = true;
 

--- a/menas/ui/service/HdfsService.js
+++ b/menas/ui/service/HdfsService.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var HdfsService = new function () {
+
+  this.getHdfsList = function(sPath, successFn, errorFn, oControl) {
+    return Functions.ajax("api/hdfs/list", "POST", sPath, successFn, errorFn, oControl);
+  };
+
+}();

--- a/menas/ui/service/HdfsService.js
+++ b/menas/ui/service/HdfsService.js
@@ -19,4 +19,16 @@ var HdfsService = new function () {
     return Functions.ajax("api/hdfs/list", "POST", sPath, successFn, errorFn, oControl);
   };
 
+  // jquery Promise
+  this.getHdfsListJqPromise = function(sPath, oControl) {
+    return $.when(Functions.ajax("api/hdfs/list", "POST", sPath, () => {}, () => {}, oControl));
+  };
+
+  // not using oControl
+  this.getHdfsListEs6Promise = function(sPath) {
+    console.log(`getHdfsListEs6Promise(${sPath})'`); // 4xx or 5xx code
+    return Promise.resolve(this.getHdfsListJqPromise(sPath))
+  }
+
+
 }();

--- a/menas/ui/service/HdfsService.js
+++ b/menas/ui/service/HdfsService.js
@@ -15,20 +15,35 @@
 
 var HdfsService = new function () {
 
+  /**
+   * Callback-based service call to list HDFS path
+   * @param sPath path to list
+   * @param successFn success fn callback
+   * @param errorFn error fn callback
+   * @param oControl control to be set to 'busy' and unbussied
+   * @returns  jqXHR
+   */
   this.getHdfsList = function(sPath, successFn, errorFn, oControl) {
     return Functions.ajax("api/hdfs/list", "POST", sPath, successFn, errorFn, oControl);
   };
 
-  // jquery Promise
+  /**
+   * jQuery-Promise version of [[HdfsService.getHdfsList]], not using busyControl
+   * @param sPath path to list
+   * @param oControl
+   * @returns jQuery Promise
+   */
   this.getHdfsListJqPromise = function(sPath, oControl) {
-    return $.when(Functions.ajax("api/hdfs/list", "POST", sPath, () => {}, () => {}, oControl));
+    return $.when(this.getHdfsList(sPath, () => {}, () => {}, oControl));
   };
 
-  // not using oControl
+  /**
+   * ES6-Promise version of [[HdfsService.getHdfsListJqPromise]], not using busyControl
+   * @param sPath path to list
+   * @returns {Promise<jQuery>}
+   */
   this.getHdfsListEs6Promise = function(sPath) {
-    console.log(`getHdfsListEs6Promise(${sPath})'`); // 4xx or 5xx code
     return Promise.resolve(this.getHdfsListJqPromise(sPath))
   }
-
 
 }();


### PR DESCRIPTION
HDFS Browser can now be hidden
 - by a click of a button
 - automatically on dialog open when one of the paths cannot be displayed in the HDFS Browser

Background:
 - the HDFS listing AJAX call was originally part of the HDFS browser itself; the call routine has been extracted into a HdfsService, directly used by the HDFS Browser. 
 - jQuery & ES6 Promise wrappers have been added for the HDFS listing call to enable promise composition to be used in dialogs (dataset dialog) where multiple HDFS checks are needed without custom chaining
 - The dialog assembly logic has been changed for the service loading to be done first and the dialog to be shown later, otherwise the dialog elements may flicker to react to the listing changes.

## UI preview
### Dataset dialog
![simple-path-dataset](https://user-images.githubusercontent.com/4457378/107334819-7df99480-6ab7-11eb-88cf-df6ef85ad456.png)
![hdfs-browser-path-dataset](https://user-images.githubusercontent.com/4457378/107334809-7c2fd100-6ab7-11eb-9a68-6813035688c6.png)
### Mapping table dialog
![simple-path-mapping-table](https://user-images.githubusercontent.com/4457378/107334829-8225b200-6ab7-11eb-84bf-83a7624f88a6.png)

## Release notes suggestion:
 - Entering HDFS/S3 paths can now be done either using the existing HDFS Browser or via a simple input field. The mode is chosen automatically on dialog open and can be switched manually back and forth.

Closes #1627.