### PR TITLE
#1818 errCol added in Conformance is not Nullable

### DIFF
--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -28,7 +28,7 @@ menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,ho
 # column will not be added at all. Allowed values: "uuid", "stableHashId", "none"
 enceladus.recordId.generation.strategy="uuid"
 
-# errCol's schema output to be (non)nullable in datagrame - both for Standardization and Conformance, regardless of errCol schema input
+# errCol's schema output to be (non)nullable in dataframe - both for Standardization and Conformance, regardless of errCol schema input
 # Warning: this works on dataframe level, when writing to/reading from parquet, columns are by default nullable, see:
 # https://spark.apache.org/docs/3.1.2/sql-data-sources-parquet.html
 enceladus.errCol.nullable=true

--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -31,7 +31,7 @@ enceladus.recordId.generation.strategy="uuid"
 # errCol's schema output to be (non)nullable in datagrame - both for Standardization and Conformance, regardless of errCol schema input
 # Warning: this works on dataframe level, when writing to/reading from parquet, columns are by default nullable, see:
 # https://spark.apache.org/docs/3.1.2/sql-data-sources-parquet.html
-enceladus.errCol.nullable=false
+enceladus.errCol.nullable=true
 
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"
 

--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -28,6 +28,9 @@ menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,ho
 # column will not be added at all. Allowed values: "uuid", "stableHashId", "none"
 enceladus.recordId.generation.strategy="uuid"
 
+# errCol's schema in output to be (non)nullable - both for Standardization and Conformance, regardless of errCol schema input
+enceladus.errCol.nullable=false
+
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"
 
 # Pattern to look for mapping table for the specified date

--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -28,7 +28,9 @@ menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,ho
 # column will not be added at all. Allowed values: "uuid", "stableHashId", "none"
 enceladus.recordId.generation.strategy="uuid"
 
