### PR TITLE
#1835: Support multiple date formats in Helper scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,3 +36,7 @@ max_line_length = 120
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{cmd,bat}]
+end_of_line = crlf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,5 +24,5 @@
 
 # Force batch scripts to always use CRLF line endings as they in some cases might not work correctly.
 # Also if a repo is accessed in Windows via a file share from Linux, the scripts will work too
-*.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/scripts/cmd/_enceladus_env.template.cmd
+++ b/scripts/cmd/_enceladus_env.template.cmd
@@ -104,3 +104,10 @@ SET MASTER=yarn
 :: Switch that tells the script if it should exit if it encounters unrecognized.
 :: On true it prints an Error and exits with 127, on false it only prints a warning
 SET EXIT_ON_UNRECOGNIZED_OPTIONS=true
+
+:: The way how the date is formatted in the OS, to check it run `echo %date%` on command line
+:: parser1 for 25.06.2021
+:: parser2 for Fri 06/25/2021
+:: parser3 for 2021-06-25
+:: The type of delimiters and language doesn't matter, parsing is done positionally
+SET DATE_PARSING_TYPE=parser1

--- a/scripts/cmd/_enceladus_env.template.cmd
+++ b/scripts/cmd/_enceladus_env.template.cmd
@@ -104,10 +104,3 @@ SET MASTER=yarn
 :: Switch that tells the script if it should exit if it encounters unrecognized.
 :: On true it prints an Error and exits with 127, on false it only prints a warning
 SET EXIT_ON_UNRECOGNIZED_OPTIONS=true
-
-:: The way how the date is formatted in the OS, to check it run `echo %date%` on command line
-:: parser1 for 25.06.2021
-:: parser2 for Fri 06/25/2021
-:: parser3 for 2021-06-25
-:: The type of delimiters and language doesn't matter, parsing is done positionally
-SET DATE_PARSING_TYPE=parser1

--- a/scripts/cmd/_run_enceladus.cmd
+++ b/scripts/cmd/_run_enceladus.cmd
@@ -464,6 +464,11 @@ CALL :validate --dataset-version,%DATASET_VERSION%
 CALL :validate --report-date,%REPORT_DATE%
 CALL :validate_either --menas-credentials-file,%MENAS_CREDENTIALS_FILE%,--menas-auth-keytab,%MENAS_AUTH_KEYTAB%
 
+IF NOT DEFINED DATE_PARSING_TYPE (
+    ECHO DATE_PARSING_TYPE not defined in `_enceladus_env.cmd`
+    SET VALID=="0"
+)
+
 :: For now this check is disabled in Windows version of the script
 :: IF NOT "%MASTER%"=="yarn" (
 ::   ECHO "Master '%MASTER%' is not allowed. The only allowed master is 'yarn'."
@@ -602,6 +607,8 @@ IF "%ASYNCHRONOUS_MODE%"=="true" (
 GOTO :eof
 
 :client_run
+:end
+
 CALL :temp_log_file TMP_PATH_NAME
 
 :: Initializing Kerberos ticket
@@ -638,7 +645,7 @@ IF EXIST %ERROR_SIGNAL_FILE% (
 :: Report the result and log location
 ECHO ""
 ECHO Job %RESULT%. Refer to logs at %TMP_PATH_NAME% | tee -a %TMP_PATH_NAME%
-EXIT /B %EXIT_STATUS%
+
 
 :: Functions
 
@@ -658,13 +665,25 @@ EXIT /B 0
 EXIT /B 0
 
 :temp_log_file
-    SET yyyy=%date:~-4%
-    SET MM=%date:~3,2%
-    SET DD=%date:~0,2%
-    ::alternate date parsing
-    ::SET YYYY=%date:~10,4%
-    ::SET MM=%date:~4,2%
-    ::SET DD=%date:~7,2%
+    IF %DATE_PARSING_TYPE%==parser1 (
+        ::25.06.2021
+        SET yyyy=%date:~-4%
+        SET MM=%date:~3,2%
+        SET DD=%date:~0,2%
+    )
+    IF %DATE_PARSING_TYPE%==parser2 (
+        ::Fri 06/25/2021
+        SET YYYY=%date:~10,4%
+        SET MM=%date:~4,2%
+        SET DD=%date:~7,2%
+    )
+    IF %DATE_PARSING_TYPE%==parser3 (
+        :: 2021-06-25
+        SET yyyy=%date:~0,4%
+        SET MM=%date:~5,2%
+        SET DD=%date:~8,2%
+    )
+    ::Time parsing
     SET HH=%time:~0,2%
     IF %HH% lss 10 (SET HH=0%time:~1,1%)
     SET MI=%time:~3,2%


### PR DESCRIPTION
* added configuration for date parsing type
* .gitattributes changed to hopefully better handle CRLF in native Windows files
* LF -> CRLF in *.cmd and *.bat files

I needed to implement the partial changes for my testing for other issues. So I thought to make it more general and include in code-base.

_Release notes:_
Configuration of the date parsing (locale dependent) to correctly name the log file.