### PR TITLE
1774 kafka error test fix (SourcePhase capitalization)

### DIFF
--- a/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/builtin/errorsender/mq/KafkaErrorSenderPluginSuite.scala
+++ b/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/builtin/errorsender/mq/KafkaErrorSenderPluginSuite.scala
@@ -163,12 +163,12 @@ class KafkaErrorSenderPluginSuite extends AnyFlatSpec with SparkTestBase with Ma
 
   Seq(
     SourcePhase.Standardization -> Seq(
-      "standardizaton,stdCastError,E00000,Standardization Error - Type cast",
-      "standardizaton,stdNullError,E00002,Standardization Error - Null detected in non-nullable attribute"
+      "Standardization,stdCastError,E00000,Standardization Error - Type cast",
+      "Standardization,stdNullError,E00002,Standardization Error - Null detected in non-nullable attribute"
     ),
     SourcePhase.Conformance -> Seq(
-      "conformance,confNegErr,E00004,Conformance Negation Error",
-      "conformance,confLitErr,E00005,Conformance Literal Error"
+      "Conformance,confNegErr,E00004,Conformance Negation Error",
+      "Conformance,confLitErr,E00005,Conformance Literal Error"
     )
   ).foreach { case (source, specificErrorParts) =>
     it should s"send $source errors to kafka as confluent_avro" in {

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/modules/SourcePhase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/modules/SourcePhase.scala
@@ -26,7 +26,7 @@ sealed trait SourcePhase {
 
 object SourcePhase {
   def withIdentifier(name: String): SourcePhase = {
-    name match {
+    name.toLowerCase match {
       case "conformance" => SourcePhase.Conformance
       case "standardization" => SourcePhase.Standardization
       case _ => throw new NoSuchElementException(s"No value found for '$name'")


### PR DESCRIPTION
For some reason, this test result was previously not correctly checked (only manifested with error log but did not break the test as expected).

Now, this PR fixes the test in terms of string capitalization - while leaving the production code intact.

  - No testing needed - CI build is done automatically and it has been passing.

RN suggestion
`KafkaErrorSenderPluginSuite` test fix for `SourcePhase.{Standardization, Conformance}` capitalization.