### PR TITLE
strip blank properties fix

### DIFF
--- a/menas/ui/service/EntityService.js
+++ b/menas/ui/service/EntityService.js
@@ -307,7 +307,9 @@ class DatasetService extends EntityService {
 
     if (oEntity._properties && oEntity._properties.map) {
       oEntity._properties.map((oProp) => {
-        oProps[oProp.name] = oProp.value
+        if (oProp.value !== "") { // strips blank properties
+          oProps[oProp.name] = oProp.value
+        }
       });
     }
 
@@ -325,23 +327,7 @@ class DatasetService extends EntityService {
     }
   }
 
-  // if properties with empty string value exist, the returned properties copy will not contain these objects (backend expecting an empty option)
-  stripBlankProperties(properties) {
-    const updatedProperties = properties.map((oProp) => {
-      if (oProp.value === "") {
-        const changedProp = jQuery.extend({}, oProp);
-        changedProp.value = undefined;
-        return changedProp;
-      } else {
-        return oProp; // unchanged
-      }
-    });
-
-    return updatedProperties;
-  }
-
   update(oDataset) {
-    oDataset._properties = this.stripBlankProperties(oDataset._properties);
     return super.update(oDataset).then((oData) => {
       return this.schemaRestDAO.getByNameAndVersion(oData.schemaName, oData.schemaVersion).then((oData) => {
         this.modelBinder.setProperty(oData, "/schema");
@@ -351,7 +337,6 @@ class DatasetService extends EntityService {
   }
 
   create(oDataset) {
-    oDataset._properties = this.stripBlankProperties(oDataset._properties);
     return super.create(oDataset);
   }
 

--- a/menas/ui/service/EntityService.js
+++ b/menas/ui/service/EntityService.js
@@ -302,15 +302,18 @@ class DatasetService extends EntityService {
   }
 
   cleanupEntity(oEntity) {
-
-    const oProps = {};
+    let oProps = {};
 
     if (oEntity._properties && oEntity._properties.map) {
+      // properties update => use _properties instead of properties + sanitize
       oEntity._properties.map((oProp) => {
         if (oProp.value !== "") { // strips blank properties
           oProps[oProp.name] = oProp.value
         }
       });
+    } else {
+      // no properties update (via populated _properties), use original properties on update (e.g. CRs are being updated)
+      oProps = oEntity.properties;
     }
 
     return {


### PR DESCRIPTION
This PR addresses 2 problems: 
1. when updating a dataset (using _Edit_), new ds property values are in `_properties` (while the old values are in `properties`); while for conformance rules update, the values are only in `properties`, as they are not being changed. (so, `_properties` is not defined)
2. when changing CRs, the ds properties are not kept (they get stripped) - update/delete/move (therefore simple `if(!dataset._properties) {...}` does not suffice)

The code now works as follows: only `_properties` are being blank-checked-and-fixed (moved to `DatasetService.cleanupEntity`), while for CR updates, the `properties` are used.

Note to self: we are so missing an UI testing framework being employed :(

## Testing done:
 - on localhost:
 1. create a dataset with ds properties -> checked in UI and DB for correct result
 1. change ds properties -> observed the blanks being removed
 1. create a conformance rule (a CastingConformanceRule) -> observe CR being added to a new version while the ds properties being still present on DS
 1. delete the conformance rule -> observe CR removed and ds properties being still present on DS


## RN suggestion:
Fixed: Dataset properties checking broke some Conformance Rules updates.
