### PR TITLE
1842 Dataset Dialog - properties editing update

### DIFF
--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -28,7 +28,7 @@
                         <Input id="newDatasetDescription" type="Text" placeholder="Description" width="100%"
                                value="{entity>/description}"/>
                         <Label text="Dataset Properties"/>
-                        <List width="100%" items="{path: 'entity>/_properties', sorter: {path: 'order'}}" class="sapUiMediumMarginBottom">
+                        <List width="100%" items="{path: 'entity>/_properties', sorter: {path: 'order'}}" class="sapUiMediumMarginBottom dsProps">
                             <InputListItem class="inputListItemSmallLabel" label="{entity>name}"
                                            tooltip="{= ${entity>description} ? ${entity>name} + ': ' + ${entity>description} : ${entity>name} }">
                                 <HBox alignItems="Center" justifyContent="End" renderType="Bare">

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -16,7 +16,7 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:form="sap.ui.layout.form"
                          xmlns:hdfs="components.hdfs">
     <Dialog id="addDatasetDialog" title="{entity>/title} Dataset" stretchOnPhone="true" resizable="true"
-            draggable="true" contentWidth="55em">
+            draggable="true" contentWidth="573px">
         <content>
             <VBox class="sapUiSmallMargin">
                 <form:SimpleForm adjustLabelSpan="false" editable="true">

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -15,10 +15,11 @@
 
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:form="sap.ui.layout.form"
                          xmlns:hdfs="components.hdfs">
-    <Dialog id="addDatasetDialog" title="{entity>/title} Dataset" stretchOnPhone="true" class="minW55rem maxW65p w50p">
+    <Dialog id="addDatasetDialog" title="{entity>/title} Dataset" stretchOnPhone="true" resizable="true"
+            draggable="true" contentWidth="55em">
         <content>
             <VBox class="sapUiSmallMargin">
-                <form:SimpleForm adjustLabelSpan="true" editable="true">
+                <form:SimpleForm adjustLabelSpan="false" editable="true">
                     <form:content>
                         <Label text="Dataset Name"/>
                         <Input id="newDatasetName" enabled="{path:'entity>/isEdit', formatter:'Formatters.not'}"
@@ -28,22 +29,26 @@
                                value="{entity>/description}"/>
                         <Label text="Dataset Properties"/>
                         <List width="100%" items="{path: 'entity>/_properties', sorter: {path: 'order'}}" class="sapUiMediumMarginBottom">
-                          <InputListItem class="inputListItemSmallLabel" label="{entity>name}"
-                              tooltip="{= ${entity>description} ? ${entity>name} + ': ' + ${entity>description} : ${entity>name} }">
-                            <HBox alignItems="Center" justifyContent="End" renderType="Bare">
-                              <Input type="Text" width="16rem" visible="{= ${entity>propertyType/_t} === 'StringPropertyType'}"
-                                class="propertyInput" value="{entity>value}" placeholder="{entity>suggestedValue}" valueState="{entity>validation}"
-                                valueStateText="{entity>validationText}"></Input>
-                              <Select width="16rem"
-                                items="{path: 'entity>allowedValues', templateShareable: false}"
-                                selectedKey="{entity>value}" valueState="{entity>validation}" valueStateText="{entity>validationText}"
-                                visible="{= ${entity>propertyType/_t} === 'EnumPropertyType'}" forceSelection="false">
-                                <core:Item key="{entity>value}" text="{entity>text}"></core:Item>
-                              </Select>
-                              <core:Icon width="1rem" class="sapUiSmallMarginBegin" color="Neutral" tooltip="{entity>essentiality/_t}"
-                                src="{= ${entity>essentiality/_t} === 'Mandatory' ? 'sap-icon://alert' : (${entity>essentiality/_t} === 'Recommended' ? 'sap-icon://warning' : 'sap-icon://accept') }"></core:Icon>
-                            </HBox>
-                          </InputListItem>
+                            <InputListItem class="inputListItemSmallLabel" label="{entity>name}"
+                                           tooltip="{= ${entity>description} ? ${entity>name} + ': ' + ${entity>description} : ${entity>name} }">
+                                <HBox alignItems="Center" justifyContent="End" renderType="Bare">
+                                    <Input type="Text" visible="{= ${entity>propertyType/_t} === 'StringPropertyType'}"
+                                           class="propertyInput" value="{entity>value}"
+                                           placeholder="{entity>suggestedValue}" valueState="{entity>validation}"
+                                           valueStateText="{entity>validationText}"></Input>
+                                    <Select class="propertyInput"
+                                            items="{path: 'entity>allowedValues', templateShareable: false}"
+                                            selectedKey="{entity>value}" valueState="{entity>validation}"
+                                            valueStateText="{entity>validationText}"
+                                            visible="{= ${entity>propertyType/_t} === 'EnumPropertyType'}"
+                                            forceSelection="false">
+                                        <core:Item key="{entity>value}" text="{entity>text}"></core:Item>
+                                    </Select>
+                                    <core:Icon width="1rem" class="sapUiSmallMarginBegin" color="Neutral"
+                                               tooltip="{entity>essentiality/_t}"
+                                               src="{= ${entity>essentiality/_t} === 'Mandatory' ? 'sap-icon://alert' : (${entity>essentiality/_t} === 'Recommended' ? 'sap-icon://warning' : 'sap-icon://accept') }"></core:Icon>
+                                </HBox>
+                            </InputListItem>
                         </List>
                         <core:Fragment type="XML" fragmentName="components.schema.selector.schemaSelector"/>
                         <Label text="Raw data folder path"/>
