### PR TITLE
#1998: Ensure log4j v2 at least 2.15.0

### DIFF
--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -124,6 +124,17 @@
             <version>${bson.codec.jsr310.version}</version>
         </dependency>
         <!-- SPRING -->
+        <!-- ensuring that log4j used us at least 2.15.0-->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
         <junit.version>4.11</junit.version>
         <kafka.spark.version>0-10</kafka.spark.version>
         <lodash.version>4.17.10</lodash.version>
+        <log4j.version>2.15.0</log4j.version>
         <mockito.core.version>3.5.2</mockito.core.version>
         <mockito.scala.version>1.16.42</mockito.scala.version>
         <momentjs.version>2.22.2</momentjs.version>

--- a/spark-jobs/pom.xml
+++ b/spark-jobs/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>
-        <hyperdrive.version>4.0.0</hyperdrive.version>
+        <hyperdrive.version>4.5.2</hyperdrive.version>
         <spark.sql.kafka.version>2.4.5</spark.sql.kafka.version>
     </properties>
 
@@ -75,7 +75,7 @@
         <!-- Hyperdrive -->
         <dependency>
             <groupId>za.co.absa.hyperdrive</groupId>
-            <artifactId>api</artifactId>
+            <artifactId>api_${scala.compat.version}</artifactId>
             <version>${hyperdrive.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
* Menas gets log4j via Spring, explicitly imported to ensure 2.15 is used
* Upgraded Hyperdrive in SparkJobs which already uses log4j 2.15

Fixes #1998