### PR TITLE
Hotfix: suggestedValueNotApplied for 2.20.1 #1796

### DIFF
--- a/data-model/src/main/scala/za/co/absa/enceladus/model/properties/propertyType/package.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/properties/propertyType/package.scala
@@ -28,16 +28,22 @@ package object propertyType {
     new Type(value = classOf[EnumPropertyType], name = "EnumPropertyType")
   ))
   sealed trait PropertyType {
-    def suggestedValue: String
+    def suggestedValue: Option[String]
 
     def isValueConforming(value: String): Try[Unit]
   }
 
-  case class StringPropertyType(suggestedValue: String = "") extends PropertyType {
+  case class StringPropertyType(suggestedValue: Option[String] = None) extends PropertyType {
     override def isValueConforming(value: String): Try[Unit] = Success(Unit)
   }
 
-  case class EnumPropertyType(allowedValues: Set[String], suggestedValue: String) extends PropertyType {
+  case class EnumPropertyType(allowedValues: Seq[String], suggestedValue: Option[String]) extends PropertyType {
+    require(allowedValues.nonEmpty, "At least one allowed value must be defined for EnumPropertyType.")
+    require(allowedValues.forall(_.nonEmpty), "Empty string is disallowed as an allowedValue for EnumPropertyType." +
+      "Consider using the property in non-mandatory context instead.")
+    require(allowedValues.size == allowedValues.toSet.size,
+      s"Allowed values for EnumPropertyType should be unique, but $allowedValues was given.")
+
     override def isValueConforming(value: String): Try[Unit] = {
       if (allowedValues.contains(value)) {
         Success(Unit)
@@ -46,9 +52,12 @@ package object propertyType {
       }
     }
 
-    isValueConforming(suggestedValue) match {
-      case Success(_) =>
-      case Failure(e) => throw PropertyTypeValidationException(s"The suggested value $suggestedValue cannot be used: ${e.getMessage}", e)
+    suggestedValue.map { existingSuggestedValue =>
+      isValueConforming(existingSuggestedValue) match {
+        case Success(_) =>
+        case Failure(e) =>
+          throw PropertyTypeValidationException(s"The suggested value $existingSuggestedValue cannot be used: ${e.getMessage}", e)
+      }
     }
   }
 
@@ -58,9 +67,8 @@ package object propertyType {
      * @param allowedValues The first value will be assinged to the [[PropertyType#suggestedValue]] field.
      * @return
      */
-    def apply(allowedValues: String*): EnumPropertyType = EnumPropertyType(allowedValues.toSet, allowedValues(0))
+    def apply(allowedValues: String*): EnumPropertyType = EnumPropertyType(allowedValues.toSeq, Some(allowedValues(0)))
   }
 
   case class PropertyTypeValidationException(msg: String, cause: Throwable) extends Exception(msg, cause)
-
 }

--- a/data-model/src/test/scala/za/co/absa/enceladus/model/PropertyDefinitionTest.scala
+++ b/data-model/src/test/scala/za/co/absa/enceladus/model/PropertyDefinitionTest.scala
@@ -30,7 +30,7 @@ class PropertyDefinitionTest extends AnyFunSuite {
       name = "testStringProperty1",
       version = 2,
       description = Some("test desc"),
-      propertyType = StringPropertyType(suggestedValue = "sort of default"),
+      propertyType = StringPropertyType(suggestedValue = Some("sort of default")),
       putIntoInfoFile = true,
       essentiality = Mandatory()
     )
@@ -47,12 +47,34 @@ class PropertyDefinitionTest extends AnyFunSuite {
     assert(stringPropertyDef.exportItem() == expectedPropertyDef)
   }
 
+  test("export string PropertyDefinition 2 - without suggestedValue") {
+    val stringPropertyDef = PropertyDefinition(
+      name = "testStringProperty1",
+      version = 2,
+      description = Some("test desc"),
+      propertyType = StringPropertyType(suggestedValue = None),
+      putIntoInfoFile = true,
+      essentiality = Mandatory()
+    )
+
+    val expectedPropertyDef =
+      s"""{"metadata":{"exportVersion":$modelVersion},"item":{
+         |"name":"testStringProperty1",
+         |"description":"test desc",
+         |"propertyType":{"_t":"StringPropertyType","suggestedValue":null},
+         |"putIntoInfoFile":true,
+         |"essentiality":{"_t":"Mandatory"}
+         |}}""".stripMargin.replaceAll("[\\r\\n]", "")
+
+    assert(stringPropertyDef.exportItem() == expectedPropertyDef)
+  }
+
   test("export enum PropertyDefinition") {
     val enumPropertyDef = PropertyDefinition(
       name = "testEnumProperty1",
       version = 3,
       description = None,
-      propertyType = EnumPropertyType(Set("optionA", "optionB", "optionC"), suggestedValue = "optionB")
+      propertyType = EnumPropertyType(Seq("optionA", "optionB", "optionC"), suggestedValue = Some("optionB"))
     )
 
     val expectedPropertyDef =
@@ -66,13 +88,32 @@ class PropertyDefinitionTest extends AnyFunSuite {
     assert(enumPropertyDef.exportItem() == expectedPropertyDef)
   }
 
+  test("export enum PropertyDefinition 2 - no suggested value") {
+    val enumPropertyDef = PropertyDefinition(
+      name = "testEnumProperty1",
+      version = 3,
+      description = None,
+      propertyType = EnumPropertyType(Seq("optionA", "optionB", "optionC"), suggestedValue = None)
+    )
+
+    val expectedPropertyDef =
+      s"""{"metadata":{"exportVersion":$modelVersion},"item":{
+         |"name":"testEnumProperty1",
+         |"propertyType":{"_t":"EnumPropertyType","allowedValues":["optionA","optionB","optionC"],"suggestedValue":null},
+         |"putIntoInfoFile":false,
+         |"essentiality":{"_t":"Optional"}
+         |}}""".stripMargin.replaceAll("[\\r\\n]", "")
+
+    assert(enumPropertyDef.exportItem() == expectedPropertyDef)
+  }
+
   test("Suggested value conformity should be checked") {
     val errorMessage = intercept[PropertyTypeValidationException] {
       PropertyDefinition(
         name = "testEnumProperty1",
         version = 3,
         description = None,
-        propertyType = EnumPropertyType(Set("optionA", "optionB", "optionC"), suggestedValue = "invalidOption")
+        propertyType = EnumPropertyType(Seq("optionA", "optionB", "optionC"), suggestedValue = Some("invalidOption"))
       )
     }.getMessage
 

--- a/data-model/src/test/scala/za/co/absa/enceladus/model/properties/propertyType/PropertyTypeTest.scala
+++ b/data-model/src/test/scala/za/co/absa/enceladus/model/properties/propertyType/PropertyTypeTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.model.properties.propertyType
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PropertyTypeTest extends AnyFlatSpec with Matchers {
+
+  "EnumPropertyType" should "check suggestedValue conformity with defined allowedValues" in {
+    val errorMessage = intercept[PropertyTypeValidationException] {
+      EnumPropertyType(Seq("optionA", "optionB", "optionC"), suggestedValue = Some("invalidOption"))
+    }.getMessage
+    errorMessage should include("Value 'invalidOption' is not one of the allowed values (optionA, optionB, optionC).")
+  }
+
+  it should "check allowedValues to contain at least 1 item" in {
+    val errorMessage = intercept[IllegalArgumentException] {
+      EnumPropertyType(Seq.empty, suggestedValue = None)
+    }.getMessage
+    errorMessage should include("At least one allowed value must be defined for EnumPropertyType.")
+  }
+
+  it should "check allowedValues only to contain nonempty strings" in {
+    Seq(
+      Seq(""),
+      Seq("", "other", "values")
+    ).foreach { invalidValues =>
+      intercept[IllegalArgumentException] {
+        EnumPropertyType(invalidValues, suggestedValue = None)
+      }.getMessage should include("Empty string is disallowed as an allowedValue for EnumPropertyType.")
+    }
+  }
+
+  it should "check allowedValues contains unique values" in {
+    val nonUniqueAllowedValues = Seq("duplicate", "duplicate", "other")
+      intercept[IllegalArgumentException] {
+        EnumPropertyType(nonUniqueAllowedValues, suggestedValue = None)
+      }.getMessage should include("Allowed values for EnumPropertyType should be unique")
+  }
+
+  it should "allow empty suggested value no matter the allowedValues" in {
+    EnumPropertyType(Seq("optionA", "optionB", "optionC"), suggestedValue = None) // throws no exception
+  }
+
+
+}

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/DatasetApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/DatasetApiIntegrationSuite.scala
@@ -26,7 +26,7 @@ import za.co.absa.enceladus.model.{Dataset, Validation}
 import za.co.absa.enceladus.model.properties.PropertyDefinition
 import za.co.absa.enceladus.model.properties.essentiality.{Essentiality, Mandatory, Optional, Recommended}
 import za.co.absa.enceladus.model.properties.propertyType.{PropertyType, EnumPropertyType, StringPropertyType}
-import za.co.absa.enceladus.model.test.factories.{DatasetFactory, PropertyDefinitionFactory}
+import za.co.absa.enceladus.model.test.factories.{DatasetFactory, PropertyDefinitionFactory, SchemaFactory}
 
 @RunWith(classOf[SpringRunner])
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -43,6 +43,53 @@ class DatasetApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll 
 
   // fixtures are cleared after each test
   override def fixtures: List[FixtureService[_]] = List(datasetFixture, propertyDefinitionFixture)
+
+  s"POST $apiUrl/create" can {
+    "return 201" when {
+      "a Dataset is created" should {
+        "return the created Dataset (with empty properties stripped)" in {
+          val dataset = DatasetFactory.getDummyDataset("dummyDs",
+            properties = Some(Map("keyA" -> "valA", "keyB" -> "valB", "keyC" -> "")))
+
+          val response = sendPost[Dataset, Dataset](s"$apiUrl/create", bodyOpt = Some(dataset))
+          assertCreated(response)
+
+          val actual = response.getBody
+          val expected = toExpected(dataset, actual).copy(properties = Some(Map("keyA" -> "valA", "keyB" -> "valB"))) // keyC stripped
+          assert(actual == expected)
+        }
+      }
+    }
+  }
+
+  s"POST $apiUrl/edit" can {
+    "return 201" when { // todo not RESTful - consider 200 OK for editing result - issue #966
+      "a Schema with the given name and version is the latest that exists" should {
+        "return the updated Schema (with empty properties stripped)" in {
+          val datasetA1 = DatasetFactory.getDummyDataset("datasetA",
+            description = Some("init version"), properties = Some(Map("keyA" -> "valA")))
+          datasetFixture.add(datasetA1)
+
+          val datasetA2 = DatasetFactory.getDummyDataset("datasetA", description = Some("updated"),
+            properties = Some(Map("keyA" -> "valA", "keyB" -> "valB", "keyC" -> "")))
+
+          val response = sendPost[Dataset, Dataset](s"$apiUrl/edit", bodyOpt = Some(datasetA2))
+          assertCreated(response)
+
+          val actual = response.getBody
+          val expectedDs = DatasetFactory.getDummyDataset(
+              name = "datasetA",
+              version = 2,
+              description = Some("updated"),
+              parent = Some(DatasetFactory.toParent(datasetA1)),
+              properties = Some(Map("keyA" -> "valA", "keyB" -> "valB"))
+          )
+          val expected = toExpected(expectedDs, actual)
+          assert(actual == expected)
+        }
+      }
+    }
+  }
 
   s"GET $apiUrl/detail/{name}/latestVersion" should {
     "return 200" when {
@@ -192,7 +239,8 @@ class DatasetApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll 
   s"PUT $apiUrl/{name}/properties" should {
     "201 Created with location " when {
       Seq(
-        ("non-empty properties map", """{"keyA":"valA","keyB":"valB"}""", Some(Map("keyA" -> "valA", "keyB" -> "valB"))),
+        ("non-empty properties map", """{"keyA":"valA","keyB":"valB","keyC":""}""",
+          Some(Map("keyA" -> "valA", "keyB" -> "valB"))), // empty string property would get removed (defined "" => undefined)
         ("empty properties map", "{}", Some(Map.empty)),
         ("no properties at all", "", None) // this is backwards compatible option with the pre-properties era versions
       ).foreach {case (testCaseName, payload, expectedPropertiesSet) =>
@@ -225,10 +273,11 @@ class DatasetApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll 
       PropertyDefinitionFactory.getDummyPropertyDefinition(name, essentiality = essentiality, propertyType = propertyType)
 
     val propDefs = Seq(
-      createPropDef("mandatoryField1", Mandatory(), StringPropertyType("default1")),
-      createPropDef("mandatoryField2", Mandatory(), StringPropertyType("default1")),
+      createPropDef("mandatoryField1", Mandatory(), StringPropertyType(Some("default1"))),
+      createPropDef("mandatoryField2", Mandatory(), StringPropertyType()),
+      createPropDef("mandatoryField3", Mandatory(), StringPropertyType()),
       createPropDef("enumField1", Optional(), EnumPropertyType("optionA", "optionB")),
-      createPropDef("enumField2", Recommended(), EnumPropertyType("optionC", "optionD"))
+      createPropDef("enumField2", Recommended(), EnumPropertyType(Seq("optionC", "optionD"), suggestedValue = None))
     )
 
     val properties = Map(
@@ -239,6 +288,7 @@ class DatasetApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll 
 
     val expectedValidation = Validation(Map(
       "mandatoryField2" -> List("Dataset property 'mandatoryField2' is mandatory, but does not exist!"),
+      "mandatoryField3" -> List("Dataset property 'mandatoryField3' is mandatory, but does not exist!"),
       "enumField1" -> List("Value 'invalidOption' is not one of the allowed values (optionA, optionB)."),
       "nonAccountedField" -> List("There is no property definition for key 'nonAccountedField'.")
     ))

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/PropertyDefinitionApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/PropertyDefinitionApiIntegrationSuite.scala
@@ -42,8 +42,14 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
   override def fixtures: List[FixtureService[_]] = List(propertyDefinitionFixture)
 
 
-  private def minimalPdCreatePayload(name: String, suggestedValue: String) =
-    s"""{"name": "$name","propertyType": {"_t": "StringPropertyType","suggestedValue": "$suggestedValue"}}"""
+  private def minimalPdCreatePayload(name: String, suggestedValue: Option[String]) = {
+    val suggestedValuePart = suggestedValue match {
+      case Some(actualSuggestedValue) => s""","suggestedValue": "$actualSuggestedValue""""
+      case _ => ""
+    }
+
+    s"""{"name": "$name","propertyType": {"_t": "StringPropertyType"$suggestedValuePart}}"""
+  }
 
   private def invalidPayload(name: String) =
     s"""{
@@ -76,14 +82,16 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
           }
         }
         "a PropertyDefinition is created with most of default values" should {
-          "return the created PropertyDefinition" in {
-            val propertyDefinition = minimalPdCreatePayload("smallPd", "default1")
-            val response = sendPost[String, PropertyDefinition](urlPattern, bodyOpt = Some(propertyDefinition))
-            assertCreated(response)
+          Seq(Some("default1"), None).foreach { suggestedValue =>
+            s"return the created PropertyDefinition (suggestedValue=$suggestedValue)" in {
+              val propertyDefinition = minimalPdCreatePayload("smallPd", suggestedValue)
+              val response = sendPost[String, PropertyDefinition](urlPattern, bodyOpt = Some(propertyDefinition))
+              assertCreated(response)
 
-            val actual = response.getBody
-            val expected = toExpected(PropertyDefinition("smallPd", propertyType = StringPropertyType("default1")), actual)
-            assert(actual == expected)
+              val actual = response.getBody
+              val expected = toExpected(PropertyDefinition("smallPd", propertyType = StringPropertyType(suggestedValue)), actual)
+              assert(actual == expected)
+            }
           }
         }
         "all prior versions of the PropertyDefinition are disabled" should {
@@ -254,7 +262,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
           assert(body ==
             """{"metadata":{"exportVersion":1},"item":{
               |"name":"propertyDefinition",
-              |"propertyType":{"_t":"StringPropertyType","suggestedValue":""},
+              |"propertyType":{"_t":"StringPropertyType","suggestedValue":null},
               |"putIntoInfoFile":false,
               |"essentiality":{"_t":"Optional"}
               |}}""".stripMargin.replaceAll("[\\r\\n]", ""))
@@ -311,7 +319,7 @@ class PropertyDefinitionApiIntegrationSuite extends BaseRestApiTest with BeforeA
                  |"name":"propertyDefinition1",
                  |"version":23,
                  |"description":null,
-                 |"propertyType":{"_t":"StringPropertyType","suggestedValue":""},
+                 |"propertyType":{"_t":"StringPropertyType","suggestedValue":null},
                  |"putIntoInfoFile":false,
                  |"essentiality":{"_t":"Optional"},
                  |"disabled":false,

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/services/DatasetServiceTest.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/services/DatasetServiceTest.scala
@@ -181,4 +181,14 @@ class DatasetServiceTest extends VersionedModelServiceTest[Dataset] with Matcher
     }
   }
 
+  test("DatasetService.removeBlankProperties removes properties with empty-string values (unit)") {
+    val properties = Map(
+      "propKey1" -> "someValue",
+      "propKey2" -> ""
+    )
+
+    val dataset = DatasetFactory.getDummyDataset(name = "datasetA", properties = Some(properties))
+    DatasetService.removeBlankProperties(dataset.properties) shouldBe Some(Map("propKey1" -> "someValue"))
+  }
+
 }

--- a/menas/ui/components/app.controller.js
+++ b/menas/ui/components/app.controller.js
@@ -49,7 +49,7 @@ sap.ui.define([
 
       GenericService.getUserInfo();
       GenericService.getOozieInfo();
-      PropertiesService.getProperties();
+      PropertiesService.getProperties(); // works correctly with existing session, hence called after login, too
 
       this._router.getRoute("root").attachMatched((oEvent) => {
         let userInfo = sap.ui.getCore().getModel().getProperty("/userInfo");

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -31,13 +31,13 @@
                           <InputListItem class="inputListItemSmallLabel" label="{entity>name}" tooltip="{entity>description}">
                             <HBox alignItems="Center" justifyContent="End" renderType="Bare">
                               <Input type="Text" width="18rem" visible="{= ${entity>propertyType/_t} === 'StringPropertyType'}"
-                                class="propertyInput" value="{entity>value}" valueState="{entity>validation}" 
+                                class="propertyInput" value="{entity>value}" placeholder="{entity>suggestedValue}" valueState="{entity>validation}"
                                 valueStateText="{entity>validationText}"></Input>
-                              <Select width="18rem"
-                                items="{path: 'entity>propertyType/allowedValues', templateShareable: false}"
+                                  <Select width="18rem"
+                                items="{path: 'entity>allowedValues', templateShareable: false}"
                                 selectedKey="{entity>value}" valueState="{entity>validation}" valueStateText="{entity>validationText}"
-                                visible="{= ${entity>propertyType/_t} === 'EnumPropertyType'}">
-                                <core:Item key="{entity>value}" text="{entity>value}"></core:Item>
+                                visible="{= ${entity>propertyType/_t} === 'EnumPropertyType'}" forceSelection="false">
+                                <core:Item key="{entity>value}" text="{entity>text}"></core:Item>
                               </Select>
                               <core:Icon width="1rem" class="sapUiSmallMarginBegin" color="Neutral" tooltip="{entity>essentiality/_t}"
                                 src="{= ${entity>essentiality/_t} === 'Mandatory' ? 'sap-icon://alert' : (${entity>essentiality/_t} === 'Recommended' ? 'sap-icon://warning' : 'sap-icon://accept') }"></core:Icon>

--- a/menas/ui/components/login/loginDetail.controller.js
+++ b/menas/ui/components/login/loginDetail.controller.js
@@ -133,6 +133,7 @@ sap.ui.define([
           this._router.navTo("home");
           this._eventBus.publish("nav", "login");
         });
+        PropertiesService.getProperties(); // refresh properties when logged in
       };
 
       let fnError = () => {

--- a/menas/ui/generic/functions.js
+++ b/menas/ui/generic/functions.js
@@ -53,5 +53,15 @@ var Functions = new function () {
         }
       }
     })
+  };
+
+  /**
+   * Checks if the property is enum-like by making sure that non-empty iterable of `allowedValues` exists
+   * @param propertyType
+   * @returns {boolean}
+   */
+  this.hasValidAllowedValues = function(propertyType) {
+    return propertyType.hasOwnProperty("allowedValues") && propertyType.allowedValues.length > 0;
   }
+
 }();

--- a/menas/ui/service/EntityService.js
+++ b/menas/ui/service/EntityService.js
@@ -305,7 +305,7 @@ class DatasetService extends EntityService {
 
     const oProps = {};
 
-    if(oEntity._properties && oEntity._properties.map){ 
+    if (oEntity._properties && oEntity._properties.map) {
       oEntity._properties.map((oProp) => {
         oProps[oProp.name] = oProp.value
       });
@@ -325,13 +325,34 @@ class DatasetService extends EntityService {
     }
   }
 
+  // if properties with empty string value exist, the returned properties copy will not contain these objects (backend expecting an empty option)
+  stripBlankProperties(properties) {
+    const updatedProperties = properties.map((oProp) => {
+      if (oProp.value === "") {
+        const changedProp = jQuery.extend({}, oProp);
+        changedProp.value = undefined;
+        return changedProp;
+      } else {
+        return oProp; // unchanged
+      }
+    });
+
+    return updatedProperties;
+  }
+
   update(oDataset) {
+    oDataset._properties = this.stripBlankProperties(oDataset._properties);
     return super.update(oDataset).then((oData) => {
       return this.schemaRestDAO.getByNameAndVersion(oData.schemaName, oData.schemaVersion).then((oData) => {
         this.modelBinder.setProperty(oData, "/schema");
         return oData
       })
     })
+  }
+
+  create(oDataset) {
+    oDataset._properties = this.stripBlankProperties(oDataset._properties);
+    return super.create(oDataset);
   }
 
   disable(sName, iVersion) {

--- a/menas/ui/service/EntityValidationService.js
+++ b/menas/ui/service/EntityValidationService.js
@@ -92,24 +92,27 @@ var EntityValidationService = new function () {
 
     aProperties.map((oProp) => {
       const sDesc = oProp.description ? ` (${oProp.description})` : "";
-      //check essentiality - if Mandatory property has no or empty value, we fail
-      if(oProp.essentiality._t === "Mandatory" && !oProp.value) {
+      const isEnum = Functions.hasValidAllowedValues(oProp.propertyType);
+      const msg = `${isEnum ? "Choose one of valid options for" : "Provide valid"} ${oProp.name}${sDesc}`;
+
+      // check essentiality - if Mandatory property has no or empty value, we fail
+      if (oProp.essentiality._t === "Mandatory" && !oProp.value) {
         isOk = false;
         oProp.validation = "Error";
-        oProp.validationText = `Provide valid ${oProp.name}${sDesc}`;
-      } else if(oProp.essentiality._t === "Recommended" && !oProp.value) {
+        oProp.validationText = msg;
+      } else if (oProp.essentiality._t === "Recommended" && !oProp.value) {
         oProp.validation = "Warning";
-        oProp.validationText = `Provide valid ${oProp.name}${sDesc}`;
+        oProp.validationText = msg;
       }
-      //for enum type properties, check that the value is allowed
-      if(oProp.propertyType.allowedValues && oProp.propertyType.allowedValues.length > 0) {
-        if(oProp.propertyType.allowedValues.filter((oVal) => { return oVal.value === oProp.value }).length === 0) {
-          isOk = false;
-          oProp.validation = "Error";
-          oProp.validationText = `Choose one of valid options for ${oProp.name}${sDesc}`;
-        }
+
+      // for enum type properties, check that the value is allowed or blank
+      // (blank is not allowed for mandatory, but the above check takes care of that)
+      if (isEnum && !oProp.propertyType.allowedValues.includes(oProp.value) && oProp.value !== "") {
+        isOk = false;
+        oProp.validation = "Error";
+        oProp.validationText = msg;
       }
-    })
+    });
     return isOk;
   };
 


### PR DESCRIPTION
#1789 backport to 2.20.1

## Test-run
My own naive UI testing worked:
 - edited an existing dataset to contain properties, again editing them - unsetting some of the properties. Correctly show in UI and expected properties maps also existed in the Mongo DB
 - created a new DS with some non-mandatory properties not set, mongo DB collection contained the expected map. 