@@ -70,7 +75,7 @@
                                               busyControl="addDatasetDialog" pathInput="selectedRawHDFSPathLabel"
                                               HDFSPath="{entity>/hdfsPath}" visible="{entity>/hdfsBrowserEnabled}"/>
                         </VBox>
-                        <Label text="Conformed data publish folder path"/>
+                        <Label text="Conformed publish folder path"/>
                         <VBox>
                             <!-- HDFS Browser and its label -->
                             <Input type="Text" id="selectedPublishHDFSPathLabel"

--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -28,12 +28,13 @@
                                value="{entity>/description}"/>
                         <Label text="Dataset Properties"/>
                         <List width="100%" items="{path: 'entity>/_properties', sorter: {path: 'order'}}" class="sapUiMediumMarginBottom">
-                          <InputListItem class="inputListItemSmallLabel" label="{entity>name}" tooltip="{entity>description}">
+                          <InputListItem class="inputListItemSmallLabel" label="{entity>name}"
+                              tooltip="{= ${entity>description} ? ${entity>name} + ': ' + ${entity>description} : ${entity>name} }">
                             <HBox alignItems="Center" justifyContent="End" renderType="Bare">
-                              <Input type="Text" width="18rem" visible="{= ${entity>propertyType/_t} === 'StringPropertyType'}"
+                              <Input type="Text" width="16rem" visible="{= ${entity>propertyType/_t} === 'StringPropertyType'}"
                                 class="propertyInput" value="{entity>value}" placeholder="{entity>suggestedValue}" valueState="{entity>validation}"
                                 valueStateText="{entity>validationText}"></Input>
-                                  <Select width="18rem"
+                              <Select width="16rem"
                                 items="{path: 'entity>allowedValues', templateShareable: false}"
                                 selectedKey="{entity>value}" valueState="{entity>validation}" valueStateText="{entity>validationText}"
                                 visible="{= ${entity>propertyType/_t} === 'EnumPropertyType'}" forceSelection="false">

--- a/menas/ui/css/style.css
+++ b/menas/ui/css/style.css
@@ -22,20 +22,13 @@ html, body {
   height: calc(100% - 112px);
 }
 
-.minW55rem {
-  min-width: 55rem !important;
-}
-
-.maxW65p {
-  max-width: 65% !important;
-}
-
 .w100p {
   width: 100%;
 }
 
-.w50p {
-  width: 50%;
+.propertyInput {
+  /*overriding default to have all fields of the same length */
+  width: 14rem !important;
 }
 
 .mt10 {

--- a/menas/ui/css/style.css
+++ b/menas/ui/css/style.css
@@ -121,3 +121,9 @@ h5[id$=datasetDetailView--scheduleTimingTitle] {
 .formWithSmallContainerMargins > div > div > div > div {
   padding-bottom: 0.9rem !important;
 }
+
+.dsProps {
+  border: 1px solid #bfbfbf;
+  padding: 8px 2px;
+  margin-top: 4px;
+}


### PR DESCRIPTION
As outlined in #1842, a longer dataset property name may have previously been cut off and the user was unable to reach the whole string.

## Solution
The dialog has undergone several changes to address the problem at hand, namely:
 - width of the value field has been slightly decreased (the values from the selection will be fully visible when opened if smaller)
 - default width of the dialog has been set to 55em (sufficient in testing), but mainly, the dialog has been made stretchable -- so if the user wants to enlarge the dialog to have more space, they can
 - more sensible tooltip has been provided - revealing the full property name string and optionally the description if available -- thus, the user can read a very long property name this way, too, if ellipsized

(I have also attempted to diminish the blank space at the label's side, but I was unsuccessful in this regard 
- with the current `ResponsiveLayout`, it can be done using `layoutData.ResponsiveFlowLayoutData.weight, but then the labels are not aligned. 
- with `ResponsiveGridLayout`, it can be done as well quite nicely with `labelSpanM` settings, but the solution on the other hand warns to clash on sync/async calls in the console. Esthetically, this solution would look the best if no issues were involved.

## Showcase
Showing a resizable dialog with enhanced hints on the DS properties:
![ds-props-resized-hints-resizable](https://user-images.githubusercontent.com/4457378/124941390-0a7a9580-e00b-11eb-868f-84b52e5e9049.png)
Smaller width version (when resized) is also fully usable:
![ds-props-smaller-display](https://user-images.githubusercontent.com/4457378/124941478-1b2b0b80-e00b-11eb-912f-8d2af5336616.png)

## Release notes suggestion
Dataset properties editing UX has been enhanced - now, there is more room for the property name, a useful tooltip is provided and the dialog is resizable.
