### PR TITLE
#1836: Standardization ignores timezone metadata for timestamp type in case the source is already timestamp

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParser.scala
@@ -545,11 +545,7 @@ object TypeParser {
                                       failOnInputNotPerSchema: Boolean,
                                       isArrayElement: Boolean)
                                      (implicit defaults: Defaults) extends DateTimeParser[Date] {
-    private val defaultTimeZone: Option[String] = if (pattern.isTimeZoned) {
-      pattern.defaultTimeZone
-    } else {
-      defaults.getDefaultDateTimeZone
-    }
+    private val defaultTimeZone: Option[String] = field.defaultTimeZone.map(Option(_)).getOrElse(defaults.getDefaultDateTimeZone)
 
     private def applyPatternToStringColumn(column: Column, pattern: String): Column = {
       defaultTimeZone.map(tz =>
@@ -601,11 +597,7 @@ object TypeParser {
                                            isArrayElement: Boolean)
                                           (implicit defaults: Defaults) extends DateTimeParser[Timestamp] {
 
-    private val defaultTimeZone: Option[String] = if (pattern.isTimeZoned) {
-      pattern.defaultTimeZone
-    } else {
-      defaults.getDefaultTimestampTimeZone
-    }
+    private val defaultTimeZone: Option[String] = field.defaultTimeZone.map(Option(_)).getOrElse(defaults.getDefaultTimestampTimeZone)
 
     private def applyPatternToStringColumn(column: Column, pattern: String): Column = {
       val interim: Column = to_timestamp(column, pattern)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
@@ -443,18 +443,24 @@ class StandardizationParquetSuite extends FixtureAnyFunSuite with SparkTestBase 
       " --report-version 1 --menas-auth-keytab src/test/resources/user.keytab.example " +
       "--raw-format parquet").split(" ")
 
+
+    /* This might seem confusing for a quick observer. The reason why this is the correct result:
+       the source data has two timestamps 12:00:00AM and 23:00:00PM *without* time zone.
+       The metadata then signal the timestamp are to be considered in CET time zone. The data are ingested with that
+       time zone and adjusted to system time zone - UTC. Therefore they are seemingly shifted by one hour. */
     val expected =
-      """+-------------------+------+
-        ||ts                 |errCol|
-        |+-------------------+------+
-        ||1969-12-31 23:00:00|[]    |
-        ||1969-12-31 22:00:00|[]    |
-        |+-------------------+------+
+      """+---+-------------------+------+
+        ||id |ts                 |errCol|
+        |+---+-------------------+------+
+        ||1  |1969-12-31 23:00:00|[]    |
+        ||2  |1969-12-31 22:00:00|[]    |
+        |+---+-------------------+------+
         |
         |""".stripMargin.replace("\r\n", "\n")
 
     val (cmd, sourceDF) = getTestDataFrame(tmpFileName, args)
     val seq = Seq(
+      StructField("id", LongType, nullable = false),
       StructField("ts", TimestampType, nullable = false, new MetadataBuilder().putString(MetadataKeys.DefaultTimeZone, "CET").build())
     )
     val schema = StructType(seq)

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -399,6 +399,10 @@ object TypedStructField {
       }
     }
 
+    def defaultTimeZone: Option[String] = {
+      getMetadataString(MetadataKeys.DefaultTimeZone)
+    }
+
     override def validate(): Seq[ValidationIssue] = {
       validator.validate(this)
     }


### PR DESCRIPTION
* Timezone in metadata is taken into account even if the source is already timestamp or date


Release note:
Time zone in metadata is taken into account even if the source data is already of timestamp type.