### PR TITLE
#1679 Landing page information takes a minute to load with 1.3M runs

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/Application.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/Application.scala
@@ -23,9 +23,11 @@ import org.springframework.context.annotation._
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 @Configuration
 class Application() {
   private val DefaultCorePoolSize = 12

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.CompletableFuture
 
 import scala.concurrent.Future
 
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
@@ -46,7 +46,7 @@ class LandingPageController @Autowired() (datasetRepository: DatasetMongoReposit
   import za.co.absa.enceladus.menas.utils.implicits._
 
   @GetMapping(path = Array("/info"))
-  def retreiveLandingPageInfo(): CompletableFuture[LandingPageInformation] = {
+  def retrieveLandingPageInfo(): CompletableFuture[LandingPageInformation] = {
     landingPageRepository.get()
   }
 
@@ -65,7 +65,7 @@ class LandingPageController @Autowired() (datasetRepository: DatasetMongoReposit
   def scheduledLandingPageStatsRecalc(): CompletableFuture[_] = {
     logger.info("Running scheduled landing page statistics recalculation")
     for {
-      newStats <- landingPageInfo
+      newStats <- landingPageInfo()
       res <- landingPageRepository.updateStatistics(newStats)
     } yield res 
   }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
@@ -61,8 +61,8 @@ class LandingPageController @Autowired() (datasetRepository: DatasetMongoReposit
   }
 
   @Async
-  @Scheduled(fixedDelay = 900000)
-  def scheduledTest(): CompletableFuture[_] = {
+  @Scheduled(initialDelay = 1000, fixedDelay = 900000)
+  def scheduledLandingPageStatsRecalc(): CompletableFuture[_] = {
     logger.info("Running scheduled landing page statistics recalculation")
     for {
       newStats <- landingPageInfo

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
@@ -17,13 +17,19 @@ package za.co.absa.enceladus.menas.controllers
 
 import java.util.concurrent.CompletableFuture
 
+import scala.concurrent.Future
+
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 import za.co.absa.enceladus.menas.models.LandingPageInformation
 import za.co.absa.enceladus.menas.repositories.DatasetMongoRepository
+import za.co.absa.enceladus.menas.repositories.LandingPageStatisticsMongoRepository
 import za.co.absa.enceladus.menas.repositories.MappingTableMongoRepository
 import za.co.absa.enceladus.menas.repositories.SchemaMongoRepository
 import za.co.absa.enceladus.menas.services.RunService
@@ -33,13 +39,18 @@ import za.co.absa.enceladus.menas.services.RunService
 class LandingPageController @Autowired() (datasetRepository: DatasetMongoRepository,
     mappingTableRepository: MappingTableMongoRepository,
     schemaRepository: SchemaMongoRepository,
-    runsService: RunService) extends BaseController {
+    runsService: RunService,
+    landingPageRepository: LandingPageStatisticsMongoRepository) extends BaseController {
 
   import scala.concurrent.ExecutionContext.Implicits.global
   import za.co.absa.enceladus.menas.utils.implicits._
 
   @GetMapping(path = Array("/info"))
-  def landingPageInfo(): CompletableFuture[LandingPageInformation] = {
+  def retreiveLandingPageInfo(): CompletableFuture[LandingPageInformation] = {
+    landingPageRepository.get()
+  }
+
+  def landingPageInfo(): Future[LandingPageInformation] = {
     for {
       dsCount <- datasetRepository.distinctCount()
       mtCount <- mappingTableRepository.distinctCount()
@@ -47,5 +58,15 @@ class LandingPageController @Autowired() (datasetRepository: DatasetMongoReposit
       runCount <- runsService.getCount()
       todaysStats <- runsService.getTodaysRunsStatistics()
     } yield LandingPageInformation(dsCount, mtCount, schemaCount, runCount, todaysStats)
+  }
+
+  @Async
+  @Scheduled(fixedDelay = 900000)
+  def scheduledTest(): CompletableFuture[_] = {
+    logger.info("Running scheduled landing page statistics recalculation")
+    for {
+      newStats <- landingPageInfo
+      res <- landingPageRepository.updateStatistics(newStats)
+    } yield res 
   }
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/LandingPageController.scala
@@ -59,8 +59,9 @@ class LandingPageController @Autowired() (datasetRepository: DatasetMongoReposit
     } yield LandingPageInformation(dsCount, mtCount, schemaCount, runCount, todaysStats)
   }
 
+  // scalastyle:off magic.number
+  @Scheduled(initialDelay = 1000, fixedDelay = 300000)
   @Async
-  @Scheduled(initialDelay = 1000, fixedDelay = 900000)
   def scheduledLandingPageStatsRecalc(): CompletableFuture[_] = {
     logger.info("Running scheduled landing page statistics recalculation")
     for {

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/LandingPageStatisticsMongoRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/LandingPageStatisticsMongoRepository.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.repositories
+
+import scala.concurrent.Future
+
+import org.mongodb.scala.MongoDatabase
+import org.mongodb.scala.model.Filters
+import org.springframework.stereotype.Repository
+
+import za.co.absa.enceladus.menas.exceptions.NotFoundException
+import za.co.absa.enceladus.menas.models.LandingPageInformation
+import za.co.absa.enceladus.model
+
+@Repository
+class LandingPageStatisticsMongoRepository(mongoDb: MongoDatabase)
+  extends MongoRepository[LandingPageInformation](mongoDb) {
+
+  private[menas] override def collectionBaseName: String = LandingPageStatisticsMongoRepository.collectionBaseName
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  def updateStatistics(newStats: LandingPageInformation): Future[_] = {
+    for {
+      cnt <- collection.countDocuments.toFuture
+      res <- if(cnt == 0) collection.insertOne(newStats).toFuture 
+               else collection.replaceOne(Filters.where("true"), newStats).toFuture
+    } yield res
+  }
+
+  def get(): Future[LandingPageInformation] = {
+    for {
+      res <- collection.find.toFuture()
+    } yield if(!res.isEmpty) res.head else throw NotFoundException("Landing page statistics not found")
+  }
+}
+
+object LandingPageStatisticsMongoRepository {
+  val collectionBaseName: String = "lading_page_statistics"
+  val collectionName: String = s"$collectionBaseName${model.CollectionSuffix}"
+}

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/LandingPageStatisticsMongoRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/LandingPageStatisticsMongoRepository.scala
@@ -35,19 +35,22 @@ class LandingPageStatisticsMongoRepository(mongoDb: MongoDatabase)
   def updateStatistics(newStats: LandingPageInformation): Future[_] = {
     for {
       cnt <- collection.countDocuments.toFuture
-      res <- if(cnt == 0) collection.insertOne(newStats).toFuture 
-               else collection.replaceOne(Filters.where("true"), newStats).toFuture
+      res <- if(cnt == 0) {
+               collection.insertOne(newStats).toFuture
+             } else {
+               collection.replaceOne(Filters.where("true"), newStats).toFuture
+             }
     } yield res
   }
 
   def get(): Future[LandingPageInformation] = {
     for {
       res <- collection.find.toFuture()
-    } yield if(!res.isEmpty) res.head else throw NotFoundException("Landing page statistics not found")
+    } yield if(res.nonEmpty) res.head else throw NotFoundException("Landing page statistics not found")
   }
 }
 
 object LandingPageStatisticsMongoRepository {
-  val collectionBaseName: String = "lading_page_statistics"
+  val collectionBaseName: String = "landing_page_statistics"
   val collectionName: String = s"$collectionBaseName${model.CollectionSuffix}"
 }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/implicits/package.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/implicits/package.scala
@@ -31,6 +31,7 @@ import za.co.absa.enceladus.model.menas._
 import za.co.absa.enceladus.model.menas.scheduler._
 import za.co.absa.enceladus.model.menas.scheduler.dataFormats._
 import za.co.absa.enceladus.model.menas.scheduler.oozie._
+import za.co.absa.enceladus.menas.models._
 import za.co.absa.enceladus.model.properties.PropertyDefinition
 import za.co.absa.enceladus.model.properties.essentiality.Essentiality
 import za.co.absa.enceladus.model.properties.propertyType.PropertyType
@@ -59,7 +60,8 @@ package object implicits {
     classOf[RunDatasetNameGroupedSummary], classOf[RunDatasetVersionGroupedSummary],
     classOf[RuntimeConfig], classOf[OozieSchedule], classOf[OozieScheduleInstance], classOf[ScheduleTiming], classOf[DataFormat],
     classOf[UserInfo], classOf[VersionedSummary], classOf[MenasAttachment], classOf[MenasReference],
-    classOf[PropertyDefinition], classOf[PropertyType], classOf[Essentiality]
+    classOf[PropertyDefinition], classOf[PropertyType], classOf[Essentiality],
+    classOf[LandingPageInformation], classOf[TodaysRunsStatistics]
   ),
     CodecRegistries.fromCodecs(new ZonedDateTimeAsDocumentCodec()), DEFAULT_CODEC_REGISTRY)
 


### PR DESCRIPTION
Fixes #1679 

This PR proposes how such expensive queries could be addressed before we invest into the massive data model rebuild or before we got requirements with more advanced caching needs (where products like redis could be used)

Here Spring will run the recalculation of the landing page statistics upon the start up and subsequently in 15 minute intervals. These statistics are stored in a mongo collection and the API endpoint simply reads the latest record.