### PR TITLE
rat-plugin config for menas in a profile (same as root pom.xml)

### DIFF
--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -386,17 +386,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <version>${maven.rat.plugin.version}</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/node_modules/**</exclude>
-                        <exclude>ui/3rdParty/cRonstrue/cronstrue.min.js</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -470,6 +459,25 @@
                                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                                 </manifest>
                             </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>license-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>${maven.rat.plugin.version}</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/node_modules/**</exclude>
+                                <exclude>ui/3rdParty/cRonstrue/cronstrue.min.js</exclude>
+                                <exclude>ui/dist/**</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
For `menas`, the existing licence check ignore items (particular for `menas`) are moved to the `license-check` profile to align the with the `root.pom` (and actually not to prevent otherwise successful build)

 - the `<exclude>ui/dist/**</exclude>` entry is added for convenience when license-checking on a built codebase.