### PR TITLE
1637 Add simple switch for prop definitions updates

### DIFF
--- a/menas/src/main/resources/application.properties.template
+++ b/menas/src/main/resources/application.properties.template
@@ -157,3 +157,6 @@ menas.oozie.splineMongoURL=mongodb://localhost:27017
 #javax.net.ssl.trustStorePassword=somePassword
 #javax.net.ssl.keyStore=/path/to/keystore.jks
 #javax.net.ssl.keyStorePassword=somePassword
+
+# Temporary fix for locking of property definition updates #1673
+# menas.feature.property.definitions.allowUpdate=false

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/RestExceptionHandler.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/RestExceptionHandler.scala
@@ -56,6 +56,11 @@ class RestExceptionHandler {
     ResponseEntity.notFound().build[Any]()
   }
 
+  @ExceptionHandler(value = Array(classOf[EndpointDisabled]))
+  def handleEndpointDisabled(exception: EndpointDisabled): ResponseEntity[Any] = {
+    ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT).build[Any]() // Could change for LOCKED but I like this more
+  }
+
   @ExceptionHandler(value = Array(classOf[SchemaParsingException]))
   def handleBadRequestException(exception: SchemaParsingException): ResponseEntity[Any] = {
     val response = RestResponse(exception.message, Option(SchemaParsingError.fromException(exception)))

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/exceptions/EndpointDisabled.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/exceptions/EndpointDisabled.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.exceptions
+
+case class EndpointDisabled(message:String = "", cause: Throwable = None.orNull) extends Exception(message, cause)
+

--- a/menas/src/test/resources/application.properties
+++ b/menas/src/test/resources/application.properties
@@ -79,3 +79,5 @@ menas.monitoring.fetch.limit=500
 
 #----------- Schema Registry
 menas.schemaRegistry.baseUrl=http://localhost:8877
+
+menas.feature.property.definitions.allowUpdate=true


### PR DESCRIPTION
So I tried a few approaches. Flips library, togglz library, refresh scope, cloud starter, profiles, custom annotations/Aspect and maybe more. Not sure. Got lost. Anyway, all too big or complicated. Might be hard to remove.

Also, found out that changing values of app props on the flight is Spring anti-pattern. 

**Solution** is a "simple" property that is set at the beginning of service start, has a default of false and only enables and disables property definitions updates. Will also be quick to revert without leaving any ghost annotations or configs. 

Nagging: Would be quite easier if we already had that stand-alone Configuration object using `@ConfigurationProperties`. 

Fixes #1637 

Relase Notes: Property Definition Updates can be enabled using a switch `menas.feature.property.definitions.update` in properties. Thus also a new property `menas.feature.property.definitions.update` that can be true or false.