### PR TITLE
#1853: Remove the warning of wrong browser type and version in Menas

### DIFF
--- a/menas/ui/components/login/loginDetail.controller.js
+++ b/menas/ui/components/login/loginDetail.controller.js
@@ -73,8 +73,16 @@ sap.ui.define([
     },
 
     onAfterRendering: function() {
-      if(!sap.ui.Device.browser.chrome || (sap.ui.Device.browser.chrome && sap.ui.Device.browser.version < 68)) {
-        sap.m.MessageBox.warning("Chrome (version 68 and higher) is currently the only supported browser for menas");
+      if (sap.ui.Device.browser.chrome && sap.ui.Device.browser.version < 68) {
+        sap.m.MessageBox.warning("Chrome browser version lower then 68 is known of having issue displaying the Menas application");
+      } else if (sap.ui.Device.browser.firefox && sap.ui.Device.browser.version < 78) {
+        sap.m.MessageBox.warning("Firefox browser version lower then 78 is known of having issue displaying the Menas application");
+      } else if (sap.ui.Device.browser.edge && sap.ui.Device.browser.version < 79) {
+        sap.m.MessageBox.warning("Edge browser version lower then 79 is known of having issue displaying the Menas application");
+      } else if (sap.ui.Device.browser.safari && sap.ui.Device.browser.version < 12) {
+        sap.m.MessageBox.warning("Safari browser version lower then 12 is known of having issue displaying the Menas application");
+      } else if (!sap.ui.Device.browser.chrome && !sap.ui.Device.browser.firefox && !sap.ui.Device.browser.edge && !sap.ui.Device.browser.safari) {
+        sap.m.MessageBox.warning("Your browser is not known if it to works wih Menas application");
       }
     },
 

--- a/menas/ui/components/login/loginDetail.controller.js
+++ b/menas/ui/components/login/loginDetail.controller.js
@@ -74,13 +74,13 @@ sap.ui.define([
 
     onAfterRendering: function() {
       if (sap.ui.Device.browser.chrome && sap.ui.Device.browser.version < 68) {
-        sap.m.MessageBox.warning("Chrome browser version lower then 68 is known of having issue displaying the Menas application");
+        sap.m.MessageBox.warning("Chrome browser version lower than 68 is known of having issue displaying the Menas application");
       } else if (sap.ui.Device.browser.firefox && sap.ui.Device.browser.version < 78) {
-        sap.m.MessageBox.warning("Firefox browser version lower then 78 is known of having issue displaying the Menas application");
+        sap.m.MessageBox.warning("Firefox browser version lower than 78 is known of having issue displaying the Menas application");
       } else if (sap.ui.Device.browser.edge && sap.ui.Device.browser.version < 79) {
-        sap.m.MessageBox.warning("Edge browser version lower then 79 is known of having issue displaying the Menas application");
+        sap.m.MessageBox.warning("Edge browser version lower than 79 is known of having issue displaying the Menas application");
       } else if (sap.ui.Device.browser.safari && sap.ui.Device.browser.version < 12) {
-        sap.m.MessageBox.warning("Safari browser version lower then 12 is known of having issue displaying the Menas application");
+        sap.m.MessageBox.warning("Safari browser version lower than 12 is known of having issue displaying the Menas application");
       } else if (!sap.ui.Device.browser.chrome && !sap.ui.Device.browser.firefox && !sap.ui.Device.browser.edge && !sap.ui.Device.browser.safari) {
         sap.m.MessageBox.warning("Your browser is not known if it to works wih Menas application");
       }


### PR DESCRIPTION
Just a simple removal of a dialog popping up, if conditions are met on Menas opening.


_Release notes suggestion:_
Warning of non-Chrome browsers reworked and reworded. Multiple other browsers should work now without warning: Firefox 78+, Edge 79+, Safari 12+.