### PR TITLE
1820 Fix auditable message for Dataset Properties

### DIFF
--- a/data-model/src/main/scala/za/co/absa/enceladus/model/Dataset.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/Dataset.scala
@@ -115,7 +115,8 @@ case class Dataset(name: String,
           AuditFieldName("schemaName", "Schema Name"),
           AuditFieldName("schemaVersion", "Schema Version"),
           AuditFieldName("schedule", "Schedule"))) ++
-        super.getSeqFieldsAudit(newRecord, AuditFieldName("conformance", "Conformance rule")))
+        super.getSeqFieldsAudit(newRecord, AuditFieldName("conformance", "Conformance rule")) ++
+        super.getOptionalMapFieldsAudit(newRecord, AuditFieldName("properties", "Property")))
   }
 
   override def exportItem(): String = {

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/menas/audit/Auditable.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/menas/audit/Auditable.scala
@@ -79,6 +79,74 @@ trait Auditable[T <: Product] { self: T =>
     }).getOrElse(Seq())
   }
 
+
+
+  private[model] def getOptionalMapFieldsAudit(newValue: T, fieldName: AuditFieldName)(implicit ct: ClassTag[T]): Seq[AuditTrailChange] = {
+    def tupleToSomeString(v: (String, _)): Option[String] = Some(s"""key: "${v._1}" value: "${v._2}"""")
+
+    val index = getFieldIndex(fieldName.declaredField)
+
+    index.map({i =>
+      val maybeNewMap = newValue.productElement(i).asInstanceOf[Option[Map[String, _]]]
+      val maybeOldMap = self.productElement(i).asInstanceOf[Option[Map[String, _]]]
+
+      (maybeNewMap, maybeOldMap) match {
+        case (Some(newMap), Some(oldMap)) =>
+          val added = newMap.toSet.diff(oldMap.toSet).toMap
+          val removed = oldMap.toSet.diff(newMap.toSet).toMap
+          val changedKey = added.keySet.intersect(removed.keySet)
+          val onlyAdded = added -- changedKey
+          val onlyRemoved = removed -- changedKey
+
+          val addedList = onlyAdded.map(t =>
+            AuditTrailChange(field = fieldName.declaredField,
+              oldValue = None,
+              newValue = tupleToSomeString(t),
+              message = s"${fieldName.humanReadableField} added."
+            )
+          )
+          val removedList = onlyRemoved.map(t =>
+            AuditTrailChange(
+              field = fieldName.declaredField,
+              oldValue = tupleToSomeString(t),
+              newValue = None,
+              message = s"${fieldName.humanReadableField} removed."
+            )
+          )
+          val changedList = changedKey.map(k =>
+            AuditTrailChange(
+              field = fieldName.declaredField,
+              oldValue = tupleToSomeString(k, removed(k)),
+              newValue = tupleToSomeString(k, added(k)),
+              message = s"${fieldName.humanReadableField} changed."
+            )
+          )
+
+          removedList ++ addedList ++ changedList
+        case (None, Some(oldMap)) =>
+          oldMap.map((v: (String, Any)) =>
+            AuditTrailChange(
+              field = fieldName.declaredField,
+              oldValue = tupleToSomeString(v),
+              newValue = None,
+              message = s"${fieldName.humanReadableField} removed."
+            )
+          )
+        case (Some(newMap), None) =>
+          newMap.map((v: (String, Any)) =>
+            AuditTrailChange(
+              field = fieldName.declaredField,
+              oldValue = None,
+              newValue = tupleToSomeString(v),
+              message = s"${fieldName.humanReadableField} added."
+            )
+          )
+        case (_, _) => Set.empty
+      }
+
+    }).getOrElse(Set.empty).toSeq
+  }
+
   /**
    * Utility function to unwrap defined option values (if Some) or keep the original value otherwise.
    */

--- a/data-model/src/test/scala/za/co/absa/enceladus/model/menas/audit/AuditableTest.scala
+++ b/data-model/src/test/scala/za/co/absa/enceladus/model/menas/audit/AuditableTest.scala
@@ -100,5 +100,24 @@ class AuditableTest extends AnyFunSuite {
     ))(result)
   }
 
