### PR TITLE
Sending errors to a secured kafka

### DIFF
--- a/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/KafkaSecurityParams.scala
+++ b/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/KafkaSecurityParams.scala
@@ -16,6 +16,7 @@
 package za.co.absa.enceladus.plugins.builtin.common.mq.kafka
 
 import com.typesafe.config.Config
+import za.co.absa.enceladus.plugins.builtin.common.mq.kafka.KafkaSecurityParams.{SaslMechanismKey, SecurityProtocolKey}
 import za.co.absa.enceladus.utils.config.ConfigUtils.ConfigImplicits
 
 /**
@@ -24,7 +25,12 @@ import za.co.absa.enceladus.utils.config.ConfigUtils.ConfigImplicits
 case class KafkaSecurityParams(
                                 securityProtocol: String,
                                 saslMechanism: Option[String]
-                              )
+                              ) {
+  def toMap: Map[String, String] = {
+    Map(SecurityProtocolKey -> securityProtocol) ++
+      saslMechanism.fold(Map.empty[String, String])(saslValue => Map(SaslMechanismKey -> saslValue))
+  }
+}
 
 object KafkaSecurityParams {
   val SecurityProtocolKey = "kafka.security.protocol"

--- a/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/errorsender/mq/KafkaErrorSenderPluginImpl.scala
+++ b/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/errorsender/mq/KafkaErrorSenderPluginImpl.scala
@@ -16,9 +16,9 @@
 package za.co.absa.enceladus.plugins.builtin.errorsender.mq
 
 import org.apache.log4j.LogManager
-import org.apache.spark.sql.functions.{col, explode, lit, size, struct}
+import org.apache.spark.sql.functions.{col, explode, lit, size, struct, typedLit}
 import org.apache.spark.sql.types.DataTypes
-import org.apache.spark.sql.{DataFrame, Encoder, Encoders}
+import org.apache.spark.sql.{Column, DataFrame, Encoder, Encoders}
 import za.co.absa.enceladus.plugins.api.postprocessor.PostProcessor
 import za.co.absa.enceladus.plugins.builtin.common.mq.kafka.KafkaConnectionParams
 import za.co.absa.enceladus.plugins.builtin.errorsender.DceError
@@ -92,13 +92,19 @@ case class KafkaErrorSenderPluginImpl(connectionParams: KafkaConnectionParams,
 
     val allowedErrorCodes = KafkaErrorSenderPluginImpl.errorCodesForSource(params.sourceId)
 
+    val reportDateCol: Column = if (dataFrame.columns.contains(ColumnNames.reportDate)) {
+      col(ColumnNames.reportDate)
+    } else {
+      typedLit[Option[java.sql.Date]](None).as(ColumnNames.reportDate)
+    }
+
     val stdErrors = dataFrame
       // only keep rows with non-empty errCol:
       .filter(size(col("errCol")) > 0)
       // and only keep columns that are needed for the actual error publishing:
       .select(
         col(ColumnNames.enceladusRecordId).cast(DataTypes.StringType).as("recordId"),
-        col(ColumnNames.reportDate),
+        reportDateCol,
         explode(col(ColumnNames.errCol)).as("singleError")
       )
       .as[SingleErrorStardardized]
@@ -146,7 +152,7 @@ case class KafkaErrorSenderPluginImpl(connectionParams: KafkaConnectionParams,
 
 object KafkaErrorSenderPluginImpl {
 
-  // columns from the original datafram (post Stdardardization/Conformance) to be addressed
+  // columns from the original dataframe (post Standardization/Conformance) to be addressed
   object ColumnNames {
     val enceladusRecordId = "enceladus_record_id"
     val reportDate = "reportDate"
@@ -165,7 +171,7 @@ object KafkaErrorSenderPluginImpl {
         dataset = Some(additionalParams.datasetName),
         ingestionNumber = None,
         processingTimestamp = additionalParams.processingTimestamp.toEpochMilli,
-        informationDate = Some(reportDate.toLocalDate.toEpochDay.toInt),
+        informationDate = Option(reportDate).map(_.toLocalDate.toEpochDay.toInt),
         outputFileName = Some(additionalParams.outputPath),
         recordId = recordId,
         errorSourceId = additionalParams.sourceId.value,

--- a/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/buildin/kafka/KafkaPluginSuite.scala
+++ b/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/buildin/kafka/KafkaPluginSuite.scala
@@ -57,7 +57,7 @@ class KafkaPluginSuite extends AnyFunSuite {
     assert(kafkaConnection.topicName == "dummyTopicName")
   }
 
-  test("Test Kafka config parser recognizes security parameters") {
+  {
     val conf = ConfigFactory.parseMap(
       Map[String, String](KafkaConnectionParams.BootstrapServersKey -> "127.0.0.1:8081",
         KafkaConnectionParams.SchemaRegistryUrlKey -> "localhost:9092",
@@ -66,17 +66,31 @@ class KafkaPluginSuite extends AnyFunSuite {
         KafkaSecurityParams.SecurityProtocolKey -> "SASL_SSL",
         KafkaSecurityParams.SaslMechanismKey -> "GSSAPI"
       ).asJava)
+    def testCreateKafkaConnection = KafkaConnectionParams.fromConfig(conf, "my.client.id", "my.topic.name")
 
-    val kafkaConnection = KafkaConnectionParams.fromConfig(conf, "my.client.id", "my.topic.name")
+    test("Test Kafka config parser recognizes security parameters") {
+      val kafkaConnection = testCreateKafkaConnection
 
-    assert(kafkaConnection.security.isDefined)
-    assert(kafkaConnection.security.get.securityProtocol == "SASL_SSL")
-    assert(kafkaConnection.security.get.saslMechanism.isDefined)
-    assert(kafkaConnection.security.get.saslMechanism.get == "GSSAPI")
-    assert(kafkaConnection.bootstrapServers == "127.0.0.1:8081")
-    assert(kafkaConnection.schemaRegistryUrl == "localhost:9092")
-    assert(kafkaConnection.clientId == "dummyClientId")
-    assert(kafkaConnection.topicName == "dummyTopicName")
+      assert(kafkaConnection.security.isDefined)
+      assert(kafkaConnection.security.get.securityProtocol == "SASL_SSL")
+      assert(kafkaConnection.security.get.saslMechanism.isDefined)
+      assert(kafkaConnection.security.get.saslMechanism.get == "GSSAPI")
+      assert(kafkaConnection.bootstrapServers == "127.0.0.1:8081")
+      assert(kafkaConnection.schemaRegistryUrl == "localhost:9092")
+      assert(kafkaConnection.clientId == "dummyClientId")
+      assert(kafkaConnection.topicName == "dummyTopicName")
+    }
+
+    test("KafkaSecurityParams correctly converts to a Map (for a DataFrameWriter usage)") {
+      val kafkaConnection = testCreateKafkaConnection
+
+      val expected = Some(Map(
+        "kafka.security.protocol" -> "SASL_SSL",
+        "kafka.sasl.mechanism" -> "GSSAPI"
+      ))
+
+      assert(kafkaConnection.security.map(_.toMap) == expected)
+    }
   }
 
   test("Test Kafka config parser throws an exception if required properties are missing") {

--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -89,12 +89,20 @@ timezone="UTC"
 #kafka.info.metrics.client.id="controlInfo"
 #kafka.info.metrics.topic.name="control.info"
 
-#kafka.error.client.id="DqErrorSender"
+#kafka.error.client.id="errorInfo"
 #kafka.error.topic.name="dq.errors"
 
 # Optional security settings
 #kafka.security.protocol="SASL_SSL"
 #kafka.sasl.mechanism="GSSAPI"
+
+# SSL configuration specifics
+#javax.net.ssl.trustStore=/path/to/my-truststore.jks
+#javax.net.ssl.trustStorePassword=trustStoreExamplePassword1
+#javax.net.ssl.keyStore=/path/to/my-keystore.jks
+#javax.net.ssl.keyStorePassword=keyStoreExamplePassword1
+#java.security.auth.login.config="/path/to/jaas.config"
+# JAAS config should contain your `KafkaClient { ... }` settings - Kerberos-based or other
 
 # Optional - allows original dataframe columns to be dropped
 conformance.allowOriginalColumnsMutability=false


### PR DESCRIPTION
As the issue specifies, the following settings are needed for SSL secured Kafka topic to be produced messages to. Those can be applied either by updating the `spark-jobs`' `application.conf` or via the `--conf "spark.driver.extraJavaOptions=-Dconfig.key.here=config.value.here` method.

```
# Enabling the error-sending plugins (info plugins analogy)
standardization.plugin.postprocessor.1=za.co.absa.enceladus.plugins.builtin.errorsender.mq.kafka.KafkaErrorSenderPlugin
conformance.plugin.postprocessor.1=za.co.absa.enceladus.plugins.builtin.errorsender.mq.kafka.KafkaErrorSenderPlugin

# Have your clientId and your error topic name defined (info plugins analogy, too)
kafka.error.client.id="my-error-client-id1"
kafka.error.topic.name="example.error.publishing.topic"

# Kafka URL settings
kafka.schema.registry.url:"https://my1017.schema.registry.example.com:8081"
kafka.bootstrap.servers="my1013.bootstrap.server.example.com:9094,my1014.bootstrap.server.example.com:9094,my1015.bootstrap.server.example.com:9094"

# security settings for SSL
kafka.security.protocol="SASL_SSL"
kafka.sasl.mechanism="GSSAPI"

# SSL configuration specifics
javax.net.ssl.trustStore=/path/to/my-truststore.jks
javax.net.ssl.trustStorePassword=trustStoreExamplePassword1
javax.net.ssl.keyStore=/path/to/my-keystore.jks
javax.net.ssl.keyStorePassword=keyStoreExamplePassword1
java.security.auth.login.config="/path/to/jaas.config"
# JAAS config should contain your `KafkaClient { ... }` settings - Kerberos-based or other
```

Small changes in the error msgs producing to apply the security settings for the _structured streaming_ approach as well. 

## Tested on in-company secured Kafka cluster/topics
![error-publish-ssl-test](https://user-images.githubusercontent.com/4457378/109174078-ca65f500-7784-11eb-9a55-767400ee27b7.png)


### Release notes suggestion
Error messages publishing now works with SSL-secured Kafka topics. Refer to the [`spark-jobs`' `reference.conf`](https://github.com/AbsaOSS/enceladus/blob/develop/spark-jobs/src/main/resources/reference.conf) on how to set it up.

Closes #1352 