### PR TITLE
1807 Add schema registry security params

### DIFF
--- a/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/InfoProducerKafka.scala
+++ b/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/InfoProducerKafka.scala
@@ -50,6 +50,11 @@ class InfoProducerKafka[T](kafkaConnectionParams: KafkaConnectionParams)
       sec.saslMechanism.foreach(saslMechanism => props.put("sasl.mechanism", saslMechanism))
     })
 
+    kafkaConnectionParams.schemaRegistrySecurityParams.foreach(param => {
+      props.put(AbstractKafkaAvroSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, param.credentialsSource)
+      param.userInfo.foreach(info => props.put(AbstractKafkaAvroSerDeConfig.USER_INFO_CONFIG, info))
+    })
+
     new KafkaProducer[GenericRecord, GenericRecord](props)
   }
 

--- a/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/KafkaConnectionParams.scala
+++ b/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/KafkaConnectionParams.scala
@@ -25,7 +25,8 @@ case class KafkaConnectionParams(
                                   schemaRegistryUrl: String,
                                   clientId: String,
                                   security: Option[KafkaSecurityParams],
-                                  topicName: String
+                                  topicName: String,
+                                  schemaRegistrySecurityParams: Option[SchemaRegistrySecurityParams]
                                 )
 
 object KafkaConnectionParams {
@@ -52,7 +53,8 @@ object KafkaConnectionParams {
       conf.getString(SchemaRegistryUrlKey),
       conf.getString(clientIdKey),
       KafkaSecurityParams.fromConfig(conf),
-      conf.getString(topicNameKey)
+      conf.getString(topicNameKey),
+      SchemaRegistrySecurityParams.fromConfig(conf)
     )
   }
 

--- a/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/KafkaSecurityParams.scala
+++ b/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/KafkaSecurityParams.scala
@@ -16,7 +16,7 @@
 package za.co.absa.enceladus.plugins.builtin.common.mq.kafka
 
 import com.typesafe.config.Config
