### PR TITLE
Feature/1603 mapping table filtering general

### DIFF
--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/JsonSerializerSuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/JsonSerializerSuite.scala
@@ -159,8 +159,21 @@ class JsonSerializerSuite extends BaseTestSuite with VersionedModelMatchers {
         |      "overrideMappingTableOwnFilter": true
         |    },
         |    {
+        |      "_t": "MappingConformanceRule",
+        |      "order": 2,"controlCheckpoint": true,
+        |      "mappingTable": "CurrencyMappingTable2",
+        |      "mappingTableVersion": 10,
+        |      "attributeMappings": {},
+        |      "targetAttribute": "CCC",
+        |      "outputColumn": "ConformedCCC",
+        |      "additionalColumns": null,
+        |      "isNullSafe": false,
+        |      "mappingTableFilter": null,
+        |      "overrideMappingTableOwnFilter": false
+        |    },
+        |    {
         |      "_t": "LiteralConformanceRule",
-        |      "order": 2,
+        |      "order": 3,
         |      "outputColumn": "ConformedLiteral",
         |      "controlCheckpoint": false,
         |      "value": "AAA"
@@ -233,7 +246,15 @@ class JsonSerializerSuite extends BaseTestSuite with VersionedModelMatchers {
             ),
             overrideMappingTableOwnFilter = Some(true)
           ),
-          LiteralConformanceRule(2,
+          MappingConformanceRule(2,
+            controlCheckpoint = true,
+            mappingTable = "CurrencyMappingTable2",
+            mappingTableVersion = 10, //scalastyle:ignore magic.number
+            attributeMappings = Map(),
+            targetAttribute = "CCC",
+            outputColumn = "ConformedCCC"
+          ),
+          LiteralConformanceRule(3,
             outputColumn = "ConformedLiteral",
             controlCheckpoint = false,
             value = "AAA"

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/test/factories/MappingTableFactory.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/test/factories/MappingTableFactory.scala
@@ -17,6 +17,7 @@ package za.co.absa.enceladus.model.test.factories
 
 import java.time.ZonedDateTime
 
+import za.co.absa.enceladus.model.dataFrameFilter.DataFrameFilter
 import za.co.absa.enceladus.model.menas.MenasReference
 import za.co.absa.enceladus.model.{DefaultValue, MappingTable, Schema}
 
@@ -38,7 +39,8 @@ object MappingTableFactory extends EntityFactory[Schema] {
                            disabled: Boolean = false,
                            dateDisabled: Option[ZonedDateTime] = None,
                            userDisabled: Option[String] = None,
-                           parent: Option[MenasReference] = None): MappingTable = {
+                           parent: Option[MenasReference] = None,
+                           filter: Option[DataFrameFilter] = None): MappingTable = {
 
     MappingTable(name,
       version,
@@ -54,7 +56,9 @@ object MappingTableFactory extends EntityFactory[Schema] {
       disabled,
       dateDisabled,
       userDisabled,
-      parent)
+      parent,
+      filter
+    )
   }
 
   def getDummyDefaultValue(columnName: String = "dummyColumnName",

--- a/menas/src/main/scala/za/co/absa/enceladus/menas/utils/implicits/package.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/utils/implicits/package.scala
@@ -32,13 +32,14 @@ import za.co.absa.enceladus.model.menas.scheduler._
 import za.co.absa.enceladus.model.menas.scheduler.dataFormats._
 import za.co.absa.enceladus.model.menas.scheduler.oozie._
 import za.co.absa.enceladus.menas.models._
+import za.co.absa.enceladus.model.dataFrameFilter._
 import za.co.absa.enceladus.model.properties.PropertyDefinition
 import za.co.absa.enceladus.model.properties.essentiality.Essentiality
 import za.co.absa.enceladus.model.properties.propertyType.PropertyType
 import za.co.absa.enceladus.model.user._
 import za.co.absa.enceladus.model.versionedModel._
-import scala.collection.immutable
 
+import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.collection.JavaConverters
 import scala.concurrent.Future
@@ -61,9 +62,9 @@ package object implicits {
     classOf[RuntimeConfig], classOf[OozieSchedule], classOf[OozieScheduleInstance], classOf[ScheduleTiming], classOf[DataFormat],
     classOf[UserInfo], classOf[VersionedSummary], classOf[MenasAttachment], classOf[MenasReference],
     classOf[PropertyDefinition], classOf[PropertyType], classOf[Essentiality],
-    classOf[LandingPageInformation], classOf[TodaysRunsStatistics]
-  ),
-    CodecRegistries.fromCodecs(new ZonedDateTimeAsDocumentCodec()), DEFAULT_CODEC_REGISTRY)
+    classOf[LandingPageInformation], classOf[TodaysRunsStatistics],
+    classOf[DataFrameFilter]
+  ), CodecRegistries.fromCodecs(new ZonedDateTimeAsDocumentCodec()), DEFAULT_CODEC_REGISTRY)
 
   def javaMapToScalaMap[K, V](javaMap: java.util.Map[K, V]): immutable.Map[K, V] = {
     // in Scala 2.12, we could just do javaMap.asScala.toMap // https://stackoverflow.com/a/64614317/1773349

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/DatasetApiIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/DatasetApiIntegrationSuite.scala
@@ -22,12 +22,14 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import za.co.absa.enceladus.menas.integration.fixtures._
+import za.co.absa.enceladus.model.conformanceRule.MappingConformanceRule
+import za.co.absa.enceladus.model.dataFrameFilter._
 import za.co.absa.enceladus.model.{Dataset, Validation}
 import za.co.absa.enceladus.model.properties.PropertyDefinition
 import za.co.absa.enceladus.model.properties.essentiality.Essentiality
 import za.co.absa.enceladus.model.properties.essentiality.Essentiality._
 import za.co.absa.enceladus.model.properties.propertyType.{EnumPropertyType, PropertyType, StringPropertyType}
-import za.co.absa.enceladus.model.test.factories.{DatasetFactory, PropertyDefinitionFactory, SchemaFactory}
+import za.co.absa.enceladus.model.test.factories.{DatasetFactory, PropertyDefinitionFactory}
 
 @RunWith(classOf[SpringRunner])
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -71,8 +73,32 @@ class DatasetApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll 
             description = Some("init version"), properties = Some(Map("keyA" -> "valA")))
           datasetFixture.add(datasetA1)
 
