### PR TITLE
#1869: SparkJobs working with LoadBalanced Menas

### DIFF
--- a/dao/src/main/scala/za/co/absa/enceladus/dao/rest/RestDaoFactory.scala
+++ b/dao/src/main/scala/za/co/absa/enceladus/dao/rest/RestDaoFactory.scala
@@ -21,8 +21,8 @@ object RestDaoFactory {
 
   private val restTemplate = RestTemplateSingleton.instance
 
-  def getInstance(authCredentials: MenasCredentials, apiBaseUrls: List[String]): MenasRestDAO = {
-    val apiCaller = CrossHostApiCaller(apiBaseUrls)
+  def getInstance(authCredentials: MenasCredentials, apiBaseUrls: List[String], urlsTryCounts: List[Int]): MenasRestDAO = {
+    val apiCaller = CrossHostApiCaller(apiBaseUrls, urlsTryCounts)
     val authClient = AuthClient(authCredentials, apiCaller)
     val restClient = new RestClient(authClient, restTemplate)
     new MenasRestDAO(apiCaller, restClient)

--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCallerSuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCallerSuite.scala
@@ -27,12 +27,55 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
     Mockito.reset(restClient)
   }
 
+  "CrossHostApiCaller" should {
+    "hold correct url and try count pairs" when {
+      "the url and try counts are fo same size" in {
+        val crossHostApiCaller = CrossHostApiCaller(Vector("a", "b", "c", "d"), Vector(1, 2, 3, 4), 3)
+        crossHostApiCaller.nextBaseUrl() should be("a", 1)
+        crossHostApiCaller.nextBaseUrl() should be("b", 2)
+        crossHostApiCaller.nextBaseUrl() should be("c", 3)
+        crossHostApiCaller.nextBaseUrl() should be("d", 4)
+        crossHostApiCaller.nextBaseUrl() should be("a", 1)
+      }
+      "fill in the try counts if there is less of them than urls " in {
+        val crossHostApiCaller = CrossHostApiCaller(Vector("a", "b", "c", "d"), Vector(1, 10), 3)
+        crossHostApiCaller.nextBaseUrl() should be("a", 1)
+        crossHostApiCaller.nextBaseUrl() should be("b", 10)
+        crossHostApiCaller.nextBaseUrl() should be("c", 10)
+        crossHostApiCaller.nextBaseUrl() should be("d", 10)
+        crossHostApiCaller.nextBaseUrl() should be("a", 1)
+      }
+      "no try counts are provided" in {
+        val crossHostApiCaller = CrossHostApiCaller(Vector("a", "b", "c"), 2)
+        crossHostApiCaller.nextBaseUrl() should be("a", 1)
+        crossHostApiCaller.nextBaseUrl() should be("b", 1)
+        crossHostApiCaller.nextBaseUrl() should be("c", 1)
+        crossHostApiCaller.nextBaseUrl() should be("a", 1)
+      }
+    }
+    "ignore exceeding try counts" when {
+      "there are more of them then urls" in {
+        val crossHostApiCaller = CrossHostApiCaller(Vector("a", "b", "c", "d"), Vector(1, 2, 3, 4, 5, 6), 3)
+        crossHostApiCaller.nextBaseUrl() should be("a", 1)
+        crossHostApiCaller.nextBaseUrl() should be("b", 2)
+        crossHostApiCaller.nextBaseUrl() should be("c", 3)
+        crossHostApiCaller.nextBaseUrl() should be("d", 4)
+        crossHostApiCaller.nextBaseUrl() should be("a", 1)      }
+    }
+    "filer out empty urls and non-positive try counts" in {
+      val crossHostApiCaller = CrossHostApiCaller(Vector("a", "", "c", "d", "e"), Vector(1, 2, -3, 0, 5), 1)
+      crossHostApiCaller.nextBaseUrl() should be("a", 1)
+      crossHostApiCaller.nextBaseUrl() should be("e", 5)
+      crossHostApiCaller.nextBaseUrl() should be("a", 1)
+    }
+  }
+
   "CrossHostApiCaller::call" should {
     "return the result of the first successful call" when {
       "there are no failures" in {
         Mockito.when(restClient.sendGet[String]("a")).thenReturn("success")
 
-        val result = new CrossHostApiCaller(List("a", "b", "c"), 0).call { str =>
+        val result = CrossHostApiCaller(Vector("a", "b", "c"), 0).call { str =>
           restClient.sendGet[String](str)
         }
 
@@ -42,16 +85,33 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
 
       "only some calls fail with a retryable exception" in {
         Mockito.when(restClient.sendGet[String]("a")).thenThrow(DaoException("Something went wrong A"))
-        Mockito.when(restClient.sendGet[String]("b")).thenReturn("success")
+        Mockito.when(restClient.sendGet[String]("b"))
+          .thenThrow(DaoException("Something went wrong B"))
+          .thenReturn("success")
 
-        val result = new CrossHostApiCaller(List("a", "b", "c"), 0).call { str =>
+        val result = CrossHostApiCaller(Vector("a", "b", "c"), Vector(3, 4), 0).call { str =>
           restClient.sendGet[String](str)
         }
 
         result should be("success")
-        Mockito.verify(restClient, Mockito.times(1)).sendGet[String]("a")
-        Mockito.verify(restClient, Mockito.times(1)).sendGet[String]("b")
+        Mockito.verify(restClient, Mockito.times(3)).sendGet[String]("a")
+        Mockito.verify(restClient, Mockito.times(2)).sendGet[String]("b")
         Mockito.verify(restClient, Mockito.never()).sendGet[String]("c")
+      }
+
+      "despite some urls have non-positive try counts" in {
+        Mockito.when(restClient.sendGet[String]("a")).thenThrow(DaoException("Something went wrong A"))
+        Mockito.when(restClient.sendGet[String]("b")).thenThrow(DaoException("Something went wrong B"))
+        Mockito.when(restClient.sendGet[String]("c")).thenReturn("success")
+
+        val result = CrossHostApiCaller(Vector("a", "b", "c"), Vector(-1, 0, 3, 12), 0).call { str =>
+          restClient.sendGet[String](str)
+        }
+
+        result should be("success")
+        Mockito.verify(restClient, Mockito.never()).sendGet[String]("a")
+        Mockito.verify(restClient, Mockito.never()).sendGet[String]("b")
+        Mockito.verify(restClient, Mockito.times(1)).sendGet[String]("c")
       }
     }
 
@@ -62,7 +122,7 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
         Mockito.when(restClient.sendGet[String]("c")).thenThrow(DaoException("Something went wrong C"))
 
         val exception = intercept[DaoException] {
-          new CrossHostApiCaller(List("a", "b", "c"), 0).call { str =>
+          CrossHostApiCaller(Vector("a", "b", "c"), 0).call { str =>
             restClient.sendGet[String](str)
           }
         }
@@ -73,12 +133,29 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
         Mockito.verify(restClient, Mockito.times(1)).sendGet[String]("c")
       }
 
+      "all calls fail with a retryable exception over multiple attempts" in {
+        Mockito.when(restClient.sendGet[String]("a")).thenThrow(DaoException("Something went wrong A"))
+        Mockito.when(restClient.sendGet[String]("b")).thenThrow(DaoException("Something went wrong B"))
+        Mockito.when(restClient.sendGet[String]("c")).thenThrow(DaoException("Something went wrong C"))
+
+        val exception = intercept[DaoException] {
+          CrossHostApiCaller(Vector("a", "b", "c"), Vector(3, 1, 2), 0).call { str =>
+            restClient.sendGet[String](str)
+          }
+        }
+
+        exception.getMessage should be("Something went wrong C")
+        Mockito.verify(restClient, Mockito.times(3)).sendGet[String]("a")
+        Mockito.verify(restClient, Mockito.times(1)).sendGet[String]("b")
+        Mockito.verify(restClient, Mockito.times(2)).sendGet[String]("c")
+      }
+
       "any call fails with a non-retryable exception" in {
         Mockito.when(restClient.sendGet[String]("a")).thenThrow(new ResourceAccessException("Something went wrong A"))
         Mockito.when(restClient.sendGet[String]("b")).thenThrow(UnauthorizedException("Wrong credentials"))
 
         val exception = intercept[UnauthorizedException] {
-          new CrossHostApiCaller(List("a", "b", "c"), 0).call { str =>
+          CrossHostApiCaller(Vector("a", "b", "c"), 0).call { str =>
             restClient.sendGet[String](str)
           }
         }
@@ -87,6 +164,25 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
         Mockito.verify(restClient, Mockito.times(1)).sendGet[String]("a")
         Mockito.verify(restClient, Mockito.times(1)).sendGet[String]("b")
         Mockito.verify(restClient, Mockito.never()).sendGet[String]("c")
+      }
+    }
+
+    "fail on not having Urls" when {
+      "none are provided" in {
+        val exception = intercept[IndexOutOfBoundsException] {
+          CrossHostApiCaller(Vector()).call { str =>
+            restClient.sendGet[String](str)
+          }
+        }
+        exception.getMessage should be ("0")
+      }
+      "all are filtered out" in {
+        val exception = intercept[IndexOutOfBoundsException] {
+          CrossHostApiCaller(Vector("", "a", "b"), Vector(3, 0, -1), 1)call { str =>
+            restClient.sendGet[String](str)
+          }
+        }
+        exception.getMessage should be ("1")
       }
     }
   }

--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/RestDaoFactorySuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/RestDaoFactorySuite.scala
@@ -23,26 +23,27 @@ import za.co.absa.enceladus.dao.auth.{InvalidMenasCredentials, MenasKerberosCred
 class RestDaoFactorySuite extends AnyWordSpec with Matchers {
 
   private val menasApiBaseUrls = List("http://localhost:8080/menas/api")
+  private val menasUrlsTryCounts = List(1)
 
   "RestDaoFactory::getInstance" should {
     "return a MenasRestDAO instance with a SpnegoAuthClient" when {
       "given a Keytab location" in {
         val keytabCredentials = MenasKerberosCredentials("user", "src/test/resources/user.keytab.example")
-        val restDao = RestDaoFactory.getInstance(keytabCredentials, menasApiBaseUrls)
+        val restDao = RestDaoFactory.getInstance(keytabCredentials, menasApiBaseUrls, menasUrlsTryCounts)
         getAuthClient(restDao.restClient).getClass should be(classOf[SpnegoAuthClient])
       }
     }
     "return a MenasRestDAO instance with a LdapAuthClient" when {
       "given plain MenasCredentials" in {
         val plainCredentials = MenasPlainCredentials("user", "changeme")
-        val restDao = RestDaoFactory.getInstance(plainCredentials, menasApiBaseUrls)
+        val restDao = RestDaoFactory.getInstance(plainCredentials, menasApiBaseUrls, menasUrlsTryCounts)
         getAuthClient(restDao.restClient).getClass should be(classOf[LdapAuthClient])
       }
     }
     "throw an error" when {
       "given invalid credentials" in {
         val exception = intercept[UnauthorizedException] {
-          RestDaoFactory.getInstance(InvalidMenasCredentials, menasApiBaseUrls)
+          RestDaoFactory.getInstance(InvalidMenasCredentials, menasApiBaseUrls, menasUrlsTryCounts)
         }
         exception.getMessage should be("No Menas credentials provided")
       }

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample1.scala
@@ -42,7 +42,7 @@ object CustomRuleSample1 extends CustomRuleSampleFs {
     val menasBaseUrls = List("http://localhost:8080/menas")
     val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/main/resources/user.keytab.example")
     implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
-    implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)
+    implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls, List.empty) // you may have to hard-code your own implementation here (if not working with menas)
 
     val experimentalMR = true
     val isCatalystWorkaroundEnabled = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
@@ -44,7 +44,7 @@ object CustomRuleSample2 extends CustomRuleSampleFs {
     val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
     val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/main/resources/user.keytab.example")
     implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
-    implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)
+    implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls, List.empty) // you may have to hard-code your own implementation here (if not working with menas)
 
     val experimentalMR = true
     val isCatalystWorkaroundEnabled = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
@@ -39,7 +39,7 @@ object CustomRuleSample3 extends CustomRuleSampleFs {
     val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
     val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/main/resources/user.keytab.example")
     implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
-    implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)
+    implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls, List.empty) // you may have to hard-code your own implementation here (if not working with menas)
 
     val experimentalMR = true
     val isCatalystWorkaroundEnabled = true

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
@@ -144,7 +144,7 @@ object CustomRuleSample4 extends CustomRuleSampleFs {
     val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
     val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/main/resources/user.keytab.example")
     implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
-    implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)
+    implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls, List.empty) // you may have to hard-code your own implementation here (if not working with menas)
 
     val dfReader: DataFrameReader = {
       val dfReader0 = spark.read

--- a/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/XPadCustomConformanceRuleSuite.scala
+++ b/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/XPadCustomConformanceRuleSuite.scala
@@ -26,6 +26,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.MenasKerberosCredentials
 import za.co.absa.enceladus.dao.rest.{MenasConnectionStringParser, RestDaoFactory}
 import za.co.absa.enceladus.model.Dataset
+import za.co.absa.enceladus.utils.config.ConfigReader
 import za.co.absa.enceladus.utils.fs.HadoopFsUtils
 import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, SparkTestBase}
 
@@ -183,11 +184,12 @@ class RpadCustomConformanceRuleSuite extends AnyFunSuite with SparkTestBase with
 
   import spark.implicits._
 
-  private val conf = ConfigFactory.load()
+  private val conf = new ConfigReader()
   private val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
+  private val menasUrlsTryCounts = conf.getIntListOption("menas.rest.uriTries").getOrElse(List.empty)
   private val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/test/resources/user.keytab.example")
   implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
-  implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)
+  implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls, menasUrlsTryCounts) // you may have to hard-code your own implementation here (if not working with menas)
 
   val experimentalMR = true
   val isCatalystWorkaroundEnabled = true

--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -23,6 +23,8 @@
 # The Menas URI can specify multiple semi-colon-separated base URIs
 # each can have multiple comma-separated hosts, these are used for fault-tolerance
 menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,host2:9000/menas"
+# Each of the above uris can be tried multiple times, also for fault-tolerance
+#menas.rest.uriTries=[1]
 
 # 'enceladus_record_id' with an id can be added containing either true UUID, always the same IDs (row-hash-based) or the
 # column will not be added at all. Allowed values: "uuid", "stableHashId", "none"

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/ConformanceExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/ConformanceExecution.scala
@@ -74,7 +74,7 @@ trait ConformanceExecution extends CommonJobExecution {
 
     // Enable Menas plugin for Control Framework
     MenasPlugin.enableMenas(
-      conf,
+      conf.config,
       cmd.datasetName,
       cmd.datasetVersion,
       cmd.reportDate,
@@ -103,7 +103,7 @@ trait ConformanceExecution extends CommonJobExecution {
 
   protected def conform[T](inputData: DataFrame, preparationResult: PreparationResult)
                           (implicit spark: SparkSession, cmd: ConformanceConfigParser[T], dao: MenasDAO): DataFrame = {
-    val recordIdGenerationStrategy = getRecordIdGenerationStrategyFromConfig(conf)
+    val recordIdGenerationStrategy = getRecordIdGenerationStrategyFromConfig(conf.config)
 
     implicit val featureSwitcher: FeatureSwitches = conformanceReader.readFeatureSwitches()
     implicit val stdFs: FileSystem = preparationResult.pathCfg.standardization.fileSystem

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/DynamicConformanceJob.scala
@@ -32,7 +32,7 @@ object DynamicConformanceJob extends ConformanceExecution {
     initialValidation()
     implicit val spark: SparkSession = obtainSparkSession(jobName) // initialize spark
     val menasCredentials = cmd.menasCredentialsFactory.getInstance()
-    implicit val dao: MenasDAO = RestDaoFactory.getInstance(menasCredentials, menasBaseUrls)
+    implicit val dao: MenasDAO = RestDaoFactory.getInstance(menasCredentials, menasBaseUrls, menasUrlsTryCounts)
 
     val preparationResult = prepareJob()
     prepareConformance(preparationResult)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -15,6 +15,8 @@
 
 package za.co.absa.enceladus.conformance
 
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+
 import java.text.SimpleDateFormat
 import java.util.Date
 import org.apache.commons.configuration2.Configuration
@@ -32,13 +34,15 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.{MenasCredentialsFactory, MenasKerberosCredentialsFactory, MenasPlainCredentialsFactory}
 import za.co.absa.enceladus.dao.rest.{MenasConnectionStringParser, RestDaoFactory}
 import za.co.absa.enceladus.model.Dataset
+import za.co.absa.enceladus.utils.config.ConfigReader
 import za.co.absa.enceladus.utils.fs.HadoopFsUtils
 import za.co.absa.enceladus.utils.validation.ValidationLevel
 import za.co.absa.hyperdrive.ingestor.api.transformer.{StreamTransformer, StreamTransformerFactory}
 
-class HyperConformance (implicit cmd: ConformanceConfig,
+class HyperConformance (menasBaseUrls: List[String],
+                        menasUrlsTryCounts: List[Int])
+                       (implicit cmd: ConformanceConfig,
                         featureSwitches: FeatureSwitches,
-                        menasBaseUrls: List[String],
                         infoDateFactory: InfoDateFactory,
                         infoVersionFactory: InfoVersionFactory) extends StreamTransformer {
   val log: Logger = LoggerFactory.getLogger(this.getClass)
@@ -48,7 +52,7 @@ class HyperConformance (implicit cmd: ConformanceConfig,
     implicit val spark: SparkSession = rawDf.sparkSession
     val menasCredentials = cmd.menasCredentialsFactory.getInstance()
 
-    implicit val dao: MenasDAO = RestDaoFactory.getInstance(menasCredentials, menasBaseUrls)
+    implicit val dao: MenasDAO = RestDaoFactory.getInstance(menasCredentials, menasBaseUrls, menasUrlsTryCounts)
     dao.authenticate()
 
     logPreConformanceInfo(rawDf)
@@ -145,8 +149,17 @@ object HyperConformance extends StreamTransformerFactory with HyperConformanceAt
     implicit val reportDateCol: InfoDateFactory = InfoDateFactory.getFactoryFromConfig(conf)
     implicit val infoVersionCol: InfoVersionFactory = InfoVersionFactory.getFactoryFromConfig(conf)
 
-    implicit val menasBaseUrls: List[String] = MenasConnectionStringParser.parse(conf.getString(menasUriKey))
-    new HyperConformance()
+    val menasBaseUrls: List[String] = MenasConnectionStringParser.parse(conf.getString(menasUriKey))
+    val menasBaseUrlsTryCounts: List[Int] = if (conf.containsKey(menasUriTriesKey)) {
+      val value = conf.getString(menasUriTriesKey)
+      val configReader = new ConfigReader(ConfigFactory.empty()
+        .withValue(menasUriTriesKey, ConfigValueFactory.fromAnyRef(value)
+        ))
+      configReader.getIntList(menasUriTriesKey)
+    } else {
+      List.empty
+    }
+    new HyperConformance(menasBaseUrls, menasBaseUrlsTryCounts)
   }
 
   private def getReportVersion(conf: Configuration): Int = {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
@@ -21,6 +21,7 @@ object HyperConformanceAttributes {
 
   // Configuration keys expected to be set up when running Conformance as a Transformer component for Hyperdrive
   val menasUriKey = "menas.rest.uri"
+  val menasUriTriesKey = "menas.rest.uriTries"
   val menasCredentialsFileKey = "menas.credentials.file"
   val menasAuthKeytabKey = "menas.auth.keytab"
   val datasetNameKey = "dataset.name"
@@ -42,6 +43,8 @@ trait HyperConformanceAttributes extends HasComponentAttributes {
   override def getProperties: Map[String, PropertyMetadata] = Map(
     menasUriKey ->
       PropertyMetadata("Menas API URL", Some("E.g. http://localhost:8080/menas"), required = true),
+    menasUriTriesKey ->
+      PropertyMetadata("How many times call to Menas API URL should be tried", Some("E.g. 3"), required = false),
     datasetNameKey ->
       PropertyMetadata("Dataset name", None, required = true),
     datasetVersionKey ->

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/config/FilterFromConfig.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/config/FilterFromConfig.scala
@@ -44,7 +44,7 @@ object FilterFromConfig {
   }
 
   private def readJson(configKey: String): Option[String] = {
-    configReader.readStringConfigIfExist(configKey).filter(_.nonEmpty).map(_.replaceAllLiterally("'","\""))
+    configReader.getStringOption(configKey).filter(_.nonEmpty).map(_.replaceAllLiterally("'","\""))
   }
 
   def loadFilter(dataFrameName: String): Option[DataFrameFilter] = {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationExecution.scala
@@ -67,7 +67,7 @@ trait StandardizationExecution extends CommonJobExecution {
 
     // Enable Menas plugin for Control Framework
     MenasPlugin.enableMenas(
-      conf,
+      conf.config,
       cmd.datasetName,
       cmd.datasetVersion,
       cmd.reportDate,
@@ -143,7 +143,7 @@ trait StandardizationExecution extends CommonJobExecution {
   protected def standardize[T](inputData: DataFrame, schema: StructType, cmd: StandardizationConfigParser[T])
                               (implicit spark: SparkSession, udfLib: UDFLibrary, defaults: Defaults): DataFrame = {
     //scalastyle:on parameter.number
-    val recordIdGenerationStrategy = getRecordIdGenerationStrategyFromConfig(conf)
+    val recordIdGenerationStrategy = getRecordIdGenerationStrategyFromConfig(conf.config)
 
     try {
       handleControlInfoValidation()

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization/StandardizationJob.scala
@@ -35,7 +35,7 @@ object StandardizationJob extends StandardizationExecution {
     implicit val defaults: Defaults = new DefaultsByFormat(cmd.rawFormat)
 
     val menasCredentials = cmd.menasCredentialsFactory.getInstance()
-    implicit val dao: MenasDAO = RestDaoFactory.getInstance(menasCredentials, menasBaseUrls)
+    implicit val dao: MenasDAO = RestDaoFactory.getInstance(menasCredentials, menasBaseUrls, menasUrlsTryCounts)
 
     val preparationResult = prepareJob()
     val schema =  prepareStandardization(args, menasCredentials, preparationResult)

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/StandardizationAndConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/StandardizationAndConformanceJob.scala
@@ -35,7 +35,7 @@ object StandardizationAndConformanceJob extends StandardizationAndConformanceExe
     implicit val defaults: Defaults = new DefaultsByFormat(cmd.rawFormat)
 
     val menasCredentials = cmd.menasCredentialsFactory.getInstance()
-    implicit val dao: MenasDAO = RestDaoFactory.getInstance(menasCredentials, menasBaseUrls)
+    implicit val dao: MenasDAO = RestDaoFactory.getInstance(menasCredentials, menasBaseUrls, menasUrlsTryCounts)
 
     val preparationResult = prepareJob()
     val schema = prepareStandardization(args, menasCredentials, preparationResult)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/StreamingFixture.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/StreamingFixture.scala
@@ -32,7 +32,8 @@ import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.utils.testUtils.SparkTestBase
 
 trait StreamingFixture extends AnyFunSuite with SparkTestBase with MockitoSugar {
-  implicit val menasBaseUrls: List[String] = List.empty
+  private val menasBaseUrls = List.empty[String]
+  private val menasUrlsTryCounts = List.empty[Int]
   implicit val cmd: ConformanceConfig = ConformanceConfig(reportVersion = Some(1), reportDate = "2020-03-23")
 
   protected def testHyperConformanceFromConfig(input: DataFrame,
@@ -91,7 +92,7 @@ trait StreamingFixture extends AnyFunSuite with SparkTestBase with MockitoSugar 
       .setControlFrameworkEnabled(false)
 
     val memoryStream = new MemoryStream[Row](1, spark.sqlContext)(RowEncoder(input.schema))
-    val hyperConformance = new HyperConformance()
+    val hyperConformance = new HyperConformance(menasBaseUrls, menasUrlsTryCounts)
     val source: DataFrame = memoryStream.toDF()
     val conformed: DataFrame = hyperConformance.applyConformanceTransformations(source, dataset)
     val sink = conformed

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/config/ConfigReader.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/config/ConfigReader.scala
@@ -16,34 +16,88 @@
 package za.co.absa.enceladus.utils.config
 
 import com.typesafe.config._
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
-import za.co.absa.enceladus.utils.config.ConfigUtils.ConfigImplicits
+import scala.util.{Failure, Try}
 
 object ConfigReader {
   val redactedReplacement: String = "*****"
 }
 
-class ConfigReader(config: Config = ConfigFactory.load()) {
+class ConfigReader(val config: Config = ConfigFactory.load()) {
   import ConfigReader._
 
-  private val log = LoggerFactory.getLogger(this.getClass)
 
-  def readStringConfigIfExist(path: String): Option[String] = {
-    config.getOptionString(path)
+  def hasPath(path: String): Boolean = {
+    config.hasPath(path)
   }
 
-  def readStringConfig(path: String, default: String): String = {
-    readStringConfigIfExist(path).getOrElse(default)
+  def getString(path: String): String = {
+    config.getString(path)
+  }
+
+  def getInt(path: String): Int = {
+    config.getInt(path)
+  }
+
+  def getBoolean(path: String): Boolean = {
+    config.getBoolean(path)
+  }
+
+  def getIntList(path: String): List[Int] = {
+    Try(config
+      .getIntList(path)
+      .asScala
+      .map(_.toInt)
+      .toList
+    ).recoverWith {
+      // if it fails try to decode it as a simple string, but if that fails too, throw the original exception
+      case e: ConfigException.WrongType => Try(getListFromString(path){_.toInt}).recoverWith{case _ => Failure(e)}
+    }.get
   }
 
   /**
-   * Given a configuration returns a new configuration which has all sensitive keys redacted.
-   *
-   * @param keysToRedact A set of keys to be redacted.
-   */
-  def getRedactedConfig(keysToRedact: Set[String]): Config = {
+    * Inspects the config for the presence of the `path` and returns an optional result.
+    *
+    * @param path path to look for, e.g. "group1.subgroup2.value3
+    * @return None if not found or defined Option[String]
+    */
+  def getStringOption(path: String): Option[String] = {
+    getIfExists(path)(getString)
+  }
+
+  /**
+    * Inspects the config for the presence of the `path` and returns an optional result.
+    *
+    * @param path path to look for, e.g. "group1.subgroup2.value3
+    * @return None if not found or defined Option[Boolean]
+    */
+  def getBooleanOption(path: String): Option[Boolean] = {
+    getIfExists(path)(getBoolean)
+  }
+
+  /**
+    * Inspects the config for the presence of the `key` and returns an optional result.
+    *
+    * @param path path to look for, e.g. "group1.subgroup2.value3
+    * @return None if not found or defined Option[Boolean]
+    */
+  def getIntListOption(path: String): Option[List[Int]] = {
+    getIfExists(path)(getIntList)
+  }
+
+  /** Handy shorthand of frequent `config.withValue(key, ConfigValueFactory.fromAnyRef(value))` */
+  def withAnyRefValue(key: String, value: AnyRef) : ConfigReader = {
+    new ConfigReader(config.withValue(key, ConfigValueFactory.fromAnyRef(value)))
+  }
+
+  /**
+    * Given a configuration returns a new configuration which has all sensitive keys redacted.
+    *
+    * @param keysToRedact A set of keys to be redacted.
+    */
+  def getRedactedConfig(keysToRedact: Set[String]): ConfigReader = {
     def withAddedKey(accumulatedConfig: Config, key: String): Config = {
       if (config.hasPath(key)) {
         accumulatedConfig.withValue(key, ConfigValueFactory.fromAnyRef(redactedReplacement))
@@ -54,29 +108,29 @@ class ConfigReader(config: Config = ConfigFactory.load()) {
 
     val redactingConfig = keysToRedact.foldLeft(ConfigFactory.empty)(withAddedKey)
 
-    redactingConfig.withFallback(config)
+    new ConfigReader(redactingConfig.withFallback(config))
   }
 
   /**
-   * Flattens TypeSafe config tree and returns the effective configuration
-   * while redacting sensitive keys.
-   *
-   * @param keysToRedact A set of keys for which should be redacted.
-   * @return the effective configuration as a map
-   */
+    * Flattens TypeSafe config tree and returns the effective configuration
+    * while redacting sensitive keys.
+    *
+    * @param keysToRedact A set of keys for which should be redacted.
+    * @return the effective configuration as a map
+    */
   def getFlatConfig(keysToRedact: Set[String] = Set()): Map[String, AnyRef] = {
-    getRedactedConfig(keysToRedact).entrySet().asScala.map({ entry =>
+    getRedactedConfig(keysToRedact).config.entrySet().asScala.map({ entry =>
       entry.getKey -> entry.getValue.unwrapped()
     }).toMap
   }
 
   /**
-   * Logs the effective configuration while redacting sensitive keys
-   * in HOCON format.
-   *
-   * @param keysToRedact A set of keys for which values shouldn't be logged.
-   */
-  def logEffectiveConfigHocon(keysToRedact: Set[String] = Set()): Unit = {
+    * Logs the effective configuration while redacting sensitive keys
+    * in HOCON format.
+    *
+    * @param keysToRedact A set of keys for which values shouldn't be logged.
+    */
+  def logEffectiveConfigHocon(keysToRedact: Set[String] = Set(), log: Logger = LoggerFactory.getLogger(this.getClass)): Unit = {
     val redactedConfig = getRedactedConfig(keysToRedact)
 
     val renderOptions = ConfigRenderOptions.defaults()
@@ -84,18 +138,18 @@ class ConfigReader(config: Config = ConfigFactory.load()) {
       .setOriginComments(false)
       .setJson(false)
 
-    val rendered = redactedConfig.root().render(renderOptions)
+    val rendered = redactedConfig.config.root().render(renderOptions)
 
     log.info(s"Effective configuration:\n$rendered")
   }
 
   /**
-   * Logs the effective configuration while redacting sensitive keys
-   * in Properties format.
-   *
-   * @param keysToRedact A set of keys for which values shouldn't be logged.
-   */
-  def logEffectiveConfigProps(keysToRedact: Set[String] = Set()): Unit = {
+    * Logs the effective configuration while redacting sensitive keys
+    * in Properties format.
+    *
+    * @param keysToRedact A set of keys for which values shouldn't be logged.
+    */
+  def logEffectiveConfigProps(keysToRedact: Set[String] = Set(), log: Logger = LoggerFactory.getLogger(this.getClass)): Unit = {
     val redactedConfig = getFlatConfig(keysToRedact)
 
     val rendered = redactedConfig.map {
@@ -106,4 +160,26 @@ class ConfigReader(config: Config = ConfigFactory.load()) {
 
     log.info(s"Effective configuration:\n$rendered")
   }
+
+  private def getIfExists[T](path: String)(readFnc: String => T): Option[T] = {
+    if (config.hasPathOrNull(path)) {
+      if (config.getIsNull(path)) {
+        None
+      } else {
+        Option(readFnc(path))
+      }
+    } else {
+      None
+    }
+  }
+
+  private def getListFromString[T](path: String)(converFnc: String => T): List[T] = {
+    import za.co.absa.enceladus.utils.implicits.StringImplicits._
+
+    val delimiter = ','
+    val source = getString(path).trimStartEndChar('[',']')
+    val listDirty = source.splitWithQuotes(delimiter)
+    listDirty.map(item => converFnc(item.trim.trimStartEndChar('"'))).toList
+  }
+
 }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/time/TimeZoneNormalizer.scala
@@ -26,7 +26,7 @@ import za.co.absa.enceladus.utils.config.ConfigReader
    */
 object TimeZoneNormalizer {
   private val log: Logger = LogManager.getLogger(this.getClass)
-  val timeZone: String = new ConfigReader().readStringConfigIfExist("timezone").getOrElse {
+  val timeZone: String = new ConfigReader().getStringOption("timezone").getOrElse {
     val default = "UTC"
     log.warn(s"No time zone (timezone) setting found. Setting to default, which is $default.")
     default

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/DefaultsByFormat.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/DefaultsByFormat.scala
@@ -51,7 +51,7 @@ class DefaultsByFormat(formatName: String,
   override def getDecimalSymbols: DecimalSymbols = globalDefaults.getDecimalSymbols
 
   private def readTimezone(path: String): Option[String] = {
-    val result = config.readStringConfigIfExist(path)
+    val result = config.getStringOption(path)
     result.foreach(tz =>
       if (!TimeZone.getAvailableIDs().contains(tz )) {
         throw new IllegalStateException(s"The setting '$tz' of '$path' is not recognized as known time zone")

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/config/ConfigReaderSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/config/ConfigReaderSuite.scala
@@ -15,10 +15,11 @@
 
 package za.co.absa.enceladus.utils.config
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ConfigException, ConfigFactory}
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class ConfigReaderSuite extends AnyWordSpec {
+class ConfigReaderSuite extends AnyWordSpec with Matchers{
   private val config = ConfigFactory.parseString(
     """
       |top = default
@@ -29,37 +30,149 @@ class ConfigReaderSuite extends AnyWordSpec {
       |  string = "str"
       |  redacted = "67890"
       |}
+      |nothing=null
+      |booleans {
+      |  yes = "true"
+      |  str = "xxx"
+      |}
+      |list = [1,2,3]
+      |list2=["10", "20", "30"]
+      |list3="1, 1, 2, 3 , 5"
+      |list4=["0", "A", "BB"]
       |""".stripMargin)
 
   private val keysToRedact = Set("redacted", "nested.redacted", "redundant.key")
 
   private val configReader = new ConfigReader(config)
 
-  "readStringConfigIfExist()" should {
-    "return Some(value) if the key exists" in {
-      assert(configReader.readStringConfigIfExist("nested.redacted").contains("67890"))
+  "hasPath" should {
+    "return true if the key exists" in {
+      assert(configReader.hasPath("nested.value.num"))
     }
-
-    "return None if the key does not exist" in {
-      assert(configReader.readStringConfigIfExist("redundant.key").isEmpty)
+    "return true if key exists even as parent" in {
+      assert(configReader.hasPath("nested"))
     }
-
-    "return a value converted to string if the value is not a string" in {
-      assert(configReader.readStringConfigIfExist("nested.value.num").contains("100"))
+    "return false if the key exists" in {
+      assert(!configReader.hasPath("does.not.exists"))
     }
   }
 
-  "readStringConfig()" should {
+  "getString()" should {
     "return the value if the key exists" in {
-      assert(configReader.readStringConfig("nested.redacted", "def") == "67890")
+      configReader.getString("nested.redacted") shouldBe "67890"
     }
-
-    "return the default value if the key does not exist" in {
-      assert(configReader.readStringConfig("redundant.key", "def") == "def")
+    "throw if the key does not exist" in {
+      intercept[ConfigException.Missing] {
+        configReader.getString("redundant.key")
+      }
     }
-
     "return a value converted to string if the value is not a string" in {
-      assert(configReader.readStringConfig("nested.value.num", "def") == "100")
+      configReader.getString("nested.value.num") shouldBe "100"
+    }
+    "throws if the value is null" in {
+      intercept[ConfigException.Null] {
+        configReader.getString("nothing")
+      }
+    }
+  }
+
+  "getInt()" should {
+    "return the value if the key exists and" when {
+      "is an integer" in {
+        configReader.getInt("nested.value.num") shouldBe 100
+      }
+      "and the value cane be converted to int" in {
+        configReader.getInt("nested.redacted") shouldBe 67890
+      }
+    }
+    "throw if the key does not exist" in {
+      intercept[ConfigException.Missing] {
+        configReader.getInt("redundant.key")
+      }
+    }
+    "throws if the value is not an integer" in {
+      intercept[ConfigException.WrongType] {
+        configReader.getInt("top")
+      }
+    }
+  }
+
+  "getBoolean()" should {
+    "return the value if the key exists and is a boolean" in {
+      assert(configReader.getBoolean("booleans.yes"))
+    }
+    "throw if the key does not exist" in {
+      intercept[ConfigException.Missing] {
+        configReader.getBoolean("booleans.not.exists")
+      }
+    }
+    "throws if the value is not a boolean" in {
+      intercept[ConfigException.WrongType] {
+        configReader.getBoolean("booleans.str")
+      }
+    }
+  }
+
+  "getIntList()" should {
+    "return list of integers" when {
+      "when the path exists and they are integers in brackets" in {
+        configReader.getIntList("list") shouldBe List(1, 2, 3)
+      }
+      "when values can be converted to int" in {
+        configReader.getIntList("list2") shouldBe List(10, 20, 30)
+      }
+      "when the values are a string not in brackets" in {
+        configReader.getIntList("list3") shouldBe List(1, 1, 2, 3, 5)
+      }
+      "even when the value is a single integer" in {
+        configReader.getIntList("nested.redacted") shouldBe List(67890)
+      }
+    }
+    "throws and exception" when {
+      "if the key does not exist" in {
+        intercept[ConfigException.Missing] {
+          configReader.getIntList("redundant.key")
+        }
+      }
+      "if the value is not a list of integers" in {
+        intercept[ConfigException.WrongType] {
+          configReader.getIntList("top")
+        }
+      }
+      "if the value is a list of strings" in {
+        intercept[ConfigException.WrongType] {
+          configReader.getIntList("list4")
+        }
+      }
+      "the value is null" in {
+        intercept[ConfigException.Null] {
+          configReader.getIntList("nothing")
+        }
+      }
+    }
+  }
+
+  "getStringOption()" should {
+    "return Some(value) if the key exists" in {
+      assert(configReader.getStringOption("nested.redacted").contains("67890"))
+    }
+    "return None if the key does not exist" in {
+      assert(configReader.getStringOption("redundant.key").isEmpty)
+    }
+    "return None if the key is Null" in {
+      assert(configReader.getStringOption("nothing").isEmpty)
+    }
+  }
+
+  "getIntListOption()" should {
+    "return Some(value) if the key exists" in {
+      assert(configReader.getIntListOption("list").contains(List(1, 2, 3)))
+    }
+    "return None if the key does not exist" in {
+      assert(configReader.getIntListOption("redundant.key").isEmpty)
+    }
+    "return None if the key is Null" in {
+      assert(configReader.getIntListOption("nothing").isEmpty)
     }
   }
 
@@ -67,24 +180,24 @@ class ConfigReaderSuite extends AnyWordSpec {
     "return the same config if there are no keys to redact" in {
       val redactedConfig = configReader.getFlatConfig(Set())
 
-      assert(redactedConfig("top") == "default")
-      assert(redactedConfig("quoted") == "text")
-      assert(redactedConfig("nested.value.num").toString == "100")
-      assert(redactedConfig("nested.string") == "str")
-      assert(redactedConfig("redacted") == "12345")
-      assert(redactedConfig("nested.redacted") == "67890")
-      assert(!redactedConfig.contains("redundant.key"))
+      redactedConfig("top") shouldBe "default"
+      redactedConfig("quoted") shouldBe "text"
+      redactedConfig("nested.value.num").toString shouldBe "100"
+      redactedConfig("nested.string") shouldBe "str"
+      redactedConfig("redacted") shouldBe "12345"
+      redactedConfig("nested.redacted") shouldBe "67890"
+      !redactedConfig.contains("redundant.key")
     }
 
     "redact an input config when given a set of keys to redact" in {
       val redactedConfig = configReader.getFlatConfig(keysToRedact)
 
-      assert(redactedConfig("top") == "default")
-      assert(redactedConfig("quoted") == "text")
-      assert(redactedConfig("nested.value.num").toString == "100")
-      assert(redactedConfig("nested.string") == "str")
-      assert(redactedConfig("redacted") == ConfigReader.redactedReplacement)
-      assert(redactedConfig("nested.redacted") == ConfigReader.redactedReplacement)
+      redactedConfig("top") shouldBe "default"
+      redactedConfig("quoted") shouldBe "text"
+      redactedConfig("nested.value.num").toString shouldBe "100"
+      redactedConfig("nested.string") shouldBe "str"
+      redactedConfig("redacted") shouldBe ConfigReader.redactedReplacement
+      redactedConfig("nested.redacted") shouldBe ConfigReader.redactedReplacement
       assert(!redactedConfig.contains("redundant.key"))
     }
   }
@@ -93,19 +206,19 @@ class ConfigReaderSuite extends AnyWordSpec {
     "return the same config if there are no keys to redact" in {
       val redactedConfig = configReader.getRedactedConfig(Set())
 
-      assertResult(config)(redactedConfig)
+      assertResult(config)(redactedConfig.config)
     }
 
     "redact an input config when given a set of keys to redact" in {
       val redactedConfig = configReader.getRedactedConfig(keysToRedact)
 
-      assert(redactedConfig.getString("top") == "default")
-      assert(redactedConfig.getString("quoted") == "text")
-      assert(redactedConfig.getInt("nested.value.num") == 100)
-      assert(redactedConfig.getString("nested.string") == "str")
-      assert(redactedConfig.getString("redacted") == ConfigReader.redactedReplacement)
-      assert(redactedConfig.getString("nested.redacted") == ConfigReader.redactedReplacement)
-      assert(!redactedConfig.hasPath("redundant.key"))
+      redactedConfig.getString("top") shouldBe "default"
+      redactedConfig.getString("quoted") shouldBe "text"
+      redactedConfig.getInt("nested.value.num") shouldBe 100
+      redactedConfig.getString("nested.string") shouldBe "str"
+      redactedConfig.getString("redacted") shouldBe ConfigReader.redactedReplacement
+      redactedConfig.getString("nested.redacted") shouldBe ConfigReader.redactedReplacement
+      !redactedConfig.hasPath("redundant.key")
     }
   }
 

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/StringImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/StringImplicitsSuite.scala
@@ -16,9 +16,9 @@
 package za.co.absa.enceladus.utils.implicits
 
 import java.security.InvalidParameterException
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.enceladus.utils.implicits.StringImplicits.StringEnhancements
 
 class StringImplicitsSuite extends AnyFunSuite with Matchers {
@@ -305,5 +305,57 @@ class StringImplicitsSuite extends AnyFunSuite with Matchers {
     "".coalesce("", "", "B", "", "C") shouldBe "B"
     "X".coalesce("Y", "Z") shouldBe "X"
     "X".coalesce("") shouldBe "X"
+  }
+
+
+}
+
+class StringImplicitsSuite_Extra extends AnyWordSpec with Matchers {
+
+   "splitWithQuotes()" should {
+     "consider an empty string to be" when {
+       "an empty sequence when limit is 0" in {
+         "".splitWithQuotes() shouldBe Seq()
+       }
+       "a sequence of one empty string when limit is non-zero" in {
+         "".splitWithQuotes(limit = -1) shouldBe Seq("")
+       }
+     }
+     "ignore delimiters in quotes" in {
+       val expected = Seq(
+         "foo",
+         "bar",
+         """c;qual="baz,blurb"""",
+         """d;junk="quux,syzygy"""",
+         ""
+       )
+       """foo,bar,c;qual="baz,blurb",d;junk="quux,syzygy",""".splitWithQuotes(limit = -1) shouldBe expected
+     }
+     "handle other delimiter" in {
+       """just."an.other".test""".splitWithQuotes('.') shouldBe Seq("just", "\"an.other\"", "test")
+     }
+   }
+
+  "trimStartEndChar()" should {
+    "keep the empty string empty" in {
+      "".trimStartEndChar('<','>') shouldBe ""
+    }
+    "remove quotes" in {
+      "'Hello world!'".trimStartEndChar(''') shouldBe "Hello world!"
+    }
+    "remove brackets" in {
+      "[a, b, c]".trimStartEndChar('[', ']') shouldBe "a, b, c"
+    }
+    "keep the string as is" when {
+      "start and end characters differ" in {
+        "[a, b, c]".trimStartEndChar('{', '}') shouldBe "[a, b, c]"
+      }
+      "only the start character matches" in {
+        "(aaaa...".trimStartEndChar('(', ')') shouldBe "(aaaa..."
+      }
+      "only the end character matches" in {
+        "Wha`".trimStartEndChar('`') shouldBe "Wha`"
+      }
+    }
   }
 }


### PR DESCRIPTION
* `RestDaoFactory` and `CrossHostApiCaller` require a list of integers representing try accounts on the Urls
* _Standardization_, _Conformance_ and _HyperConformance_ changed to provide try counts to Dao, read from configuration
* `ConfigReader` enhanced and unified to read configurations more easily and universally
* `StringImplicits` inlcude new functions to process list-like strings

RN:
It's now possible to specify the number how many times a Menas Urs will be tried before proceeding to next one, This is set via a new optional configuration `menas.rest.uriTries` in a form of list of integers (comma delimited either in brackets or as a string in quotes).