### PR TITLE
#1968: Release standardized dataframe after its saving in the combined

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/StandardizationAndConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/StandardizationAndConformanceJob.scala
@@ -50,6 +50,7 @@ object StandardizationAndConformanceJob extends StandardizationAndConformanceExe
       processStandardizationResult(args, standardized, preparationResult, schema, cmd, menasCredentials)
       // post processing deliberately rereads the output to make sure that outputted data is stable #1538
       runPostProcessing(SourcePhase.Standardization, preparationResult, cmd)
+      standardized.unpersist()
 
       prepareConformance(preparationResult)
       val confInputData = readConformanceInputData(preparationResult.pathCfg)


### PR DESCRIPTION
* added unpersist after Standardization in` StandardizationAndConformanceJob.scala`

Closes #1968 

Release notes:
Releasing cached standardization data after its phase in the combined _Standardization&Conformance job_, reducing its memory requirement.