-          val datasetA2 = DatasetFactory.getDummyDataset("datasetA", description = Some("updated"),
-            properties = Some(Map("keyA" -> "valA", "keyB" -> "valB", "keyC" -> "")))
+          val exampleMappingCr = MappingConformanceRule(0,
+            controlCheckpoint = true,
+            mappingTable = "CurrencyMappingTable",
+            mappingTableVersion = 9, //scalastyle:ignore magic.number
+            attributeMappings = Map("InputValue" -> "STRING_VAL"),
+            targetAttribute = "CCC",
+            outputColumn = "ConformedCCC",
+            isNullSafe = true,
+            mappingTableFilter = Some(
+              AndJoinedFilters(Set(
+                OrJoinedFilters(Set(
+                  EqualsFilter("column1", "soughtAfterValue"),
+                  EqualsFilter("column1", "alternativeSoughtAfterValue")
+                )),
+                DiffersFilter("column2", "anotherValue"),
+                NotFilter(IsNullFilter("col3"))
+              ))
+            ),
+            overrideMappingTableOwnFilter = Some(true)
+          )
+
+          val datasetA2 = DatasetFactory.getDummyDataset("datasetA",
+            description = Some("updated"),
+            properties = Some(Map("keyA" -> "valA", "keyB" -> "valB", "keyC" -> "")),
+            conformance = List(exampleMappingCr)
+          )
 
           val response = sendPost[Dataset, Dataset](s"$apiUrl/edit", bodyOpt = Some(datasetA2))
           assertCreated(response)
@@ -83,7 +109,8 @@ class DatasetApiIntegrationSuite extends BaseRestApiTest with BeforeAndAfterAll 
               version = 2,
               description = Some("updated"),
               parent = Some(DatasetFactory.toParent(datasetA1)),
-              properties = Some(Map("keyA" -> "valA", "keyB" -> "valB"))
+              properties = Some(Map("keyA" -> "valA", "keyB" -> "valB")),
+              conformance = List(exampleMappingCr)
           )
           val expected = toExpected(expectedDs, actual)
           assert(actual == expected)


### PR DESCRIPTION
This is backend preparation for #1603. Most notably:
 - bson codec for `DataFrameFilter` has been added to mongo registry, otherwise, the SerDe would not work at all
 - Json SerDe for MT and DS tests with `DataFrameFilter`s being used 
 - DatasetAPI IntegTest extended to cover DataFrameFilter usage for Datasets.

# Release notes suggestion
 - DataFrameFilter BSON serialization fixed