### PR TITLE
#1808SparkVersionGuard: For Spark 3, min version = 3.0.0

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/SparkCompatibility.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/SparkCompatibility.scala
@@ -26,6 +26,6 @@ import za.co.absa.commons.version.Version._
 import za.co.absa.commons.version.impl.SemVer20Impl.SemanticVersion
 
 object SparkCompatibility {
-  val minSparkVersionIncluded: SemanticVersion = semver"2.4.2"
+  val minSparkVersionIncluded: SemanticVersion = semver"3.1.2"
   val maxSparkVersionExcluded: Option[SemanticVersion] = Some(semver"3.2.0")
 }


### PR DESCRIPTION
SparkVersionGuard: For Spark 3, the min version has been set to 3.0.0

Closes #1808.