### PR TITLE
#1787: MenasDAO.getDataset backwards compatibility fix

### DIFF
--- a/dao/src/main/scala/za/co/absa/enceladus/dao/MenasDAO.scala
+++ b/dao/src/main/scala/za/co/absa/enceladus/dao/MenasDAO.scala
@@ -18,7 +18,9 @@ package za.co.absa.enceladus.dao
 import org.apache.spark.sql.types.StructType
 import za.co.absa.enceladus.model._
 import za.co.absa.atum.model._
+import za.co.absa.enceladus.utils.validation.ValidationLevel.Constants.DefaultValidationLevel
 import za.co.absa.enceladus.utils.validation.ValidationLevel.ValidationLevel
+
 /**
   * Trait for Menas API DAO.
   */
@@ -26,7 +28,6 @@ trait MenasDAO {
 
   /**
     * Authenticates user with Menas
-    * @throws UnauthorizedException if authentication fails
     */
   @throws[UnauthorizedException]
   def authenticate(): Unit
@@ -39,7 +40,7 @@ trait MenasDAO {
     * @param validateProperties if set to other then  `NoValidation` datasets's `propertiesValidation` field will be populated
     * @return The retrieved dataset
     */
-  def getDataset(name: String, version: Int, validateProperties: ValidationLevel): Dataset
+  def getDataset(name: String, version: Int, validateProperties: ValidationLevel = DefaultValidationLevel): Dataset
 
   /**
    * Retrieves properties to be written to the info file

--- a/dao/src/main/scala/za/co/absa/enceladus/dao/rest/MenasRestDAO.scala
+++ b/dao/src/main/scala/za/co/absa/enceladus/dao/rest/MenasRestDAO.scala
@@ -19,6 +19,7 @@ import org.apache.spark.sql.types.{DataType, StructType}
 import za.co.absa.atum.model.{Checkpoint, ControlMeasure, RunStatus}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.{Dataset, MappingTable, Run, SplineReference, Validation}
+import za.co.absa.enceladus.utils.validation.ValidationLevel.Constants.DefaultValidationLevel
 import za.co.absa.enceladus.utils.validation.ValidationLevel.ValidationLevel
 
 /**
@@ -31,16 +32,21 @@ protected class MenasRestDAO(private[rest] val apiCaller: ApiCaller,
     restClient.authenticate()
   }
 
-  def getDataset(name: String, version: Int, validateProperties: ValidationLevel): Dataset = {
+  def getDataset(name: String, version: Int, validateProperties: ValidationLevel = DefaultValidationLevel): Dataset = {
+    val queryParam = if (validateProperties != DefaultValidationLevel) {
+      s"?validateProperties=$validateProperties"
+    } else {
+      ""
+    }
     apiCaller.call { apiBaseUrl =>
-      val url = s"$apiBaseUrl/api/dataset/$name/$version?validateProperties=$validateProperties"
+      val url = s"$apiBaseUrl/api/dataset/$name/$version$queryParam"
       restClient.sendGet[Dataset](url)
     }
   }
 
   def getDatasetPropertiesForInfoFile(datasetName: String, datasetVersion: Int): Map[String, String] = {
     apiCaller.call { apiBaseUrl =>
-      val url = s"$apiBaseUrl/api/dataset/$datasetName/$datasetVersion/properties/?putIntoInfoFile=true"
+      val url = s"$apiBaseUrl/api/dataset/$datasetName/$datasetVersion/properties?putIntoInfoFile=true"
       restClient.sendGet[Map[String, String]](url)
     }
   }

--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/MenasRestDAOSuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/MenasRestDAOSuite.scala
@@ -66,12 +66,22 @@ class MenasRestDAOSuite extends BaseTestSuite with VersionedModelMatchers {
       Mockito.verify(restClient, Mockito.only()).authenticate()
     }
 
-    "getDataset" in {
+    "getDataset without validation" in {
       val expected = DatasetFactory.getDummyDataset(name, version)
-      val url = s"$apiBaseUrl/api/dataset/$name/$version?validateProperties=${ValidationLevel.NoValidation}"
+      val url = s"$apiBaseUrl/api/dataset/$name/$version"
       Mockito.when(restClient.sendGet[Dataset](url)).thenReturn(expected)
 
       val result = menasDao.getDataset(name, version, ValidationLevel.NoValidation)
+
+      result should matchTo(expected)
+    }
+
+    "getDataset with validation" in {
+      val expected = DatasetFactory.getDummyDataset(name, version)
+      val url = s"$apiBaseUrl/api/dataset/$name/$version?validateProperties=${ValidationLevel.Strictest}"
+      Mockito.when(restClient.sendGet[Dataset](url)).thenReturn(expected)
+
+      val result = menasDao.getDataset(name, version, ValidationLevel.Strictest)
 
       result should matchTo(expected)
     }

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/DatasetController.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/controllers/DatasetController.scala
@@ -26,10 +26,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation._
 import za.co.absa.enceladus.menas.services.DatasetService
-import za.co.absa.enceladus.utils.validation.ValidationLevel.{NoValidationName, ValidationLevel}
+import za.co.absa.enceladus.utils.validation.ValidationLevel.ValidationLevel
 import za.co.absa.enceladus.model.conformanceRule.ConformanceRule
 import za.co.absa.enceladus.model.properties.PropertyDefinition
 import za.co.absa.enceladus.model.{Dataset, Validation}
+import za.co.absa.enceladus.utils.validation.ValidationLevel.Constants.DefaultValidationLevelName
 
 import scala.concurrent.Future
 import scala.util.Try
@@ -134,7 +135,7 @@ class DatasetController @Autowired()(datasetService: DatasetService)
                                          @PathVariable("datasetVersion") datasetVersion: Int,
                                          @RequestParam(value = "validateProperties",
                                                        required = false,
-                                                       defaultValue = NoValidationName) validate: ValidationLevel
+                                                       defaultValue = DefaultValidationLevelName) validate: ValidationLevel
                                         ): CompletableFuture[Dataset] = {
     datasetService.getVersionValidated(datasetName, datasetVersion, validate).map {
       case Some(ds) => ds

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/ValidationLevel.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/ValidationLevel.scala
@@ -21,7 +21,7 @@ object ValidationLevel extends Enumeration {
   final val NoValidation, ForRun, Strictest = Value
 
   object Constants { // Not to mix with enumeration items
-    final val DefaultValidationLevel:ValidationLevel  = NoValidation
+    final val DefaultValidationLevel: ValidationLevel = NoValidation
 
     final val DefaultValidationLevelName = "NoValidation" // This is used in an annotation - for that the type MUST NOT be specified
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/validation/ValidationLevel.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/validation/ValidationLevel.scala
@@ -20,5 +20,10 @@ object ValidationLevel extends Enumeration {
 
   final val NoValidation, ForRun, Strictest = Value
 
-  final val NoValidationName = "NoValidation" // This is used in an annotation - for that the type MUST NOT be specified
+  object Constants { // Not to mix with enumeration items
+    final val DefaultValidationLevel:ValidationLevel  = NoValidation
+
+    final val DefaultValidationLevelName = "NoValidation" // This is used in an annotation - for that the type MUST NOT be specified
+  }
+
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/ValidationLevelSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/ValidationLevelSuite.scala
@@ -21,7 +21,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 class ValidationLevelSuite extends AnyFunSuite {
 
-  // these two simple steps shoudl prevent an unintended default validation level change without thinking through the consequences
+  // these two simple steps should prevent an unintended default validation level change without thinking through the consequences
 
   test("Verify enumeration names") {
     // this ensures that the defined constant stays correct - as the `toString` function cannot be used in annotations, even indirectly

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/validation/ValidationLevelSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/validation/ValidationLevelSuite.scala
@@ -21,8 +21,14 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 class ValidationLevelSuite extends AnyFunSuite {
 
+  // these two simple steps shoudl prevent an unintended default validation level change without thinking through the consequences
+
   test("Verify enumeration names") {
     // this ensures that the defined constant stays correct - as the `toString` function cannot be used in annotations, even indirectly
-    ValidationLevel.NoValidationName should be (ValidationLevel.NoValidation.toString)
+    ValidationLevel.Constants.DefaultValidationLevelName should be (ValidationLevel.NoValidation.toString)
+  }
+
+  test("Verify default validation level") {
+    ValidationLevel.Constants.DefaultValidationLevel.toString should be (ValidationLevel.Constants.DefaultValidationLevelName)
   }
 }


### PR DESCRIPTION
* defined `DefaultValidationLevel`
* default value for `validationLevel` in `getDataset`
* if value for validationLevel is equal to DefaultValidationLevel, validation level is not added to query string

Release notes:
MenasDAO.getDataset made backward compatible.

Closes #1787 