### PR TITLE
#1718: Show keytab entry key type in helper scripts

### DIFF
--- a/scripts/bash/run_enceladus.sh
+++ b/scripts/bash/run_enceladus.sh
@@ -493,7 +493,7 @@ if [[ -z "$DRY_RUN" ]]; then
       if [[ -n "$PR" ]]; then
         # Initialize a ticket
         kinit -k -t "$MENAS_AUTH_KEYTAB" "$PR"
-        klist 2>&1 | tee -a "$TMP_PATH_NAME"
+        klist -e 2>&1 | tee -a "$TMP_PATH_NAME"
       else
         echoerr "WARNING!"
         echoerr "Unable to determine principle from the keytab file $MENAS_AUTH_KEYTAB."

--- a/scripts/cmd/_run_enceladus.cmd
+++ b/scripts/cmd/_run_enceladus.cmd
@@ -552,14 +552,11 @@ CALL :temp_log_file TMP_PATH_NAME
 
 :: Initializing Kerberos ticket
 IF DEFINED MENAS_AUTH_KEYTAB (
-    CALL :echoerr "Menas keytab authentication is not yet supported in Windows helper scripts."
-    :: Get principle stored in the keyfile (Thanks @Zejnilovic)
-    :: PR=`printf "read_kt $MENAS_AUTH_KEYTAB\nlist" | ktutil | grep -Pio "(?<=\ )[A-Za-z0-9\-\._]*?(?=@)" | head -1`
-    :: Alternative way, might be less reliable
-    :: PR=`printf "read_kt $MENAS_AUTH_KEYTAB\nlist" | ktutil | sed -n '5p' | awk '{print $3}' | cut -d '@' -f1`
+    :: Get principle stored in the keyfile`
+    FOR /F "tokens=1-3" %%A IN ('ktab -l -k %MENAS_AUTH_KEYTAB%') DO IF "%%A"=="0" SET PR=%%B
     IF DEFINED PR (
         kinit -k -t "%MENAS_AUTH_KEYTAB%" "%PR%"
-        klist 2>&1 | tee -a %TMP_PATH_NAME%
+        klist -e 2>&1 | tee -a %TMP_PATH_NAME%
     ) ELSE (
         CALL :echoerr "WARNING!"
         CALL :echoerr "Unable to determine principle from the keytab file %MENAS_AUTH_KEYTAB%."


### PR DESCRIPTION
* Added `-e` switch to `klist` call in helper scripts
* Menas keytab authentication has been implemented for Windows helper script

Release note:
Keytab authentication now supported by Windows _Helper Scripts_ too. General better keytab logging in _Helper Scripts_ (`klist -e`).

Closes #1718 