### PR TITLE
#1981 MCR title missing bugfix

### DIFF
--- a/menas/ui/components/dataset/conformanceRule/MappingConformanceRule/display.fragment.xml
+++ b/menas/ui/components/dataset/conformanceRule/MappingConformanceRule/display.fragment.xml
@@ -18,6 +18,10 @@
     <CustomListItem>
         <form:SimpleForm adjustLabelSpan="true" editable="false">
             <form:content>
+                <!-- normally, commonRuleFields.fragment.xml would be used here, but for MRC we need special content bc. of multiple outputs -->
+                <Title text="{=${order} + 1}. {_t}" level="H2"/>
+                <core:Fragment type="XML" fragmentName="components.dataset.conformanceRule.add.checkpointBox"/>
+
                 <Label text="Mapping Table"/>
                 <Link text="{mappingTable} (v{mappingTableVersion})" press="toMappingTable"
                       cust:name="{mappingTable}" cust:version="{mappingTableVersion}"/>


### PR DESCRIPTION
As outlined in issue #1981 description, a Mapping Conformance Rule title (with rule index) was missing in the _Conformance Rules view_. This PR aims to solve the issue and also adds the missing _Check Control Measures_ checkbox view (that was incidentally found missing, too).

## Background
The issue was most probably introduced in https://github.com/AbsaOSS/enceladus/pull/1721/files#L21 - where for the MCR, a functionality for multiple outputs was added.

It was correctly identified then that the original fragment (containing an indexed label, control measures checkbox, and single output view) was not usable anymore, because it forces single column output (the MCR view accounts displaying the output columns) - **so the fragment usage was removed, however, no suitable replacement was given - leaving the indexed title and checkbox missing.**

## Testrun/showcase:
![missing-mcr-title-fix](https://user-images.githubusercontent.com/4457378/142398342-3fdd07ee-0bbe-42eb-b741-6c2b4a0839d5.png)
(the expected title is in place alongside the _Check Control Measures_ checkbox view)

## Release notes suggestion
Bugfix: The _Conformance Rules_ view now correctly displays an indexed label and _Check Control Measures_ checkbox view for MappingConformanceRules (both missing since v2.22.0)


Closes #1981 