### PR TITLE
#1909 Increase the limit of columns shown in menas column selection

### DIFF
--- a/menas/ui/components/dataset/conformanceRule/RuleColumnDialog.js
+++ b/menas/ui/components/dataset/conformanceRule/RuleColumnDialog.js
@@ -60,7 +60,9 @@ class RuleColumnDialog {
   }
 
   setSchema(schema) {
-    this.oDialog.setModel(new sap.ui.model.json.JSONModel(schema), "schema");
+    const model = new sap.ui.model.json.JSONModel(schema);
+    model.setSizeLimit(5000);
+    this.oDialog.setModel(model, "schema");
   }
 
   onColumnSubmit() {


### PR DESCRIPTION
Fixes #1909 

Release Notes: Increased limit of columns shown in the selector for Coalesce and Concatenation conformance rules to 5000. This should fit most needs.