-# errCol's schema in output to be (non)nullable - both for Standardization and Conformance, regardless of errCol schema input
+# errCol's schema output to be (non)nullable in datagrame - both for Standardization and Conformance, regardless of errCol schema input
+# Warning: this works on dataframe level, when writing to/reading from parquet, columns are by default nullable, see:
+# https://spark.apache.org/docs/3.1.2/sql-data-sources-parquet.html
 enceladus.errCol.nullable=false
 
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/ErrorColNormalization.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/ErrorColNormalization.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.common
+
+import com.typesafe.config.Config
+import org.apache.spark.sql.DataFrame
+import za.co.absa.enceladus.utils.error.ErrorMessage
+import za.co.absa.enceladus.utils.implicits.DataFrameImplicits._
+
+
+object ErrorColNormalization {
+
+  def getErrorColNullabilityFromConfig(conf: Config): Boolean = {
+    conf.getBoolean("enceladus.errCol.nullable") // may throw ConfigException._
+  }
+
+  def normalizeErrColNullability(dfInput: DataFrame, nullability: Boolean): DataFrame = {
+    dfInput.setNullableStateOfColumn(ErrorMessage.errorColumnName, nullability)
+  }
+
+}

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/ErrorColNormalization.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/ErrorColNormalization.scala
@@ -28,7 +28,7 @@ object ErrorColNormalization {
   }
 
   def normalizeErrColNullability(dfInput: DataFrame, nullability: Boolean): DataFrame = {
-    dfInput.setNullableStateOfColumn(ErrorMessage.errorColumnName, nullability)
+    dfInput.withNullableColumnState(ErrorMessage.errorColumnName, nullability)
   }
 
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/SparkCompatibility.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/SparkCompatibility.scala
@@ -26,6 +26,6 @@ import za.co.absa.commons.version.Version._
 import za.co.absa.commons.version.impl.SemVer20Impl.SemanticVersion
 
 object SparkCompatibility {
-  val minSparkVersionIncluded: SemanticVersion = semver"2.4.2"
+  val minSparkVersionIncluded: SemanticVersion = semver"3.1.2"
   val maxSparkVersionExcluded: Option[SemanticVersion] = Some(semver"3.2.0")
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/ConformanceExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/ConformanceExecution.scala
@@ -30,7 +30,7 @@ import za.co.absa.enceladus.common.plugin.menas.MenasPlugin
 import za.co.absa.enceladus.common.{CommonJobExecution, Constants, RecordIdGeneration}
 import za.co.absa.enceladus.conformance.config.{ConformanceConfig, ConformanceConfigParser}
 import za.co.absa.enceladus.conformance.interpreter.rules.ValidationException
-import za.co.absa.enceladus.conformance.interpreter.{FeatureSwitches, DynamicInterpreter}
+import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.MenasCredentials
 import za.co.absa.enceladus.model.Dataset

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/ConformanceExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/ConformanceExecution.scala
@@ -30,7 +30,7 @@ import za.co.absa.enceladus.common.plugin.menas.MenasPlugin
 import za.co.absa.enceladus.common.{CommonJobExecution, Constants, RecordIdGeneration}
 import za.co.absa.enceladus.conformance.config.{ConformanceConfig, ConformanceConfigParser}
 import za.co.absa.enceladus.conformance.interpreter.rules.ValidationException
-import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
+import za.co.absa.enceladus.conformance.interpreter.{FeatureSwitches, DynamicInterpreter}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.MenasCredentials
 import za.co.absa.enceladus.model.Dataset

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/ConformancePropertiesProvider.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/ConformancePropertiesProvider.scala
@@ -21,10 +21,11 @@ import za.co.absa.enceladus.conformance.config.ConformanceConfigParser
 import za.co.absa.enceladus.utils.config.ConfigUtils.ConfigImplicits
 import za.co.absa.enceladus.conformance.interpreter.{FeatureSwitches, ThreeStateSwitch}
 import ConformancePropertiesProvider._
+import za.co.absa.enceladus.common.ErrorColNormalization
 
 /**
-  * Reads conformance properties from the configuration file
-  */
+ * Reads conformance properties from the configuration file
+ */
 class ConformancePropertiesProvider {
   private val enableCF: Boolean = true
   private val log: Logger = LoggerFactory.getLogger(this.getClass)
@@ -36,13 +37,16 @@ class ConformancePropertiesProvider {
     enabled
   }
 
-  def readFeatureSwitches[T]()(implicit cmdConfig: ConformanceConfigParser[T]): FeatureSwitches = FeatureSwitches()
-    .setExperimentalMappingRuleEnabled(isExperimentalRuleEnabled())
-    .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled())
-    .setControlFrameworkEnabled(enableCF)
-    .setBroadcastStrategyMode(broadcastingStrategyMode)
-    .setBroadcastMaxSizeMb(broadcastingMaxSizeMb)
-    .setOriginalColumnsMutability(isOriginalColumnsMutabilityEnabled())
+  def readFeatureSwitches[T]()(implicit cmdConfig: ConformanceConfigParser[T]): FeatureSwitches = {
+    FeatureSwitches()
+      .setExperimentalMappingRuleEnabled(isExperimentalRuleEnabled())
+      .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled())
+      .setControlFrameworkEnabled(enableCF)
+      .setBroadcastStrategyMode(broadcastingStrategyMode)
+      .setBroadcastMaxSizeMb(broadcastingMaxSizeMb)
+      .setOriginalColumnsMutability(isOriginalColumnsMutabilityEnabled)
+      .setErrColNullability(isErrColNullability)
+  }
 
   private def isExperimentalRuleEnabled[T]()(implicit cmd: ConformanceConfigParser[T]): Boolean = {
     val enabled = getCmdOrConfigBoolean(cmd.experimentalMappingRule, experimentalRuleKey, defaultValue = false)
@@ -56,10 +60,16 @@ class ConformancePropertiesProvider {
     enabled
   }
 
-  private def isOriginalColumnsMutabilityEnabled[T]()(implicit cmd: ConformanceConfigParser[T]): Boolean = {
+  private def isOriginalColumnsMutabilityEnabled[T]: Boolean = {
     val enabled = conf.getOptionBoolean(allowOriginalColumnsMutabilityKey).getOrElse(false)
     log.info(s"Original column mutability enabled = $enabled")
     enabled
+  }
+
+  private def isErrColNullability[T]: Boolean = {
+    val nullability = ErrorColNormalization.getErrorColNullabilityFromConfig(conf)
+    log.info(s"ErrCol nullability in Conformance = $nullability")
+    nullability
   }
 
   private def broadcastingStrategyMode: ThreeStateSwitch = {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -149,6 +149,7 @@ object HyperConformance extends StreamTransformerFactory with HyperConformanceAt
       .setControlFrameworkEnabled(false)
       .setBroadcastStrategyMode(Always)
       .setBroadcastMaxSizeMb(0)
+      .setErrColNullability(true)
 
     implicit val reportDateCol: InfoDateFactory = InfoDateFactory.getFactoryFromConfig(conf)
 

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
@@ -393,7 +393,7 @@ case class DynamicInterpreter()(implicit inputFs: FileSystem) {
   }
 
   private def ensureErrorColumnNullability(inputDf: DataFrame, nullable: Boolean): DataFrame = {
-    inputDf.setNullableStateOfColumn(ErrorMessage.errorColumnName, nullable)
+    inputDf.withNullableColumnState(ErrorMessage.errorColumnName, nullable)
   }
 
   /**

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
@@ -34,7 +34,7 @@ sealed abstract case class FeatureSwitches(
                                                        broadcastStrategyMode: ThreeStateSwitch = Auto,
                                                        broadcastMaxSizeMb: Int = 0,
                                                        allowOriginalColumnsMutability: Boolean = false,
-                                                       errColNullability: Boolean = false // default value conforms to enceladus.errCol.nullable in reference.conf
+                                                       errColNullability: Boolean = true // default value conforms to enceladus.errCol.nullable in reference.conf
                                                      ) {
   private def copy(
                     experimentalMappingRuleEnabled: Boolean = this.experimentalMappingRuleEnabled,

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/FeatureSwitches.scala
@@ -28,27 +28,30 @@ package za.co.absa.enceladus.conformance.interpreter
   * @param broadcastMaxSizeMb             Specifies the maximum size of a mapping table for which the broadcasting strategy can be used.
   */
 sealed abstract case class FeatureSwitches(
-                                            experimentalMappingRuleEnabled: Boolean = false,
-                                            catalystWorkaroundEnabled: Boolean = false,
-                                            controlFrameworkEnabled: Boolean = false,
-                                            broadcastStrategyMode: ThreeStateSwitch = Auto,
-                                            broadcastMaxSizeMb: Int = 0,
-                                            allowOriginalColumnsMutability: Boolean = false
-                                          ) {
+                                                       experimentalMappingRuleEnabled: Boolean = false,
+                                                       catalystWorkaroundEnabled: Boolean = false,
+                                                       controlFrameworkEnabled: Boolean = false,
+                                                       broadcastStrategyMode: ThreeStateSwitch = Auto,
+                                                       broadcastMaxSizeMb: Int = 0,
+                                                       allowOriginalColumnsMutability: Boolean = false,
+                                                       errColNullability: Boolean = false // default value conforms to enceladus.errCol.nullable in reference.conf
+                                                     ) {
   private def copy(
                     experimentalMappingRuleEnabled: Boolean = this.experimentalMappingRuleEnabled,
                     catalystWorkaroundEnabled: Boolean = this.catalystWorkaroundEnabled,
                     controlFrameworkEnabled: Boolean = this.controlFrameworkEnabled,
                     broadcastStrategyMode: ThreeStateSwitch = this.broadcastStrategyMode,
                     broadcastMaxSizeMb: Int = this.broadcastMaxSizeMb,
-                    allowOriginalColumnsMutability: Boolean = this.allowOriginalColumnsMutability
+                    allowOriginalColumnsMutability: Boolean = this.allowOriginalColumnsMutability,
+                    errColNullability: Boolean = this.errColNullability
                   ): FeatureSwitches = {
     new FeatureSwitches(experimentalMappingRuleEnabled,
       catalystWorkaroundEnabled,
       controlFrameworkEnabled,
       broadcastStrategyMode,
       broadcastMaxSizeMb,
-      allowOriginalColumnsMutability) {}
+      allowOriginalColumnsMutability,
+      errColNullability) {}
   }
 
   def setExperimentalMappingRuleEnabled(value: Boolean): FeatureSwitches = {
@@ -73,6 +76,10 @@ sealed abstract case class FeatureSwitches(
 
   def setOriginalColumnsMutability(value: Boolean): FeatureSwitches = {
     copy(allowOriginalColumnsMutability = value)
+  }
+
+  def setErrColNullability(value: Boolean): FeatureSwitches = {
+    copy(errColNullability = value)
   }
 
 }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationExecution.scala
@@ -26,7 +26,7 @@ import za.co.absa.atum.core.Atum
 import za.co.absa.enceladus.common.RecordIdGeneration.getRecordIdGenerationStrategyFromConfig
 import za.co.absa.enceladus.common.config.{JobConfigParser, PathConfig}
 import za.co.absa.enceladus.common.plugin.menas.MenasPlugin
-import za.co.absa.enceladus.common.{CommonJobExecution, Constants}
+import za.co.absa.enceladus.common.{CommonJobExecution, Constants, ErrorColNormalization}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.MenasCredentials
 import za.co.absa.enceladus.model.Dataset
@@ -144,11 +144,12 @@ trait StandardizationExecution extends CommonJobExecution {
                               (implicit spark: SparkSession, udfLib: UDFLibrary): DataFrame = {
     //scalastyle:on parameter.number
     val recordIdGenerationStrategy = getRecordIdGenerationStrategyFromConfig(conf)
+    val errColNullability = ErrorColNormalization.getErrorColNullabilityFromConfig(conf)
 
     try {
       handleControlInfoValidation()
       StandardizationInterpreter.standardize(inputData, schema, cmd.rawFormat,
-        cmd.failOnInputNotPerSchema, recordIdGenerationStrategy)
+        cmd.failOnInputNotPerSchema, recordIdGenerationStrategy, errColNullability)
     } catch {
       case e@ValidationException(msg, errors) =>
         val errorDescription = s"$msg\nDetails: ${errors.mkString("\n")}"

--- a/spark-jobs/src/test/resources/interpreter/mappingCases/multiple_output/simpleMultiOutSchema.txt
+++ b/spark-jobs/src/test/resources/interpreter/mappingCases/multiple_output/simpleMultiOutSchema.txt
@@ -3,7 +3,7 @@ root
  |-- int_num: integer (nullable = true)
  |-- long_num: long (nullable = true)
  |-- str_val: string (nullable = true)
- |-- errCol: array (nullable = true)
+ |-- errCol: array (nullable = false)
  |    |-- element: struct (containsNull = true)
  |    |    |-- errType: string (nullable = true)
  |    |    |-- errCode: string (nullable = true)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/common/error/ErrorMessageFactory.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/common/error/ErrorMessageFactory.scala
@@ -15,8 +15,10 @@
 
 package za.co.absa.enceladus.common.error
 
+import javax.annotation.Nullable
+
 object ErrorMessageFactory {
-  val errColSchema: String =  "\n |-- errCol: array (nullable = true)\n"+
+  def errColSchema(nullable: Boolean): String =  s"\n |-- errCol: array (nullable = $nullable)\n"+
     " |    |-- element: struct (containsNull = false)\n"+
     " |    |    |-- errType: string (nullable = true)\n"+
     " |    |    |-- errCode: string (nullable = true)\n"+
@@ -29,7 +31,7 @@ object ErrorMessageFactory {
     " |    |    |    |    |-- mappingTableColumn: string (nullable = true)\n"+
     " |    |    |    |    |-- mappedDatasetColumn: string (nullable = true)\n"
 
-  def attachErrColToSchemaPrint(schemaPrint: String): String = {
-    schemaPrint + errColSchema
+  def attachErrColToSchemaPrint(nullable: Boolean, schemaPrint: String): String = {
+    schemaPrint + errColSchema(nullable)
   }
 }

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/StreamingFixture.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/StreamingFixture.scala
@@ -84,6 +84,7 @@ trait StreamingFixture extends AnyFunSuite with SparkTestBase with MockitoSugar 
       .setExperimentalMappingRuleEnabled(false)
       .setCatalystWorkaroundEnabled(catalystWorkaround)
       .setControlFrameworkEnabled(false)
+      .setErrColNullability(true)
 
     val memoryStream = new MemoryStream[Row](1, spark.sqlContext)(RowEncoder(input.schema))
     val hyperConformance = new HyperConformance()

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingGroupExplodeSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingGroupExplodeSuite.scala
@@ -30,7 +30,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/simpleResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, false, simpleMappingRule)
+      simpleTestCaseFactory.getTestCase(true, false, true, simpleMappingRule)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
@@ -48,7 +48,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/simpleMultiOutResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, false, simpleMappingRuleMultipleOutputs)
+      simpleTestCaseFactory.getTestCase(true, false, false, simpleMappingRuleMultipleOutputs)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum" ,$"conformedNum", $"conformedBool")
@@ -66,7 +66,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/simpleDefValResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, false, simpleMappingRuleWithDefaultValue)
+      simpleTestCaseFactory.getTestCase(true, false, true, simpleMappingRuleWithDefaultValue)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
@@ -84,7 +84,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/simpleDefValMultiOutResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, false, simpleMappingRuleMultipleOutputsWithDefaults)
+      simpleTestCaseFactory.getTestCase(true, false, false, simpleMappingRuleMultipleOutputsWithDefaults)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum" ,$"conformedNum", $"conformedBool")
@@ -102,7 +102,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/nested1Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, nestedMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, false, true, nestedMappingRule1)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum1")
@@ -120,7 +120,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/nested1ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, nestedMappingRule1Multi)
+      nestedTestCaseFactory.getTestCase(true, false, true, nestedMappingRule1Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1",
@@ -139,7 +139,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/nested2Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, nestedMappingRule2)
+      nestedTestCaseFactory.getTestCase(true, false, true, nestedMappingRule2)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum2")
@@ -157,7 +157,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/nested3Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, nestedMappingRule3)
+      nestedTestCaseFactory.getTestCase(true, false, true, nestedMappingRule3)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"conformedNum3", $"errCol")
@@ -175,7 +175,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/nested3ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, nestedMappingRule3Multi)
+      nestedTestCaseFactory.getTestCase(true, false, true, nestedMappingRule3Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2",
@@ -194,7 +194,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array1Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule1)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
@@ -212,7 +212,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array1ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule1Multi)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule1Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
@@ -230,7 +230,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array2Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule2)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule2)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -248,7 +248,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array2ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule2Multi)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule2Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -266,7 +266,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array3Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule3)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule3)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -284,7 +284,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array3ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule3Multi)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule3Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -302,7 +302,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array4Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule4)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule4)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -320,7 +320,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array4ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule4Multi)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule4Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -338,7 +338,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array5Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule5)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule5)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -356,7 +356,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array5ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule5Multi)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule5Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -374,7 +374,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array6Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule6)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule6)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -392,7 +392,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array7Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, arrayMappingRule2)
+      nestedTestCaseFactory.getTestCase(true, false, true, arrayMappingRule2)
 
     val inputDf2 = inputDf.withColumn("errCol", array(typedLit(ErrorMessage("Initial", "000", "ErrMsg", "id", Seq(), Seq()))))
 
