### PR TITLE
Feature/2017 propertydef migration

### DIFF
--- a/scripts/migration/menas_db.py
+++ b/scripts/migration/menas_db.py
@@ -213,16 +213,11 @@ class MenasDb(object):
         return self.get_distinct_entities_ids(schema_names, ATTACHMENT_COLLECTION, entity_name_field="refName",
                                               distinct_field="refName", migration_free_only=True)
 
-    def assemble_migration_free_propdefs_from_ds_names(self, ds_names: List[str]) -> List[str]:
-        prop_names = self.get_property_names_from_ds_names(ds_names)
-        # migration-free prop names
-        return self.get_distinct_entities_ids(prop_names, PROPERTY_DEF_COLLECTION, migration_free_only=True)
-
     def assemble_migration_free_propdefs_from_prop_names(self, prop_names: List[str]) -> List[str]:
         return self.get_distinct_entities_ids(prop_names, PROPERTY_DEF_COLLECTION, migration_free_only=True)
 
-    def assemble_all_migration_free_propdefs(self) -> List[str]:
-        return self.get_all_distinct_entities_ids(PROPERTY_DEF_COLLECTION, migration_free_only=True)
+    def assemble_all_propdefs(self, migration_free_only=True) -> List[str]:
+        return self.get_all_distinct_entities_ids(PROPERTY_DEF_COLLECTION, migration_free_only=migration_free_only)
 
     @staticmethod
     def get_database(conn_str: str, db_name: str) -> Database:

--- a/scripts/migration/migrate_menas.py
+++ b/scripts/migration/migrate_menas.py
@@ -301,8 +301,8 @@ def check_compatible_property_definitions(source_db: MenasDb, target_db: MenasDb
 
     diff = set(source_propdefs).difference(set(target_propdefs))
     if len(diff) != 0:
-        raise MenasDbCollectionError(f"Property definitions missing on target: {diff},"
-                                     " cannot continue dataset migration! "
+        raise MenasDbCollectionError("Property definition need to be migrated before Datasets are migrated. "
+                                     f"These PDs are missing on target: {diff}."
                                      "Migrate property definitions first (-p * or -p PDname1 PDname2 ...)")
 
 

--- a/scripts/migration/migrate_menas.py
+++ b/scripts/migration/migrate_menas.py
@@ -232,6 +232,9 @@ def migrate_collections_by_ds_names(source_db: MenasDb, target_db: MenasDb,
     migration_free_attachment_names = source_db.assemble_migration_free_attachments_from_schema_names(schemas_names_for_attachments)
     print('Attachments of schemas to migrate: {}'.format(migration_free_attachment_names))
 
+    migration_free_propdef_names = source_db.assemble_migration_free_propdefs_from_ds_names(ds_names)
+    print('Property definitions to migrate: {}'.format(migration_free_propdef_names))
+
     if not dryrun:
         print("")
         migrate_entities(source_db, target_db, SCHEMA_COLLECTION, all_migration_free_schemas, describe_default_entity, entity_name="schema", locking=True)
@@ -241,6 +244,8 @@ def migrate_collections_by_ds_names(source_db: MenasDb, target_db: MenasDb,
         migrate_entities(source_db, target_db, RUN_COLLECTION, run_unique_ids, describe_run_entity, entity_name="run", name_field="uniqueId")
         migrate_entities(source_db, target_db, ATTACHMENT_COLLECTION, migration_free_attachment_names,
                          describe_attachment_entity, entity_name="attachment", name_field="refName")
+        migrate_entities(source_db, target_db, PROPERTY_DEF_COLLECTION, migration_free_propdef_names,
+                         describe_default_entity, entity_name="property definition", locking=True)
     else:
         print("*** Dryrun selected, no actual migration will take place.")
 


### PR DESCRIPTION
~Property definitions are now part of by-dataset-names migration.~
 - ~entities are locked after successful migration~
 - ~non-locked property definitions are being found in datasets by name (even from not-locked datasets)~

 * Property definitions now have a separate mode of migration `-p`
 * DS migration contains a check that PDs of source must be found on target
   * currently not necessarily in the exact version - do we need to check target version to be == or >= to source PD version?

## Example run:

1. Initialize blank target db `mns2` first:
`./initialize_menas.py  mongodb://localhost:27017/admin -t mns2`
2. Migrate property definitions (here, using `-p *` for all PDs):
`./migrate_menas.py mongodb://localhost:27017/admin mongodb://localhost:27017/admin -s menas -p * -t mns2`
3. Now, datasets can be migrated:
`./migrate_menas.py mongodb://localhost:27017/admin mongodb://localhost:27017/admin -s menas -d mydataset1 mydataset2 -t mns2`

Merge after #2018 (based on it). just the last commit is relevant
Closes #2017 