### PR TITLE
#1836: Standardization ignores timezone metadata for timestamp type in case the source is already timestamp (2.21)

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -545,11 +545,7 @@ object TypeParser {
                                       failOnInputNotPerSchema: Boolean,
                                       isArrayElement: Boolean)
                                      (implicit defaults: Defaults) extends DateTimeParser[Date] {
-    private val defaultTimeZone: Option[String] = if (pattern.isTimeZoned) {
-      pattern.defaultTimeZone
-    } else {
-      defaults.getDefaultDateTimeZone
-    }
+    private val defaultTimeZone: Option[String] = field.defaultTimeZone.map(Option(_)).getOrElse(defaults.getDefaultDateTimeZone)
 
     private def applyPatternToStringColumn(column: Column, pattern: String): Column = {
       defaultTimeZone.map(tz =>
@@ -601,11 +597,7 @@ object TypeParser {
                                            isArrayElement: Boolean)
                                           (implicit defaults: Defaults) extends DateTimeParser[Timestamp] {
 
-    private val defaultTimeZone: Option[String] = if (pattern.isTimeZoned) {
-      pattern.defaultTimeZone
-    } else {
-      defaults.getDefaultTimestampTimeZone
-    }
+    private val defaultTimeZone: Option[String] = field.defaultTimeZone.map(Option(_)).getOrElse(defaults.getDefaultTimestampTimeZone)
 
     private def applyPatternToStringColumn(column: Column, pattern: String): Column = {
       val interim: Column = to_timestamp(column, pattern)

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -399,6 +399,10 @@ object TypedStructField {
       }
     }
 
+    def defaultTimeZone: Option[String] = {
+      getMetadataString(MetadataKeys.DefaultTimeZone)
+    }
+
     override def validate(): Seq[ValidationIssue] = {
       validator.validate(this)
     }


### PR DESCRIPTION
* Timezone in metadata is taken into account even if the source is already timestamp or date