@@ -409,7 +409,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
   test("Test group explode rule failure if key fields are in different arrays") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, false, wrongMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, false, true, wrongMappingRule1)
 
     intercept[Exception] {
       DynamicInterpreter().interpret(dataset, inputDf)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingGroupExplodeSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingGroupExplodeSuite.scala
@@ -200,7 +200,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -218,7 +218,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -236,7 +236,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -254,7 +254,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -272,7 +272,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -290,7 +290,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -308,7 +308,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -326,7 +326,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -344,7 +344,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -362,7 +362,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -380,7 +380,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)
@@ -400,7 +400,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
       .cache
 
-    val actualSchema = normalizeErrColNullability(cleanupContainsNullProperty(dfOut.schema.treeString))
+    val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
 
     assertSchema(actualSchema, expectedSchema)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingInterpreterSuite.scala
@@ -38,12 +38,6 @@ trait MappingInterpreterSuite extends AnyFunSuite with SparkTestBase with Logger
     super.afterAll()
   }
 
-  protected def normalizeErrColNullability(inputSchemaTree: String): String = {
-    inputSchemaTree
-      .replaceAll("errCol: array \\(nullable = false\\)", "errCol: array (nullable = true)")
-      .trim
-  }
-
   protected def cleanupContainsNullProperty(inputSchemaTree: String): String = {
     // This cleanup is needed since when a struct is processed via nestedStructMap() or nestedStructAndErrorMap(),
     // the new version of the struct always has the flag containsNull = false.

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleBroadcastSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleBroadcastSuite.scala
@@ -31,7 +31,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/simpleResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, true, simpleMappingRule)
+      simpleTestCaseFactory.getTestCase(true, true, true, simpleMappingRule)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
@@ -49,7 +49,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/simpleMultiOutResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, true, simpleMappingRuleMultipleOutputs)
+      simpleTestCaseFactory.getTestCase(true, true, false, simpleMappingRuleMultipleOutputs)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum" ,$"conformedNum", $"conformedBool")
@@ -67,7 +67,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/simpleDefValResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, true, simpleMappingRuleWithDefaultValue)
+      simpleTestCaseFactory.getTestCase(true, true, true, simpleMappingRuleWithDefaultValue)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
@@ -85,7 +85,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/simpleDefValMultiOutResults.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      simpleTestCaseFactory.getTestCase(true, true, simpleMappingRuleMultipleOutputsWithDefaults)
+      simpleTestCaseFactory.getTestCase(true, true, false, simpleMappingRuleMultipleOutputsWithDefaults)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum" ,$"conformedNum", $"conformedBool")
@@ -103,7 +103,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/nested1Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, nestedMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, true, true, nestedMappingRule1)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum1")
@@ -121,7 +121,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/nested1ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, nestedMappingRule1Multi)
+      nestedTestCaseFactory.getTestCase(true, true, true, nestedMappingRule1Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1",
@@ -140,7 +140,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/nested2Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, nestedMappingRule2)
+      nestedTestCaseFactory.getTestCase(true, true, true, nestedMappingRule2)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum2")
@@ -158,7 +158,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/nested3Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, nestedMappingRule3)
+      nestedTestCaseFactory.getTestCase(true, true, true, nestedMappingRule3)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"conformedNum3", $"errCol")
@@ -176,7 +176,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/nested3ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, nestedMappingRule3Multi)
+      nestedTestCaseFactory.getTestCase(true, true, true, nestedMappingRule3Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2",
@@ -195,7 +195,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array1Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule1)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
@@ -213,7 +213,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array1ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule1Multi)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule1Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
@@ -231,7 +231,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array2Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule2)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule2)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -249,7 +249,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array2ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule2Multi)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule2Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -267,7 +267,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array3Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule3)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule3)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -285,7 +285,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array3ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule3Multi)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule3Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -303,7 +303,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array4Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule4)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule4)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -321,7 +321,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array4ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule4Multi)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule4Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -339,7 +339,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array5Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule5)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule5)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -357,7 +357,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/multiple_output/array5ResultsMulti.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule5Multi)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule5Multi)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -375,7 +375,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array6Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule6)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule6)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
@@ -393,7 +393,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val expectedResults = getResourceString("/interpreter/mappingCases/array7Results.json")
 
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, arrayMappingRule2)
+      nestedTestCaseFactory.getTestCase(true, true, true, arrayMappingRule2)
 
     val inputDf2 = inputDf.withColumn("errCol", array(typedLit(ErrorMessage("Initial", "000", "ErrMsg", "id", Seq(), Seq()))))
 