+  test("Testing removed getOptionalMapFieldsAudit") {
+    val result = obj3.getOptionalMapFieldsAudit(obj2, AuditFieldName("properties", "Property"))
+    assertResult(Seq(
+      AuditTrailChange(field = "properties", newValue = None, oldValue = Some("""key: "key1" value: "value1""""), message = "Property removed.")
+    ))(result)
+  }
 
+  test("Testing added getOptionalMapFieldsAudit - explicitly None properties") {
+    val result = obj2.copy(properties = None).getOptionalMapFieldsAudit(obj3, AuditFieldName("properties", "Property"))
+    assertResult(Seq(
+      AuditTrailChange(field = "properties", newValue = Some("""key: "key1" value: "value1""""), oldValue = None, message = "Property added.")
+    ))(result)
+  }
+
+  test("Testing removed getOptionalMapFieldsAudit  - explicitly None properties") {
+    val result = obj3.getOptionalMapFieldsAudit(obj2.copy(properties = None), AuditFieldName("properties", "Property"))
+    assertResult(Seq(
+      AuditTrailChange(field = "properties", newValue = None, oldValue = Some("""key: "key1" value: "value1""""), message = "Property removed.")
+    ))(result)
+  }
 }

--- a/data-model/src/test/scala/za/co/absa/enceladus/model/menas/audit/AuditableTest.scala
+++ b/data-model/src/test/scala/za/co/absa/enceladus/model/menas/audit/AuditableTest.scala
@@ -37,6 +37,15 @@ class AuditableTest extends AnyFunSuite {
     schemaVersion = 1,
     conformance = List(LiteralConformanceRule(order = 0, controlCheckpoint = true, outputColumn = "something", value = "1.01")))
 
+  val obj3 = Dataset(name = "Test DS",
+    version = 3,
+    hdfsPath = "newPath",
+    hdfsPublishPath = "newPublishPath",
+    schemaName = "newSchema",
+    schemaVersion = 1,
+    conformance = List(LiteralConformanceRule(order = 0, controlCheckpoint = true, outputColumn = "something", value = "1.01")),
+    properties = Some(Map("key1" -> "value1")))
+
   test("Testing getPrimitiveFieldsAudit empty") {
     val emptyRes = obj1.getPrimitiveFieldsAudit(obj2, Seq())
     assertResult(Seq())(emptyRes)
@@ -75,4 +84,21 @@ class AuditableTest extends AnyFunSuite {
           AuditTrailChange(field = "conformance", oldValue = Some("LiteralConformanceRule(0,something,true,1.01)"), None, message = "Conformance rule removed.")
     ))(removedRes)
   }
+
+  test("Testing added getOptionalMapFieldsAudit") {
+    val result = obj2.getOptionalMapFieldsAudit(obj3, AuditFieldName("properties", "Property"))
+    assertResult(Seq(
+      AuditTrailChange(field = "properties", newValue = Some("""key: "key1" value: "value1""""), oldValue = None, message = "Property added.")
+    ))(result)
+  }
+
+  test("Testing changed getOptionalMapFieldsAudit") {
+    val newObj2 = obj2.copy(properties = Some(Map("key1" -> "value previous")))
+    val result = newObj2.getOptionalMapFieldsAudit(obj3, AuditFieldName("properties", "Property"))
+    assertResult(Seq(
+      AuditTrailChange(field = "properties", newValue = Some("""key: "key1" value: "value1""""), oldValue = Some("""key: "key1" value: "value previous""""), message = "Property changed.")
+    ))(result)
+  }
+
+
 }


### PR DESCRIPTION
**How it looks now:**

![image](https://user-images.githubusercontent.com/17467768/122683580-6918d480-d200-11eb-808b-1afbc16a6352.png)


**Release notes**: 
Now Audit Trail in Menas shows added, removed and changed properties

Fixes #1820