### PR TITLE
#1978 icons mixup corrected for filter edit

### DIFF
--- a/menas/ui/components/mappingTable/filterEdit/filterTreeEdit.fragment.xml
+++ b/menas/ui/components/mappingTable/filterEdit/filterTreeEdit.fragment.xml
@@ -28,9 +28,9 @@
                         <Menu>
                             <MenuItem id="addAndBtn" text="AND" icon="sap-icon://combine" />
                             <MenuItem id="addOrBtn" text="OR" icon="sap-icon://split" />
-                            <MenuItem id="addNotBtn" text="NOT" icon="sap-icon://filter" />
-                            <MenuItem id="addEqualsBtn" text="Equals" icon="sap-icon://clear-filter" />
-                            <MenuItem id="addDiffersBtn" text="Differs" icon="sap-icon://SAP-icons-TNT/solution-not-licensed" />
+                            <MenuItem id="addNotBtn" text="NOT" icon="sap-icon://SAP-icons-TNT/solution-not-licensed" />
+                            <MenuItem id="addEqualsBtn" text="Equals" icon="sap-icon://filter" />
+                            <MenuItem id="addDiffersBtn" text="Differs" icon="sap-icon://clear-filter" />
                             <MenuItem id="addIsNullBtn" text="IsNull" icon="sap-icon://SAP-icons-TNT/marquee" />
                         </Menu>
                     </menu>

--- a/menas/ui/service/FilterTreeUtils.js
+++ b/menas/ui/service/FilterTreeUtils.js
@@ -61,6 +61,10 @@ class FilterTreeUtils {
           filterNode.text = "OR";
           filterNode.icon = "sap-icon://split";
           break;
+        case "NotFilter":
+          filterNode.text = "NOT";
+          filterNode.icon = "sap-icon://SAP-icons-TNT/solution-not-licensed";
+          break;
         case "EqualsFilter":
           filterNode.text = `Value of "${filterNode.columnName}" equals to "${filterNode.value}" (of type ${filterNode.valueType})`;
           filterNode.icon = "sap-icon://filter";
@@ -68,10 +72,6 @@ class FilterTreeUtils {
         case "DiffersFilter":
           filterNode.text = `Value of "${filterNode.columnName}" differs from "${filterNode.value}" (of type ${filterNode.valueType})`;
           filterNode.icon = "sap-icon://clear-filter";
-          break;
-        case "NotFilter":
-          filterNode.text = "NOT";
-          filterNode.icon = "sap-icon://SAP-icons-TNT/solution-not-licensed";
           break;
         case "IsNullFilter":
           filterNode.text = `Value of "${filterNode.columnName}" is null`;


### PR DESCRIPTION
This PR solves the icons mixup for filter editing mentioned in #1978 :

![icons-mixup-before](https://user-images.githubusercontent.com/4457378/141265075-865e9921-cf0d-4062-a943-632f34913365.jpeg)
(⬆️ shows the mixed-up state prior to this PR)

Now, the icons are as intended and also conform to the icons used in filter view.

## Testrun
Filter editing now:
![icons-mixup-fix](https://user-images.githubusercontent.com/4457378/141265164-5eb49f16-da8f-441b-b8c5-f7997ad9835f.png)

Filter view (unchanged, just for reference):
![filter-view-icons](https://user-images.githubusercontent.com/4457378/141265208-52888ade-5819-4bff-98f2-e112435aac65.png)


Closes #1978 

## Suggested RN
Filter edit icons are now switched to better convey their expected meaning and to conform to the icons used in the filter view.