@@ -411,7 +411,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
   test("Test broadcasting rule failure if key fields are in different arrays") {
     val expectedResults = getResourceString("/interpreter/mappingCases/arrayWrongJoinResults.json")
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      nestedTestCaseFactory.getTestCase(true, true, wrongMappingRule1)
+      nestedTestCaseFactory.getTestCase(true, true, true, wrongMappingRule1)
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"errCol")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleSuite.scala
@@ -38,7 +38,7 @@ class MappingRuleSuite extends AnyFunSuite with SparkTestBase with LoggerTestBas
 
   test("Test non-existent mapping table directory handling in a mapping rule") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      testCaseFactory.getTestCase(true, false, nonExistentTableMappingRule)
+      testCaseFactory.getTestCase(true, false, false, nonExistentTableMappingRule)
 
     val ex = intercept[AnalysisException] {
       DynamicInterpreter().interpret(dataset, inputDf).cache
@@ -49,7 +49,7 @@ class MappingRuleSuite extends AnyFunSuite with SparkTestBase with LoggerTestBas
 
   test("Test non-existent mapping table directory handling in an experimental mapping rule") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      testCaseFactory.getTestCase(false, false, nonExistentTableMappingRule)
+      testCaseFactory.getTestCase(false, false, false, nonExistentTableMappingRule)
 
     val ex = intercept[AnalysisException] {
       DynamicInterpreter().interpret(dataset, inputDf).cache
@@ -60,7 +60,7 @@ class MappingRuleSuite extends AnyFunSuite with SparkTestBase with LoggerTestBas
 
   test("Test empty mapping table error handling in a mapping rule") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      testCaseFactory.getTestCase(true, false, emptyTableMappingRule)
+      testCaseFactory.getTestCase(true, false, false, emptyTableMappingRule)
 
     val ex = intercept[RuntimeException] {
       DynamicInterpreter().interpret(dataset, inputDf).cache
@@ -71,7 +71,7 @@ class MappingRuleSuite extends AnyFunSuite with SparkTestBase with LoggerTestBas
 
   test("Test empty mapping table error handling in an experimental mapping rule") {
     implicit val (inputDf, dataset, dao, progArgs, featureSwitches) =
-      testCaseFactory.getTestCase(false, false, emptyTableMappingRule)
+      testCaseFactory.getTestCase(false, false, false, emptyTableMappingRule)
 
     val ex = intercept[RuntimeException] {
       DynamicInterpreter().interpret(dataset, inputDf).cache

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/testcasefactories/NestedTestCaseFactory.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/testcasefactories/NestedTestCaseFactory.scala
@@ -298,10 +298,12 @@ class NestedTestCaseFactory(implicit val spark: SparkSession) extends HadoopFsTe
     * @param experimentalMappingRule       If true, the experimental mapping rule will be used.
     * @param enableMappingRuleBroadcasting Specify if the broadcasting strategy will be used for the mapping rule.
     * @param conformanceRules              Zero or more conformance rules to be applied as the part of conformance.
+    * @param errColNullability             errCol nullability
     * @return A dataframe, a dataset, a Menas DAO, a Cmd Config and feature switches prepared to run conformance interpreter
     */
   def getTestCase(experimentalMappingRule: Boolean,
                   enableMappingRuleBroadcasting: Boolean,
+                  errColNullability: Boolean,
                   conformanceRules: ConformanceRule*): (DataFrame, Dataset, MenasDAO, ConformanceConfig, FeatureSwitches) = {
 
     val inputDf = spark.read
@@ -321,6 +323,7 @@ class NestedTestCaseFactory(implicit val spark: SparkSession) extends HadoopFsTe
       .setCatalystWorkaroundEnabled(true)
       .setControlFrameworkEnabled(false)
       .setBroadcastStrategyMode(if (enableMappingRuleBroadcasting) Always else Never)
+      .setErrColNullability(errColNullability)
 
     (inputDf, dataset, dao, cmdConfig, featureSwitches)
   }

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/testcasefactories/SimpleTestCaseFactory.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/testcasefactories/SimpleTestCaseFactory.scala
@@ -165,10 +165,12 @@ class SimpleTestCaseFactory(implicit val spark: SparkSession) extends HadoopFsTe
     * @param experimentalMappingRule       If true, the experimental mapping rule will be used.
     * @param conformanceRules              Zero or more conformance rules to be applied as the part of conformance.
     * @param enableMappingRuleBroadcasting Specify if the broadcasting strategy will be used for the mapping rule.
+    * @param errColNullability             errCol nullability
     * @return A dataframe, a dataset, a Menas DAO, a Cmd Config and feature switches prepared to run conformance interpreter
     */
   def getTestCase(experimentalMappingRule: Boolean,
                   enableMappingRuleBroadcasting: Boolean,
+                  errColNullability: Boolean,
                   conformanceRules: ConformanceRule*): (DataFrame, Dataset, MenasDAO, ConformanceConfig, FeatureSwitches) = {
     val inputDf = spark.read.schema(testCaseSchema).json(testCaseDataJson.toDS)
     val dataset = getDataSetWithConformanceRules(testCaseDataset, conformanceRules: _*)
@@ -191,6 +193,7 @@ class SimpleTestCaseFactory(implicit val spark: SparkSession) extends HadoopFsTe
       .setCatalystWorkaroundEnabled(true)
       .setControlFrameworkEnabled(false)
       .setBroadcastStrategyMode(if (enableMappingRuleBroadcasting) Always else Never)
+      .setErrColNullability(errColNullability)
 
     (inputDf, dataset, dao, cmdConfig, featureSwitches)
   }

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -59,47 +59,50 @@ class StandardizationInterpreterSuite  extends AnyFunSuite with SparkTestBase wi
 
     logDataFrameContent(src)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
-    logDataFrameContent(std)
+    Seq(true, false).foreach { errColNullability => // checking both nullability cases
+      val std = StandardizationInterpreter.standardize(src, desiredSchema, "", errorColNullability = errColNullability).cache()
+      logDataFrameContent(std)
 
-    val actualSchema = std.schema.treeString
-    val expectedSchema = "root\n" +
-      " |-- first_name: string (nullable = true)\n" +
-      " |-- last_name: string (nullable = true)\n" +
-      " |-- body_stats: struct (nullable = false)\n" +
-      " |    |-- height: integer (nullable = true)\n" +
-      " |    |-- weight: integer (nullable = true)\n" +
-      " |    |-- miscellaneous: struct (nullable = false)\n" +
-      " |    |    |-- eye_color: string (nullable = true)\n" +
-      " |    |    |-- glasses: boolean (nullable = true)\n" +
-      " |    |-- temperature_measurements: array (nullable = true)\n" +
-      " |    |    |-- element: double (containsNull = true)\n" +
-      " |-- errCol: array (nullable = true)\n" +
-      " |    |-- element: struct (containsNull = false)\n" +
-      " |    |    |-- errType: string (nullable = true)\n" +
-      " |    |    |-- errCode: string (nullable = true)\n" +
-      " |    |    |-- errMsg: string (nullable = true)\n" +
-      " |    |    |-- errCol: string (nullable = true)\n" +
-      " |    |    |-- rawValues: array (nullable = true)\n" +
-      " |    |    |    |-- element: string (containsNull = true)\n" +
-      " |    |    |-- mappings: array (nullable = true)\n" +
-      " |    |    |    |-- element: struct (containsNull = true)\n" +
-      " |    |    |    |    |-- mappingTableColumn: string (nullable = true)\n" +
-      " |    |    |    |    |-- mappedDatasetColumn: string (nullable = true)\n"
-    assert(actualSchema == expectedSchema)
+      val actualSchema = std.schema.treeString
+      val expectedSchema = "root\n" +
+        " |-- first_name: string (nullable = true)\n" +
+        " |-- last_name: string (nullable = true)\n" +
+        " |-- body_stats: struct (nullable = false)\n" +
+        " |    |-- height: integer (nullable = true)\n" +
+        " |    |-- weight: integer (nullable = true)\n" +
+        " |    |-- miscellaneous: struct (nullable = false)\n" +
+        " |    |    |-- eye_color: string (nullable = true)\n" +
+        " |    |    |-- glasses: boolean (nullable = true)\n" +
+        " |    |-- temperature_measurements: array (nullable = true)\n" +
+        " |    |    |-- element: double (containsNull = true)\n" +
+        s" |-- errCol: array (nullable = $errColNullability)\n" +
+        " |    |-- element: struct (containsNull = false)\n" +
+        " |    |    |-- errType: string (nullable = true)\n" +
+        " |    |    |-- errCode: string (nullable = true)\n" +
+        " |    |    |-- errMsg: string (nullable = true)\n" +
+        " |    |    |-- errCol: string (nullable = true)\n" +
+        " |    |    |-- rawValues: array (nullable = true)\n" +
+        " |    |    |    |-- element: string (containsNull = true)\n" +
+        " |    |    |-- mappings: array (nullable = true)\n" +
+        " |    |    |    |-- element: struct (containsNull = true)\n" +
+        " |    |    |    |    |-- mappingTableColumn: string (nullable = true)\n" +
+        " |    |    |    |    |-- mappedDatasetColumn: string (nullable = true)\n"
+      assert(actualSchema == expectedSchema)
 
-    val exp = Seq(
-      PatientRow("Jane", "Goodall", BodyStats(164, 61, "green", Option(true), Seq(36.6, 36.7, 37.0, 36.6))),
-      PatientRow("Scott", "Lang", BodyStats(0, 83, "blue", Option(false),Seq(36.6, 36.7, 37.0, 36.6)), Seq(
-        ErrorMessage.stdCastErr("body stats.height", "various")
-      )),
-      PatientRow("Aldrich", "Killian", BodyStats(181, 90, "brown or orange", None, Seq(36.7, 36.5, 38.0, 48.0, 152.0, 831.0, 0.0)), Seq(
-        ErrorMessage.stdCastErr("body stats.miscellaneous.glasses", "not any more"),
-        ErrorMessage.stdCastErr("body stats.temperature measurements[*]", "exploded")
-      ))
-    )
 
-    assertResult(exp)(std.as[PatientRow].collect().toList)
+      val exp = Seq(
+        PatientRow("Jane", "Goodall", BodyStats(164, 61, "green", Option(true), Seq(36.6, 36.7, 37.0, 36.6))),
+        PatientRow("Scott", "Lang", BodyStats(0, 83, "blue", Option(false),Seq(36.6, 36.7, 37.0, 36.6)), Seq(
+          ErrorMessage.stdCastErr("body stats.height", "various")
+        )),
+        PatientRow("Aldrich", "Killian", BodyStats(181, 90, "brown or orange", None, Seq(36.7, 36.5, 38.0, 48.0, 152.0, 831.0, 0.0)), Seq(
+          ErrorMessage.stdCastErr("body stats.miscellaneous.glasses", "not any more"),
+          ErrorMessage.stdCastErr("body stats.temperature measurements[*]", "exploded")
+        ))
+      )
+
+      assertResult(exp)(std.as[PatientRow].collect().toList)
+    }
   }
 }
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
@@ -56,13 +56,13 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
     val src = seq.toDF(fieldName)
     val desiredSchema = generateDesiredSchema(TimestampType)
 
-    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(
+    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(nullable = false,
       "root\n"+
       " |-- arrayField: array (nullable = true)\n" +
       " |    |-- element: timestamp (containsNull = true)"
     )
 
-    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "", errorColNullability = false).cache()
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
     val expectedData = Seq(
@@ -91,12 +91,12 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
     val src = seq.toDF(fieldName)
     val desiredSchema = generateDesiredSchema(TimestampType, s""""${MetadataKeys.Pattern}": "HH:mm:ss dd.MM.yyyy"""")
 
-    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(
+    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(nullable = true,
     "root\n"+
       " |-- arrayField: array (nullable = true)\n" +
       " |    |-- element: timestamp (containsNull = true)"
     )
-    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "", errorColNullability = true).cache()
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
     val expectedData = Seq(
@@ -137,13 +137,13 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
     val src = seq.toDF(fieldName)
     val desiredSchema = generateDesiredSchema(IntegerType, s""""${MetadataKeys.Pattern}": "Size: #;Size: -#"""")
 
-    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(
+    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(nullable = false,
       "root\n"+
         " |-- arrayField: array (nullable = true)\n" +
         " |    |-- element: integer (containsNull = true)"
     )
 
-    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "", errorColNullability = false).cache()
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
     val expectedData = Seq(
@@ -169,13 +169,13 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
     val src = seq.toDF(fieldName)
     val desiredSchema = generateDesiredSchema(FloatType, s""""${MetadataKeys.DefaultValue}": "3.14", "${MetadataKeys.MinusSign}": "~" """)
 
-    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(
+    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(nullable = false,
       "root\n"+
         " |-- arrayField: array (nullable = true)\n" +
         " |    |-- element: float (containsNull = true)"
     )
 
-    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "", errorColNullability = false).cache()
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
     val expectedData = Seq(
@@ -201,14 +201,14 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
     val subArrayJson = """{"type": "array", "elementType": "string", "containsNull": false}"""
     val desiredSchema = generateDesiredSchema(subArrayJson, s""""${MetadataKeys.DefaultValue}": "Nope"""")
 
-    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(
+    val expectedSchema = ErrorMessageFactory.attachErrColToSchemaPrint(nullable = true,
       "root\n"+
         " |-- arrayField: array (nullable = true)\n" +
         " |    |-- element: array (containsNull = true)\n" +
         " |    |    |-- element: string (containsNull = true)"
     )
 
-    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val stdDF = StandardizationInterpreter.standardize(src, desiredSchema, "", errorColNullability = true).cache()
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
     val expectedData = Seq(

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
@@ -185,7 +185,7 @@ object ExplodeTools {
           .groupBy(groupByColumns: _*)
           .agg(collect_list(deconstructedField).as(tmpColName),
             array_distinct(flatten(collect_list(col(errorCol)))).as(errorCol))
-          .setNullableStateOfColumn(errorCol, true) // explicitly nullable: expected schema outcome, see issue #1818
+          .withNullableColumnState(errorCol, true) // explicitly nullable: expected schema outcome, see issue #1818
     }
 
     // Restore null values to yet another temporary field

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.types.StructType
 import za.co.absa.spark.hats.Extensions._
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.schema.SchemaUtils._
+import za.co.absa.enceladus.utils.implicits.DataFrameImplicits._
 
 object ExplodeTools {
   // scalastyle:off null
@@ -178,10 +179,12 @@ object ExplodeTools {
       case Some(errorCol) =>
         // Implode taking into account the error column
         // Errors should be collected, flattened and made distinct
+        // decDf.schema: "errCol: array (nullable = true)", while the result would contain "errCol: array (nullable = true)" bc. collect_list
         decDf.orderBy(orderByRecordCol, orderByInsideArray)
           .groupBy(groupByColumns: _*)
           .agg(collect_list(deconstructedField).as(tmpColName),
             array_distinct(flatten(collect_list(col(errorCol)))).as(errorCol))
+          .setNullableStateOfColumn(errorCol, true) // explicitly nullable: expected schema outcome, see issue #1818
     }
 
     // Restore null values to yet another temporary field

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala
@@ -16,13 +16,13 @@
 package za.co.absa.enceladus.utils.explode
 
 import org.apache.log4j.LogManager
-import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
-import za.co.absa.spark.hats.Extensions._
+import org.apache.spark.sql.{Column, DataFrame}
+import za.co.absa.enceladus.utils.implicits.DataFrameImplicits._
 import za.co.absa.enceladus.utils.schema.SchemaUtils
 import za.co.absa.enceladus.utils.schema.SchemaUtils._
-import za.co.absa.enceladus.utils.implicits.DataFrameImplicits._
+import za.co.absa.spark.hats.Extensions._
 
 object ExplodeTools {
   // scalastyle:off null
@@ -179,7 +179,8 @@ object ExplodeTools {
       case Some(errorCol) =>
         // Implode taking into account the error column
         // Errors should be collected, flattened and made distinct
-        // decDf.schema: "errCol: array (nullable = true)", while the result would contain "errCol: array (nullable = true)" bc. collect_list
+        // decDf.schema: "errCol: array (nullable = true)", while the result would contain "errCol: array (nullable = false)"
+        // bc. collect_list. See issue #1818
         decDf.orderBy(orderByRecordCol, orderByInsideArray)
           .groupBy(groupByColumns: _*)
           .agg(collect_list(deconstructedField).as(tmpColName),

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
@@ -78,13 +78,18 @@ object DataFrameImplicits {
     def setNullableStateOfColumn(columnName: String, nullable: Boolean): DataFrame = {
       // Courtesy of https://stackoverflow.com/a/33195510
 
-      // modify [[StructField] with name `columnName`
+      // modify [[StructField] with name `columnName` if its nullability differs
       val newSchema = StructType(df.schema.map {
-        case StructField(c, t, _, m) if c.equals(columnName) => StructField(c, t, nullable = nullable, m)
+        case StructField(c, t, n, m) if c.equals(columnName) && n != nullable =>
+          StructField(c, t, nullable = nullable, m)
         case y: StructField => y
       })
-      // apply new schema
-      df.sqlContext.createDataFrame(df.rdd, newSchema)
+
+      if (newSchema == df.schema) {
+        df // no change
+      } else {
+        df.sqlContext.createDataFrame(df.rdd, newSchema) // apply new schema
+      }
     }
 
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicits.scala
@@ -75,7 +75,7 @@ object DataFrameImplicits {
      * @param columnName is the column name to change
      * @param nullable   boolean flag to set the nullability of the column `columnName` to
      */
-    def setNullableStateOfColumn(columnName: String, nullable: Boolean): DataFrame = {
+    def withNullableColumnState(columnName: String, nullable: Boolean): DataFrame = {
       // Courtesy of https://stackoverflow.com/a/33195510
 
       // modify [[StructField] with name `columnName` if its nullability differs

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/ExplosionSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/ExplosionSuite.scala
@@ -588,7 +588,7 @@ class ExplosionSuite extends AnyFunSuite with SparkTestBase with DatasetComparer
         | |    |    |    |-- action: string (nullable = true)
         | |    |    |    |-- check: string (nullable = true)
         | |    |-- legid: long (nullable = true)
-        | |-- errors: array (nullable = false)
+        | |-- errors: array (nullable = true)
         | |    |-- element: string (containsNull = true)
         |""".stripMargin.replace("\r\n", "\n")
     assertSchema(restoredDf.schema.treeString, expectedSchema)

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
@@ -172,7 +172,7 @@ class DataFrameImplicitsSuite extends AnyFunSuite with SparkTestBase with Matche
     val df1 = spark.createDataFrame(spark.sparkContext.parallelize(testData), originalSchema)
     assert(df1.schema == originalSchema, "Nullability changing tests - initialization failed")
 
-    test("changing nullability of a column") {
+    test("changing nullability of a column (true -> false, false -> true)") {
       val newSchema1 = df1.setNullableStateOfColumn("name", false).schema
       newSchema1.toSet should contain(StructField("name", StringType, nullable = false))
 
@@ -180,12 +180,17 @@ class DataFrameImplicitsSuite extends AnyFunSuite with SparkTestBase with Matche
       newSchema2.toSet should contain(StructField("name", StringType, nullable = true))
     }
 
-    test("changing nullability of a column - no-op (true)") {
+    test("changing nullability of an existing column - no-op (already true)") {
       val newSchema = df1.setNullableStateOfColumn("name", true).schema
       newSchema shouldBe originalSchema
     }
 
-    test("changing nullability of a column - no-op (false)") {
+    test("changing nullability of an existing column - no-op (already false)") {
+      val newSchema = df1.setNullableStateOfColumn("language", false).schema
+      newSchema shouldBe originalSchema
+    }
+
+    test("attempted changing nullability of a non-existing column - no-op") {
       val newSchema = df1.setNullableStateOfColumn("language", false).schema
       newSchema shouldBe originalSchema
     }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
@@ -15,11 +15,15 @@
 
 package za.co.absa.enceladus.utils.implicits
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import za.co.absa.enceladus.utils.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 
-class DataFrameImplicitsSuite extends AnyFunSuite with SparkTestBase  {
+class DataFrameImplicitsSuite extends AnyFunSuite with SparkTestBase with Matchers {
+
   import spark.implicits._
 
   private val columnName = "data"
@@ -85,7 +89,7 @@ class DataFrameImplicitsSuite extends AnyFunSuite with SparkTestBase  {
   private def inputDataToString(width: Int, leftAlign: Boolean, limit: Option[Int] = Option(20)): String = {
     val (extraLine, seq) = limit match {
       case Some(n) =>
-        val line =  if (inputDataSeq.length > n) {
+        val line = if (inputDataSeq.length > n) {
           s"only showing top $n rows\n"
         } else {
           ""
@@ -152,5 +156,38 @@ class DataFrameImplicitsSuite extends AnyFunSuite with SparkTestBase  {
     val expected = inputDataToString(cellWidth, leftAlign, Option(50))
 
     assert(result == expected)
+  }
+
+  { // nullability changing tests
+    val testData = Seq(
+      Row("James", "Java"),
+      Row("Michael", "Python")
+    )
+
+    val originalSchema = StructType(Seq(
+      StructField("name", StringType, nullable = true),
+      StructField("language", StringType, nullable = false)
+    ))
+
+    val df1 = spark.createDataFrame(spark.sparkContext.parallelize(testData), originalSchema)
+    assert(df1.schema == originalSchema, "Nullability changing tests - initialization failed")
+
+    test("changing nullability of a column") {
+      val newSchema1 = df1.setNullableStateOfColumn("name", false).schema
+      newSchema1.toSet should contain(StructField("name", StringType, nullable = false))
+
+      val newSchema2 = df1.setNullableStateOfColumn("language", true).schema
+      newSchema2.toSet should contain(StructField("name", StringType, nullable = true))
+    }
+
+    test("changing nullability of a column - no-op (true)") {
+      val newSchema = df1.setNullableStateOfColumn("name", true).schema
+      newSchema shouldBe originalSchema
+    }
+
+    test("changing nullability of a column - no-op (false)") {
+      val newSchema = df1.setNullableStateOfColumn("language", false).schema
+      newSchema shouldBe originalSchema
+    }
   }
 }

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
@@ -173,25 +173,25 @@ class DataFrameImplicitsSuite extends AnyFunSuite with SparkTestBase with Matche
     assert(df1.schema == originalSchema, "Nullability changing tests - initialization failed")
 
     test("changing nullability of a column (true -> false, false -> true)") {
-      val newSchema1 = df1.setNullableStateOfColumn("name", false).schema
+      val newSchema1 = df1.withNullableColumnState("name", false).schema
       newSchema1.toSet should contain(StructField("name", StringType, nullable = false))
 
-      val newSchema2 = df1.setNullableStateOfColumn("language", true).schema
+      val newSchema2 = df1.withNullableColumnState("language", true).schema
       newSchema2.toSet should contain(StructField("name", StringType, nullable = true))
     }
 
     test("changing nullability of an existing column - no-op (already true)") {
-      val newSchema = df1.setNullableStateOfColumn("name", true).schema
+      val newSchema = df1.withNullableColumnState("name", true).schema
       newSchema shouldBe originalSchema
     }
 
     test("changing nullability of an existing column - no-op (already false)") {
-      val newSchema = df1.setNullableStateOfColumn("language", false).schema
+      val newSchema = df1.withNullableColumnState("language", false).schema
       newSchema shouldBe originalSchema
     }
 
     test("attempted changing nullability of a non-existing column - no-op") {
-      val newSchema = df1.setNullableStateOfColumn("language", false).schema
+      val newSchema = df1.withNullableColumnState("language", false).schema
       newSchema shouldBe originalSchema
     }
   }


### PR DESCRIPTION
# The Problem 
The problem is at length described in https://github.com/AbsaOSS/enceladus/issues/1818, but to sum up:
When running conformance under Spark 3.1, the `errCol` is not nullable; while it is nullable under Spark 2.4

# The Cause
[utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala](https://github.com/AbsaOSS/enceladus/blob/cbc06ff3b329b6f5eb169b499a65b4d36f567ce4/utils/src/main/scala/za/co/absa/enceladus/utils/explode/ExplodeTools.scala#L184) calls 
```scala
        decDf.orderBy(orderByRecordCol, orderByInsideArray)
          .groupBy(groupByColumns: _*)
          .agg(collect_list(deconstructedField).as(tmpColName),
            array_distinct(flatten(collect_list(col(errorCol)))).as(errorCol))
```
On Spark 3, the `errCol` in `decDf` is nullable, while in the result of this operation, `errCol` is not nullable anymore. The underlying **root cause seems to be function `collect_list`**. **When operating on a nullable column, under Spark 2.4 the result remains nullable while under Spark 3.1 is changed to not-nullable**.

## Evidence
The following code demonstrates the difference when ran on Spark 2.4 and Spark 3.1:

```scala
// hint: use ":paste" command to paste all at-once in spark-shell

import org.apache.spark.sql.Row
import org.apache.spark.sql.types.{StringType, StructField, StructType}

val arrayStructData = Seq(
  Row("James", "Java"),
  Row("James", "Python"),
  Row("Michael", "Java"),
  Row("Washington", null)
)

val arrayStructSchema = StructType(Seq(
  StructField("name", StringType, nullable = true),
  StructField("language", StringType, nullable = true)
))

val df1 = spark.createDataFrame(spark.sparkContext.parallelize(arrayStructData), arrayStructSchema)
df1.show
df1.printSchema

val df2 = df1.groupBy("name").agg(collect_list("language").as("langs"))

df2.show
df2.printSchema
```

All output is the same except for the df2's schema, which differs: `langs: array (nullable = true)` for Spark 2 vs `langs: array (nullable = false)` for Spark3.1

### Spark 2 output
```
+----------+--------+
|      name|language|
+----------+--------+
|     James|    Java|
|     James|  Python|
|   Michael|    Java|
|Washington|    null|
+----------+--------+

root
 |-- name: string (nullable = true)
 |-- language: string (nullable = true)

+----------+--------------+
|      name|         langs|
+----------+--------------+
|     James|[Java, Python]|
|Washington|            []|
|   Michael|        [Java]|
+----------+--------------+

root
 |-- name: string (nullable = true)
 |-- langs: array (nullable = true)
 |    |-- element: string (containsNull = true)
``` 
### Spark 3 output
```
+----------+--------+
|      name|language|
+----------+--------+
|     James|    Java|
|     James|  Python|
|   Michael|    Java|
|Washington|    null|
+----------+--------+

root
 |-- name: string (nullable = true)
 |-- language: string (nullable = true)

+----------+--------------+
|      name|         langs|
+----------+--------------+
|     James|[Java, Python]|
|Washington|            []|
|   Michael|        [Java]|
+----------+--------------+

root
 |-- name: string (nullable = true)
 |-- langs: array (nullable = false)
 |    |-- element: string (containsNull = false)
``` 

## Conclusion
The change in Spark 3 is logically correct because the result of `array_collect` is guaranteed to be non-null, hence the observed nullability change.
Albeit a reasonable logic, this change can cause migration issues where the resulting schema change is significant.



# Fixing the issue
  - errCol nullablity (on the dataframe level) in conformance and standardization is now driven by config value `enceladus.errCol.nullable` (default: true = original Eneceladus 2.x behavior) 
    - but **beware, that parquet, when read by spark, will contain all columns nullable** (see the [doc](https://spark.apache.org/docs/3.1.2/sql-data-sources-parquet.html)) 
  - tests updated: normalizeErrColNullability removed
 - added DataFrameImplicits.setNullableStateOfColumn + unitTests

Closes #1818.