### PR TITLE
Suppress compiler warning of obsolete Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
     <properties>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <!--plugin versions-->
         <dockerfile.maven.version>1.4.13</dockerfile.maven.version>
         <gitflow.maven.plugin.version>1.16.0</gitflow.maven.plugin.version>


### PR DESCRIPTION
To suppress this _warning_ during compilation:
```
Warning:java: source value 1.5 is obsolete and will be removed in a future release
Warning:java: target value 1.5 is obsolete and will be removed in a future release
```