### PR TITLE
1842 Dataset Dialog - properties editing update

### DIFF
--- a/menas/ui/components/dataset/addDataset.fragment.xml
+++ b/menas/ui/components/dataset/addDataset.fragment.xml
@@ -15,10 +15,11 @@
 
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:form="sap.ui.layout.form"
                          xmlns:hdfs="components.hdfs">
-    <Dialog id="addDatasetDialog" title="{entity>/title} Dataset" stretchOnPhone="true" class="minW55rem maxW65p w50p">
+    <Dialog id="addDatasetDialog" title="{entity>/title} Dataset" stretchOnPhone="true" resizable="true"
+            draggable="true" contentWidth="573px">
         <content>
             <VBox class="sapUiSmallMargin">
-                <form:SimpleForm adjustLabelSpan="true" editable="true">
+                <form:SimpleForm adjustLabelSpan="false" editable="true">
                     <form:content>
                         <Label text="Dataset Name"/>
                         <Input id="newDatasetName" enabled="{path:'entity>/isEdit', formatter:'Formatters.not'}"
@@ -27,22 +28,27 @@
                         <Input id="newDatasetDescription" type="Text" placeholder="Description" width="100%"
                                value="{entity>/description}"/>
                         <Label text="Dataset Properties"/>
-                        <List width="100%" items="{path: 'entity>/_properties', sorter: {path: 'order'}}" class="sapUiMediumMarginBottom">
-                          <InputListItem class="inputListItemSmallLabel" label="{entity>name}" tooltip="{entity>description}">
-                            <HBox alignItems="Center" justifyContent="End" renderType="Bare">
-                              <Input type="Text" width="18rem" visible="{= ${entity>propertyType/_t} === 'StringPropertyType'}"
-                                class="propertyInput" value="{entity>value}" placeholder="{entity>suggestedValue}" valueState="{entity>validation}"
-                                valueStateText="{entity>validationText}"></Input>
-                                  <Select width="18rem"
-                                items="{path: 'entity>allowedValues', templateShareable: false}"
-                                selectedKey="{entity>value}" valueState="{entity>validation}" valueStateText="{entity>validationText}"
-                                visible="{= ${entity>propertyType/_t} === 'EnumPropertyType'}" forceSelection="false">
-                                <core:Item key="{entity>value}" text="{entity>text}"></core:Item>
-                              </Select>
-                              <core:Icon width="1rem" class="sapUiSmallMarginBegin" color="Neutral" tooltip="{entity>essentiality/_t}"
-                                src="{= ${entity>essentiality/_t} === 'Mandatory' ? 'sap-icon://alert' : (${entity>essentiality/_t} === 'Recommended' ? 'sap-icon://warning' : 'sap-icon://accept') }"></core:Icon>
-                            </HBox>
-                          </InputListItem>
+                        <List width="100%" items="{path: 'entity>/_properties', sorter: {path: 'order'}}" class="sapUiMediumMarginBottom dsProps">
+                            <InputListItem class="inputListItemSmallLabel" label="{entity>name}"
+                                           tooltip="{= ${entity>description} ? ${entity>name} + ': ' + ${entity>description} : ${entity>name} }">
+                                <HBox alignItems="Center" justifyContent="End" renderType="Bare">
+                                    <Input type="Text" visible="{= ${entity>propertyType/_t} === 'StringPropertyType'}"
+                                           class="propertyInput" value="{entity>value}"
+                                           placeholder="{entity>suggestedValue}" valueState="{entity>validation}"
+                                           valueStateText="{entity>validationText}"></Input>
+                                    <Select class="propertyInput"
+                                            items="{path: 'entity>allowedValues', templateShareable: false}"
+                                            selectedKey="{entity>value}" valueState="{entity>validation}"
+                                            valueStateText="{entity>validationText}"
+                                            visible="{= ${entity>propertyType/_t} === 'EnumPropertyType'}"
+                                            forceSelection="false">
+                                        <core:Item key="{entity>value}" text="{entity>text}"></core:Item>
+                                    </Select>
+                                    <core:Icon width="1rem" class="sapUiSmallMarginBegin" color="Neutral"
+                                               tooltip="{entity>essentiality/_t}"
+                                               src="{= ${entity>essentiality/_t} === 'Mandatory' ? 'sap-icon://alert' : (${entity>essentiality/_t} === 'Recommended' ? 'sap-icon://warning' : 'sap-icon://accept') }"></core:Icon>
+                                </HBox>
+                            </InputListItem>
                         </List>
                         <core:Fragment type="XML" fragmentName="components.schema.selector.schemaSelector"/>
                         <Label text="Raw data folder path"/>
@@ -69,7 +75,7 @@
                                               busyControl="addDatasetDialog" pathInput="selectedRawHDFSPathLabel"
                                               HDFSPath="{entity>/hdfsPath}" visible="{entity>/hdfsBrowserEnabled}"/>
                         </VBox>
-                        <Label text="Conformed data publish folder path"/>
+                        <Label text="Conformed publish folder path"/>
                         <VBox>
                             <!-- HDFS Browser and its label -->
                             <Input type="Text" id="selectedPublishHDFSPathLabel"

--- a/menas/ui/css/style.css
+++ b/menas/ui/css/style.css
@@ -22,20 +22,13 @@ html, body {
   height: calc(100% - 112px);
 }
 
-.minW55rem {
-  min-width: 55rem !important;
-}
-
-.maxW65p {
-  max-width: 65% !important;
-}
-
 .w100p {
   width: 100%;
 }
 
-.w50p {
-  width: 50%;
+.propertyInput {
+  /*overriding default to have all fields of the same length */
+  width: 14rem !important;
 }
 
 .mt10 {
@@ -127,4 +120,10 @@ h5[id$=datasetDetailView--scheduleTimingTitle] {
 
 .formWithSmallContainerMargins > div > div > div > div {
   padding-bottom: 0.9rem !important;
+}
+
+.dsProps {
+  border: 1px solid #bfbfbf;
+  padding: 8px 2px;
+  margin-top: 4px;
 }


### PR DESCRIPTION
_This is the same as https://github.com/AbsaOSS/enceladus/pull/1845 for Enceladus develop_

- as stated in https://github.com/AbsaOSS/enceladus/pull/1845, Dataset edit dialog has been updated:
  - layout tweaked, resizable (default: Small), enhanced tooltips, properties border 

![DsEditsmallSizeDefault2withToolTip](https://user-images.githubusercontent.com/4457378/125758454-125d13d3-7502-441a-a0f9-a06375374409.png)

## Test-run
I have test-ran it on local Menas and noticed no change from the original in #1845.

Relates to #1842.