### PR TITLE
#1987: Repartitioning prevents processing of zero size files - ver. 2.25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,6 @@ build.log
 #  syntax: regexp
 #  ^\.pc/
 
-build.log
-
 .cache*
 dependency-reduced-pom.xml
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/common/CommonExecutionSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/common/CommonExecutionSuite.scala
@@ -15,6 +15,8 @@
 
 package za.co.absa.enceladus.common
 
+import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.mockito.Mockito
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
@@ -33,6 +35,9 @@ class CommonExecutionSuite extends AnyFlatSpec with Matchers with SparkTestBase 
       prepareJob()
     }
     override protected def validatePaths(pathConfig: PathConfig): Unit = {}
+    override def repartitionDataFrame(df:  DataFrame, minBlockSize: Option[Long], maxBlockSize: Option[Long])
+                                     (implicit spark: SparkSession): DataFrame =
+      super.repartitionDataFrame(df, minBlockSize, maxBlockSize)
   }
 
   Seq(
@@ -57,6 +62,16 @@ class CommonExecutionSuite extends AnyFlatSpec with Matchers with SparkTestBase 
         exceptionMessage should include(subMsg)
       }
     }
+  }
+
+  "repartitionDataFrame" should "pass on empty data" in {
+    val schema = new StructType()
+      .add("not_important", StringType, nullable = true)
+    val df = spark.read.schema(schema).parquet("src/test/resources/data/empty")
+    println(df.rdd.getNumPartitions)
+    val commonJob = new CommonJobExecutionTest
+    val result = commonJob.repartitionDataFrame(df, Option(1), Option(2))
+    result shouldBe df
   }
 
 }

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/testcasefactories/SimpleTestCaseFactory.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/testcasefactories/SimpleTestCaseFactory.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories
 
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.mockito.Mockito.{mock, when => mockWhen}
@@ -25,7 +25,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.{ConformanceRule, MappingConformanceRule}
 import za.co.absa.enceladus.model.test.factories.{DatasetFactory, MappingTableFactory}
 import za.co.absa.enceladus.model.{Dataset, DefaultValue, MappingTable}
-import za.co.absa.enceladus.utils.fs.{HadoopFsUtils, LocalFsUtils}
+import za.co.absa.enceladus.utils.fs.LocalFsUtils
 import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
 import za.co.absa.enceladus.utils.validation.ValidationLevel
 


### PR DESCRIPTION
* Handling 0 partition case in repartitioning
* .gitignore duplicate entry fixed

_Release notes:_
_Fixed issue when trying to repartition an empty dataset with 0 partitions._