### PR TITLE
#1887 defaultTimestampTimeZone can be source type specific

### DIFF
--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/DefaultsByFormat.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/DefaultsByFormat.scala
@@ -83,6 +83,6 @@ object DefaultsByFormat {
   private final val DefaultKeyName = "default"
   private final val ObsoleteTimestampTimeZoneName = "defaultTimestampTimeZone"
   private final val ObsoleteDateTimeZoneName = "defaultDateTimeZone"
-  private final val TimestampTimeZoneKeyName = "enceladus.defaultTimestampTimeZone"
-  private final val DateTimeZoneKeyName = "enceladus.defaultDateTimeZone"
+  private final val TimestampTimeZoneKeyName = "standardization.defaultTimestampTimeZone"
+  private final val DateTimeZoneKeyName = "standardization.defaultDateTimeZone"
 }

--- a/utils/src/test/resources/application.conf
+++ b/utils/src/test/resources/application.conf
@@ -14,5 +14,5 @@
 #system-wide time zone
 timezone="UTC"
 
-enceladus.defaultTimestampTimeZone.default="CET"
-enceladus.defaultTimestampTimeZone.xml="Africa/Johannesburg"
+standardization.defaultTimestampTimeZone.default="CET"
+standardization.defaultTimestampTimeZone.xml="Africa/Johannesburg"

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/types/DefaultsByFormatSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/types/DefaultsByFormatSuite.scala
@@ -24,7 +24,7 @@ class DefaultsByFormatSuite extends AnyFunSuite {
   private val customTimestampConfig  = new ConfigReader(
     ConfigFactory.empty()
       .withValue("defaultTimestampTimeZone", ConfigValueFactory.fromAnyRef("UTC")) // fallback to "obsolete"
-      .withValue("enceladus.defaultTimestampTimeZone.json", ConfigValueFactory.fromAnyRef("WrongTimeZone"))
+      .withValue("standardization.defaultTimestampTimeZone.json", ConfigValueFactory.fromAnyRef("WrongTimeZone"))
   )
 
   test("Format specific timestamp time zone override exists") {
@@ -56,9 +56,9 @@ class DefaultsByFormatSuite extends AnyFunSuite {
   private val customDateConfig = new ConfigReader(
     ConfigFactory.empty()
       .withValue("defaultDateTimeZone", ConfigValueFactory.fromAnyRef("UTC")) // fallback to "obsolete"
-      .withValue("enceladus.defaultDateTimeZone.default", ConfigValueFactory.fromAnyRef("PST"))
-      .withValue("enceladus.defaultDateTimeZone.csv", ConfigValueFactory.fromAnyRef("JST"))
-      .withValue("enceladus.defaultDateTimeZone.parquet", ConfigValueFactory.fromAnyRef("Gibberish"))
+      .withValue("standardization.defaultDateTimeZone.default", ConfigValueFactory.fromAnyRef("PST"))
+      .withValue("standardization.defaultDateTimeZone.csv", ConfigValueFactory.fromAnyRef("JST"))
+      .withValue("standardization.defaultDateTimeZone.parquet", ConfigValueFactory.fromAnyRef("Gibberish"))
   )
 
   test("Format specific date time zone override exists") {


### PR DESCRIPTION
* rename of the configuration prefix from `enceladus.` to `standardization.`

Just a little change in the new configuration name. Believe it doesn't need retesting, that the UTs are enough.