### PR TITLE
cronstrue not being loaded without existing session

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/WebSecurityConfig.scala
@@ -61,7 +61,7 @@ class WebSecurityConfig @Autowired()(beanFactory: BeanFactory,
         .and()
         .authorizeRequests()
           .antMatchers("/index.html", "/resources/**", "/generic/**",
-            "/service/**", "/webjars/**", "/css/**", "/components/**", "/admin/health",
+            "/service/**", "/webjars/**", "/3rdParty/**", "/css/**", "/components/**", "/admin/health",
             "/api/oozie/isEnabled", "/api/user/version", s"/${projectVersion}/**", "/api/configuration/**")
           .permitAll()
         .anyRequest()


### PR DESCRIPTION
Allowing the path for cRonstrue to be loaded without authorization seems to be needed to get correct Menas behavior without having to refresh the page after login.

### Test-ran
 - naively test ran on my machine: even on login page, the library is now loaded immediately:
 ![cronstrue-loaded-1st-from-3rdParty2](https://user-images.githubusercontent.com/4457378/120794371-6d729b80-c538-11eb-96e5-a1499ebfaffb.png)
 
Also, having an existing custom dataset with defined schedule and having oozie enabled in config (so that the Scheduling tab is reachable), now the dataset data and its scheduling details are also correctly shown in the UI (this was not the case for the first run after login before this fix)

hints: of course, we should remerge/cherrypick this to other branches (`hotfix/2.{20,21}.1`, `develop`, ...)