-import za.co.absa.enceladus.plugins.builtin.common.mq.kafka.KafkaSecurityParams.{SaslMechanismKey, SecurityProtocolKey}
+import za.co.absa.enceladus.plugins.builtin.common.mq.kafka.KafkaSecurityParams._
 import za.co.absa.enceladus.utils.config.ConfigUtils.ConfigImplicits
 
 /**
@@ -27,8 +27,12 @@ case class KafkaSecurityParams(
                                 saslMechanism: Option[String]
                               ) {
   def toMap: Map[String, String] = {
-    Map(SecurityProtocolKey -> securityProtocol) ++
-      saslMechanism.fold(Map.empty[String, String])(saslValue => Map(SaslMechanismKey -> saslValue))
+    Map(
+      SecurityProtocolKey -> Some(securityProtocol),
+      SaslMechanismKey -> saslMechanism
+    ).collect {
+      case (key, Some(value)) => key -> value
+    }
   }
 }
 

--- a/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/SchemaRegistrySecurityParams.scala
+++ b/plugins-builtin/src/main/scala/za/co/absa/enceladus/plugins/builtin/common/mq/kafka/SchemaRegistrySecurityParams.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.plugins.builtin.common.mq.kafka
+
+import com.typesafe.config.Config
+import za.co.absa.enceladus.utils.config.ConfigUtils.ConfigImplicits
+
+case class SchemaRegistrySecurityParams(credentialsSource: String,
+                                        userInfo: Option[String])
+
+object SchemaRegistrySecurityParams {
+  val BasicAuthCredentialsSourceKey = "kafka.schema.registry.basic.auth.credentials.source"
+  val BasicAuthUserInfoKey = "kafka.schema.registry.basic.auth.user.info"
+
+  def fromConfig(conf: Config): Option[SchemaRegistrySecurityParams] = {
+    conf.getOptionString(BasicAuthCredentialsSourceKey).map { source =>
+      SchemaRegistrySecurityParams(source,
+        conf.getOptionString(BasicAuthUserInfoKey))
+    }
+  }
+}

--- a/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/buildin/kafka/KafkaPluginSuite.scala
+++ b/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/buildin/kafka/KafkaPluginSuite.scala
@@ -19,7 +19,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.plugins.buildin.factories.DceControlInfoFactory
 import za.co.absa.enceladus.plugins.buildin.kafka.dummy.DummyControlInfoProducer
-import za.co.absa.enceladus.plugins.builtin.common.mq.kafka.{KafkaConnectionParams, KafkaSecurityParams}
+import za.co.absa.enceladus.plugins.builtin.common.mq.kafka.{KafkaConnectionParams, KafkaSecurityParams, SchemaRegistrySecurityParams}
 import za.co.absa.enceladus.plugins.builtin.controlinfo.mq.ControlInfoSenderPlugin
 
 import scala.collection.JavaConverters._
@@ -64,7 +64,9 @@ class KafkaPluginSuite extends AnyFunSuite {
         "my.client.id" -> "dummyClientId",
         "my.topic.name" -> "dummyTopicName",
         KafkaSecurityParams.SecurityProtocolKey -> "SASL_SSL",
-        KafkaSecurityParams.SaslMechanismKey -> "GSSAPI"
+        KafkaSecurityParams.SaslMechanismKey -> "GSSAPI",
+        SchemaRegistrySecurityParams.BasicAuthCredentialsSourceKey -> "USER_INFO",
+        SchemaRegistrySecurityParams.BasicAuthUserInfoKey -> "user1:password2"
       ).asJava)
     def testCreateKafkaConnection = KafkaConnectionParams.fromConfig(conf, "my.client.id", "my.topic.name")
 
@@ -75,6 +77,8 @@ class KafkaPluginSuite extends AnyFunSuite {
       assert(kafkaConnection.security.get.securityProtocol == "SASL_SSL")
       assert(kafkaConnection.security.get.saslMechanism.isDefined)
       assert(kafkaConnection.security.get.saslMechanism.get == "GSSAPI")
+      assert(kafkaConnection.schemaRegistrySecurityParams.get.credentialsSource == "USER_INFO")
+      assert(kafkaConnection.schemaRegistrySecurityParams.get.userInfo.get == "user1:password2")
       assert(kafkaConnection.bootstrapServers == "127.0.0.1:8081")
       assert(kafkaConnection.schemaRegistryUrl == "localhost:9092")
       assert(kafkaConnection.clientId == "dummyClientId")

--- a/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/builtin/errorsender/mq/KafkaErrorSenderPluginSuite.scala
+++ b/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/builtin/errorsender/mq/KafkaErrorSenderPluginSuite.scala
@@ -113,7 +113,7 @@ class KafkaErrorSenderPluginSuite extends AnyFlatSpec with SparkTestBase with Ma
     val errorPlugin: KafkaErrorSenderPluginImpl = KafkaErrorSenderPlugin.apply(testConfig)
 
     errorPlugin.connectionParams shouldBe KafkaConnectionParams(bootstrapServers = testKafkaUrl, schemaRegistryUrl = testSchemaRegUrl,
-      clientId = testClientId, security = None, topicName = testTopicName)
+      clientId = testClientId, security = None, topicName = testTopicName, schemaRegistrySecurityParams = None)
 
     errorPlugin.keySchemaRegistryConfig shouldBe Map(
       SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> testSchemaRegUrl,

--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -96,6 +96,10 @@ timezone="UTC"
 #kafka.security.protocol="SASL_SSL"
 #kafka.sasl.mechanism="GSSAPI"
 
+# Optional Schema Registry Parameters
+#kafka.schema.registry.basic.auth.credentials.source=USER_INFO
+#kafka.schema.registry.basic.auth.user.info=user:password
+
 # SSL configuration specifics
 #javax.net.ssl.trustStore=/path/to/my-truststore.jks
 #javax.net.ssl.trustStorePassword=trustStoreExamplePassword1

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/Constants.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/Constants.scala
@@ -32,6 +32,7 @@ object Constants {
     "spline.mongodb.url",
     "sun.boot.class.path",
     "sun.java.command",
-    "s3.kmsKeyId"
+    "s3.kmsKeyId",
+    "kafka.schema.registry.basic.auth.user.info"
   )
 }


### PR DESCRIPTION
New configs for SparkJobs using kafak plugins
- kafka.schema.registry.basic.auth.credentials.source
- kafka.schema.registry.basic.auth.user.info

Release Notes:
Added new properties for KafkaPlugins to be able to connect to Secured SchemaRegistry

Fixes #1807
