### PR TITLE
#1926 Add executor extra java opts to helper scripts

### DIFF
--- a/scripts/bash/enceladus_env.template.sh
+++ b/scripts/bash/enceladus_env.template.sh
@@ -82,9 +82,18 @@ LOG_DIR="/tmp"
 APPLICATION_PROPERTIES_CLIENT="-Dconfig.file=/absolute/path/application.conf"
 APPLICATION_PROPERTIES_CLUSTER="-Dconfig.file=application.conf"
 
+KRB5_CONF_CLIENT="-Djava.security.krb5.conf=/absolute/path/krb5.conf"
+KRB5_CONF_CLUSTER="-Djava.security.krb5.conf=krb5.conf"
+
+TRUST_STORE_CLIENT="-Djavax.net.ssl.trustStore=/absolute/path/trustStore.jks"
+TRUST_STORE_CLUSTER="-Djavax.net.ssl.trustStore=trustStore.jks"
+TRUST_STORE_PASSWORD="-Djavax.net.ssl.trustStorePassword=password"
+
 # Files to send when running in cluster mode (comma separated)
 # Hash is used as the file alias: https://stackoverflow.com/a/49866757/1038282
 ENCELADUS_FILES="/absolute/path/application.conf#application.conf"
+ENCELADUS_FILES="${ENCELADUS_FILES},/absolute/path/krb5.conf#krb5.conf"
+ENCELADUS_FILES="${ENCELADUS_FILES},/absolute/path/emr_cacerts.jks#emr_cacerts.jks"
 
 # Additional environment-specific Spark options, e.g. "--conf spark.driver.host=myhost"
 # To specify several configuration options prepend '--conf' to each config key.
@@ -96,13 +105,15 @@ ADDITIONAL_SPARK_CONF=""
 # Additional JVM options
 # Example: ADDITIONAL_JVM_CONF="-Dtimezone=UTC -Dfoo=bar"
 # for deployment mode: client
-ADDITIONAL_JVM_CONF_CLIENT="$APPLICATION_PROPERTIES_CLIENT $JAAS_CLIENT"
+ADDITIONAL_JVM_CONF_CLIENT="$APPLICATION_PROPERTIES_CLIENT $KRB5_CONF_CLIENT $TRUST_STORE_CLIENT $TRUST_STORE_PASSWORD $JAAS_CLIENT"
+ADDITIONAL_JVM_EXECUTOR_CONF_CLIENT="$KRB5_CONF_CLIENT $TRUST_STORE_CLIENT $TRUST_STORE_PASSWORD"
 
 # for deployment mode: cluster
 # Warning!
 # Avoid suppression of Info level logger. This will lead to the fact that, we are not able to get application_id
 # and thus the scripts will not be able to continue properly, not giving the status update or kill option on interrupt
-ADDITIONAL_JVM_CONF_CLUSTER="$APPLICATION_PROPERTIES_CLUSTER $JAAS_CLUSTER"
+ADDITIONAL_JVM_CONF_CLUSTER="$APPLICATION_PROPERTIES_CLUSTER $KRB5_CONF_CLUSTER $TRUST_STORE_CLUSTER $TRUST_STORE_PASSWORD $JAAS_CLUSTER"
+ADDITIONAL_JVM_EXECUTOR_CONF_CLUSTER="$KRB5_CONF_CLUSTER $TRUST_STORE_CLUSTER $TRUST_STORE_PASSWORD"
 
 # Switch that tells the script if it should exit if it encounters unrecognized.
 # On true it prints an Error and exits with 127, on false it only prints a warning

--- a/scripts/bash/run_enceladus.sh
+++ b/scripts/bash/run_enceladus.sh
@@ -471,11 +471,17 @@ add_spark_conf_cmd "spark.memory.fraction" "${CONF_SPARK_MEMORY_FRACTION}"
 # Adding JVM configuration, entry point class name and the jar file
 if [[ "$DEPLOY_MODE" == "client" ]]; then
   ADDITIONAL_JVM_CONF="$ADDITIONAL_JVM_CONF_CLIENT"
+  ADDITIONAL_JVM_EXECUTOR_CONF="$ADDITIONAL_JVM_EXECUTOR_CONF_CLIENT"
 else
   ADDITIONAL_JVM_CONF="$ADDITIONAL_JVM_CONF_CLUSTER"
+  ADDITIONAL_JVM_EXECUTOR_CONF="$ADDITIONAL_JVM_EXECUTOR_CONF_CLUSTER"
   add_spark_conf_cmd "spark.yarn.submit.waitAppCompletion" "false"
 fi
-CMD_LINE="${CMD_LINE} ${ADDITIONAL_SPARK_CONF} ${SPARK_CONF} --conf \"${JVM_CONF} ${ADDITIONAL_JVM_CONF}\" --class ${CLASS} ${JAR}"
+
+CMD_LINE="${CMD_LINE} ${ADDITIONAL_SPARK_CONF} ${SPARK_CONF}"
+CMD_LINE="${CMD_LINE} --conf \"${JVM_CONF} ${ADDITIONAL_JVM_CONF}\""
+CMD_LINE="${CMD_LINE} --conf \"spark.executor.extraJavaOptions=${ADDITIONAL_JVM_EXECUTOR_CONF}\""
+CMD_LINE="${CMD_LINE} --class ${CLASS} ${JAR}"
 
 # Adding command line parameters that go AFTER the jar file
 add_to_cmd_line "--menas-auth-keytab" "${MENAS_AUTH_KEYTAB}"


### PR DESCRIPTION
Closes #1926

RN: Adds ability to specify additional java opts for executor through enceladus_env file. Also to the env file, we added the example for krb5.conf and truststore. 