### PR TITLE
#1927 Spline _LINEAGE and Atum _INFO files permission alignment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <!--dependency versions-->
         <abris.version>3.1.1</abris.version>
         <absa.commons.version>0.0.27</absa.commons.version>
-        <atum.version>3.6.0</atum.version>
+        <atum.version>3.6.1-SNAPSHOT</atum.version>
         <bower.chart.js.version>2.7.3</bower.chart.js.version>
         <bson.codec.jsr310.version>3.5.4</bson.codec.jsr310.version>
         <cobrix.version>2.1.0</cobrix.version>

--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -110,3 +110,5 @@ timezone="UTC"
 
 # Optional - allows original dataframe columns to be dropped
 conformance.allowOriginalColumnsMutability=false
+
+atum.hdfs.info.file.permissions=733

--- a/spark-jobs/src/main/resources/spline.properties.template
+++ b/spark-jobs/src/main/resources/spline.properties.template
@@ -25,6 +25,8 @@ spline.persistence.composition.factories=za.co.absa.spline.persistence.mongo.Mon
 spline.mongodb.url=mongodb://localhost:27017
 spline.mongodb.name=spline
 
+spline.hdfs.file.permissions=733
+
 #
 # A property for setting up persistence to Apache Atlas. Additional properties defining connectivity to Atlas are required to be part of this configuration file. (see Atlas configuration file)
 # spline.persistence.factory=za.co.absa.spline.persistence.atlas.AtlasPersistenceFactory


### PR DESCRIPTION
(in progress)
(blocked by unpublished dependency from: https://github.com/AbsaOSS/atum/pull/114)

- Spline's desired FS permissions were set in `spline.properties` (`spline.properties.template`) using the `spline.hdfs.file.permissions` config key.
- Atum's desired FS permissons were set in `reference.conf` using the `atum.hdfs.info.file.permissions` config key. (uses unpublished atum snapshot -- see above)

## Test run on EMR
Having set both of the desired FS permission to `733` (deliberately unusual) and building the project and having run on EMR HDFS, I have seen the following.
```bash
[ec2-user@<some emr host> enceladus]$ sudo hdfs dfs -getfacl  /tmp/<my output path>/
# file: <my output path>
# owner: root
# group: hdfsadmingroup
user::rwx
group::r-x
other::r-x
```
The above documents that the umask there is `022`.

```
[ec2-user@<some emr host> enceladus]$ hdfs dfs -ls <my output path>
Found 4 items
-rwx--x--x   1 root hdfsadmingroup       4046 2021-09-24 14:48 <my output path>/_INFO
-rwx--x--x   1 root hdfsadmingroup      10601 2021-09-24 14:48 <my output path>/_LINEAGE
...
```
Having listed the FS permissions set on the files in question can serve as evidence that the desired permissions `733` were used and after having been adjusted by the `022` umask, the result is `711` as shown above.

