### PR TITLE
#1707: Make Enceladus compilation Warning free and keep it that way

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -79,6 +79,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -78,6 +78,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -59,6 +59,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -330,6 +330,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/auth/kerberos/ActiveDirectoryLdapAuthoritiesPopulator.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/auth/kerberos/ActiveDirectoryLdapAuthoritiesPopulator.scala
@@ -18,26 +18,28 @@ package za.co.absa.enceladus.menas.auth.kerberos
 import java.util
 
 import org.springframework.ldap.core.DirContextOperations
-import org.springframework.ldap.core.DistinguishedName
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.AuthorityUtils
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator
+import javax.naming.ldap.LdapName
 
 class ActiveDirectoryLdapAuthoritiesPopulator extends LdapAuthoritiesPopulator  {
 
   import scala.collection.JavaConversions._
 
- override def getGrantedAuthorities(userData: DirContextOperations, username: String): util.Collection[_ <: GrantedAuthority] = {
+  override def getGrantedAuthorities(userData: DirContextOperations, username: String): util.Collection[_ <: GrantedAuthority] = {
     val groups = userData.getStringAttributes("memberOf")
 
-     if (groups == null) {
-            AuthorityUtils.NO_AUTHORITIES
-        }
-     else {
-       groups.map({group =>
-         new SimpleGrantedAuthority(new DistinguishedName(group).removeLast().getValue)
+    if (groups == null) {
+      AuthorityUtils.NO_AUTHORITIES
+    }
+    else {
+      groups.map({group =>
+        val ldapName = new LdapName(group)
+        val role = ldapName.getRdn(ldapName.size() - 1).getValue.toString
+        new SimpleGrantedAuthority(role)
        }).toList
-     }
+    }
   }
 }

--- a/migrations-cli/pom.xml
+++ b/migrations-cli/pom.xml
@@ -77,6 +77,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/migrations/pom.xml
+++ b/migrations/pom.xml
@@ -85,6 +85,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins-api/pom.xml
+++ b/plugins-api/pom.xml
@@ -54,6 +54,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugins-builtin/pom.xml
+++ b/plugins-builtin/pom.xml
@@ -91,6 +91,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
         <maven.rat.plugin.version>0.12</maven.rat.plugin.version>
-        <maven.scala.version>3.2.0</maven.scala.version>
+        <maven.scala.version>4.4.0</maven.scala.version>
         <maven.scoverage.version>1.3.0</maven.scoverage.version>
         <maven.shade.version>3.2.1</maven.shade.version>
         <maven.sources.version>3.0.1</maven.sources.version>

--- a/spark-jobs/pom.xml
+++ b/spark-jobs/pom.xml
@@ -238,6 +238,13 @@ spark-submit -(remove this)-packages org.apache.spark:spark-sql-kafka-0-10_2.11:
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -79,6 +79,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xfatal-warnings</arg>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                    </args>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
* Deprecated call replaced in `ActiveDirectoryLdapAuthoritiesPopulator`
* Whole project set to fail on compilation warning
* `scala-maven-plugin` upgraded to version 4.4.0

Release notes:
Project Enceladus is now built without any warnings. (No deprecated code calls, no advanced language features). Project is set to fail  on compilation in case of any such warnings.