### PR TITLE
#2027: Ensures TimezoneNormalizer is used in tests

### DIFF
--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/auth/MenasPlainCredentialsSuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/auth/MenasPlainCredentialsSuite.scala
@@ -18,9 +18,9 @@ package za.co.absa.enceladus.dao.rest.auth
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.enceladus.dao.auth.MenasPlainCredentials
 import za.co.absa.enceladus.utils.fs.LocalFsUtils
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class MenasPlainCredentialsSuite extends AnyWordSpec with SparkTestBase {
+class MenasPlainCredentialsSuite extends AnyWordSpec with TZNormalizedSparkTestBase {
 
   "MenasPlainCredentials" should {
     "be read from *.conf" in {

--- a/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/UppercaseCustomConformanceRuleSuite.scala
+++ b/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/UppercaseCustomConformanceRuleSuite.scala
@@ -23,9 +23,7 @@ import za.co.absa.enceladus.conformance.config.ConformanceConfig
 import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
-import za.co.absa.enceladus.utils.fs.HadoopFsUtils
-import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, TZNormalizedSparkTestBase}
 
 
 case class TestInputRow(id: Int, mandatoryString: String, nullableString: Option[String])
@@ -34,7 +32,7 @@ object TestOutputRow {
   def apply(input: TestInputRow, doneUpper: String): TestOutputRow = TestOutputRow(input.id, input.mandatoryString, input.nullableString, doneUpper)
 }
 
-class UppercaseCustomConformanceRuleSuite extends AnyFunSuite with SparkTestBase with MockitoSugar with HadoopFsTestBase {
+class UppercaseCustomConformanceRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with MockitoSugar with HadoopFsTestBase {
   import spark.implicits._
 
   implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)

--- a/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/XPadCustomConformanceRuleSuite.scala
+++ b/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/XPadCustomConformanceRuleSuite.scala
@@ -26,8 +26,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.dao.auth.MenasKerberosCredentials
 import za.co.absa.enceladus.dao.rest.{MenasConnectionStringParser, RestDaoFactory}
 import za.co.absa.enceladus.model.Dataset
-import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, TZNormalizedSparkTestBase}
 
 case class XPadTestInputRow(intField: Int, stringField: Option[String])
 case class XPadTestOutputRow(intField: Int, stringField: Option[String], targetField: String)
@@ -35,7 +34,7 @@ object XPadTestOutputRow {
   def apply(input: XPadTestInputRow, targetField: String): XPadTestOutputRow = XPadTestOutputRow(input.intField, input.stringField, targetField)
 }
 
-class LpadCustomConformanceRuleSuite extends AnyFunSuite with SparkTestBase with MockitoSugar with HadoopFsTestBase {
+class LpadCustomConformanceRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with MockitoSugar with HadoopFsTestBase {
   import spark.implicits._
 
   implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
@@ -179,7 +178,7 @@ class LpadCustomConformanceRuleSuite extends AnyFunSuite with SparkTestBase with
 }
 
 
-class RpadCustomConformanceRuleSuite extends AnyFunSuite with SparkTestBase with HadoopFsTestBase {
+class RpadCustomConformanceRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with HadoopFsTestBase {
 
   import spark.implicits._
 

--- a/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/builtin/errorsender/mq/KafkaErrorSenderPluginSuite.scala
+++ b/plugins-builtin/src/test/scala/za/co/absa/enceladus/plugins/builtin/errorsender/mq/KafkaErrorSenderPluginSuite.scala
@@ -16,7 +16,6 @@
 package za.co.absa.enceladus.plugins.builtin.errorsender.mq
 
 import java.time.Instant
-
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
@@ -32,10 +31,10 @@ import za.co.absa.enceladus.plugins.builtin.errorsender.mq.KafkaErrorSenderPlugi
 import za.co.absa.enceladus.plugins.builtin.errorsender.mq.kafka.KafkaErrorSenderPlugin
 import za.co.absa.enceladus.plugins.builtin.errorsender.params.ErrorSenderPluginParams
 import za.co.absa.enceladus.utils.modules.SourcePhase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
 
-class KafkaErrorSenderPluginSuite extends AnyFlatSpec with SparkTestBase with Matchers with BeforeAndAfterAll {
+class KafkaErrorSenderPluginSuite extends AnyFlatSpec with TZNormalizedSparkTestBase with Matchers with BeforeAndAfterAll {
 
   private val port = 6081
   private val wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(port))

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/utils/converters/SparkMenasSchemaConvertorSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/utils/converters/SparkMenasSchemaConvertorSuite.scala
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.databind.SerializationFeature
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.rest_api.models.rest.exceptions.SchemaParsingException
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class SparkMenasSchemaConvertorSuite extends AnyFunSuite with SparkTestBase {
+class SparkMenasSchemaConvertorSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
   private val objectMapper = new ObjectMapper()
     .registerModule(DefaultScalaModule)
     .registerModule(new JavaTimeModule())

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/common/CommonExecutionSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/common/CommonExecutionSuite.scala
@@ -25,10 +25,10 @@ import za.co.absa.enceladus.common.config.PathConfig
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.{Dataset, Validation}
 import za.co.absa.enceladus.standardization.config.StandardizationConfig
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.enceladus.utils.validation.ValidationLevel
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class CommonExecutionSuite extends AnyFlatSpec with Matchers with SparkTestBase with MockitoSugar {
+class CommonExecutionSuite extends AnyFlatSpec with Matchers with TZNormalizedSparkTestBase with MockitoSugar {
 
   private class CommonJobExecutionTest extends CommonJobExecution {
     def testRun(implicit dao: MenasDAO, cmd: StandardizationConfig): PreparationResult = {

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/common/RecordIdGenerationSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/common/RecordIdGenerationSuite.scala
@@ -16,16 +16,15 @@
 package za.co.absa.enceladus.common
 
 import java.util.UUID
-
 import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigValueFactory}
 import za.co.absa.enceladus.common.RecordIdGenerationSuite.{SomeData, SomeDataWithId}
 import RecordIdGeneration._
 import IdType._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class RecordIdGenerationSuite extends AnyFlatSpec with Matchers with SparkTestBase {
+class RecordIdGenerationSuite extends AnyFlatSpec with Matchers with TZNormalizedSparkTestBase {
   import spark.implicits._
 
   val data1 = Seq(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/config/ConformanceParserSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/config/ConformanceParserSuite.scala
@@ -16,14 +16,13 @@
 package za.co.absa.enceladus.conformance.config
 
 import java.time.ZonedDateTime
-
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.ConformanceExecution
 import za.co.absa.enceladus.dao.auth.{MenasKerberosCredentials, MenasPlainCredentials}
 import za.co.absa.enceladus.model.Dataset
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class ConformanceParserSuite extends AnyFunSuite with SparkTestBase {
+class ConformanceParserSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
 
   private val year = "2018"
   private val month = "12"

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/datasource/DatasourceSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/datasource/DatasourceSuite.scala
@@ -19,9 +19,9 @@ import org.apache.spark.sql.types.IntegerType
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.samples.EmployeeConformance
 import za.co.absa.enceladus.model.dataFrameFilter._
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class DatasourceSuite extends AnyFunSuite with SparkTestBase {
+class DatasourceSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
 
   test("Data Source loads all data needed for test sample") {
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ArrayConformanceSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ArrayConformanceSuite.scala
@@ -23,11 +23,10 @@ import za.co.absa.enceladus.conformance.config.ConformanceConfig
 import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.conformance.samples._
 import za.co.absa.enceladus.dao.MenasDAO
-import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, TZNormalizedSparkTestBase}
 
 
-class ArrayConformanceSuite extends AnyFunSuite with SparkTestBase with BeforeAndAfterAll with HadoopFsTestBase {
+class ArrayConformanceSuite extends AnyFunSuite with TZNormalizedSparkTestBase with BeforeAndAfterAll with HadoopFsTestBase {
 
   import spark.implicits._
   // spark.enableControlFrameworkTracking()

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/ChorusMockSuite.scala
@@ -22,15 +22,14 @@ import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.MappingConformanceRule
 import za.co.absa.enceladus.model.{MappingTable, Dataset => ConfDataset}
-import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase}
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 
 case class MyMappingTable(id: Int, mappedAttr: MyMappingTableInner)
 case class MyMappingTableInner(description: String, name: String)
 case class MyData(id: Int, toJoin: Int)
 case class MyDataConfd(id: Int, toJoin: Int, confMapping: MyMappingTableInner)
 
-class ChorusMockSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with HadoopFsTestBase {
+class ChorusMockSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with HadoopFsTestBase {
 
   def testChorusMockData(useExperimentalMappingRule: Boolean): Unit = {
     val d = Seq(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -27,11 +27,10 @@ import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.conformance.samples._
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.utils.fs.FileReader
-import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase}
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.validation.ValidationLevel
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class InterpreterSuite extends AnyFunSuite with SparkTestBase with BeforeAndAfterAll with LoggerTestBase with HadoopFsTestBase {
+class InterpreterSuite extends AnyFunSuite with TZNormalizedSparkTestBase with BeforeAndAfterAll with LoggerTestBase with HadoopFsTestBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/LiteralJoinMappingRuleTest.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/LiteralJoinMappingRuleTest.scala
@@ -22,10 +22,9 @@ import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.{DropConformanceRule, LiteralConformanceRule, MappingConformanceRule}
 import za.co.absa.enceladus.model.{MappingTable, Dataset => ConfDataset}
-import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase}
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 
-class LiteralJoinMappingRuleTest extends AnyFunSuite with SparkTestBase with LoggerTestBase with HadoopFsTestBase {
+class LiteralJoinMappingRuleTest extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with HadoopFsTestBase {
 
   def testMappingRuleWithLiteral(useExperimentalMappingRule: Boolean): Unit = {
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/NestedStructSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/NestedStructSuite.scala
@@ -17,15 +17,14 @@ package za.co.absa.enceladus.conformance.interpreter
 
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.interpreter.fixtures.NestedStructsFixture
-import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, TZNormalizedSparkTestBase}
 
 /**
   * The purpose of these tests is to ensure Catalyst optimizer issue is handled.
   *
   * Without applying a workaround any test in this suite makes Spark freeze.
   */
-class NestedStructSuite extends AnyFunSuite with SparkTestBase with NestedStructsFixture with HadoopFsTestBase {
+class NestedStructSuite extends AnyFunSuite with TZNormalizedSparkTestBase with NestedStructsFixture with HadoopFsTestBase {
 
   test("Test Dynamic Conformance does not hang on many mixed conformance rules") {
     implicit val featureSwitches: FeatureSwitches = FeatureSwitches()

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/MultipleMappingFixture.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/MultipleMappingFixture.scala
@@ -16,7 +16,6 @@
 package za.co.absa.enceladus.conformance.interpreter.fixtures
 
 import java.io.File
-
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.types.{StructField, StructType}
@@ -30,12 +29,12 @@ import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.{Dataset, MappingTable}
 import za.co.absa.enceladus.model.conformanceRule._
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
 import scala.io.Source.fromFile
 import scala.util.control.NonFatal
 
-trait MultipleMappingFixture extends BeforeAndAfterAll with SparkTestBase {
+trait MultipleMappingFixture extends BeforeAndAfterAll with TZNormalizedSparkTestBase {
 
   this: Suite =>
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/NestedStructsFixture.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/NestedStructsFixture.scala
@@ -16,7 +16,6 @@
 package za.co.absa.enceladus.conformance.interpreter.fixtures
 
 import java.io.File
-
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.mockito.Mockito.{mock, when => mockWhen}
@@ -27,12 +26,12 @@ import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule._
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.enceladus.utils.validation.ValidationLevel
-import za.co.absa.spark.commons.test.SparkTestBase
 
 import scala.util.control.NonFatal
 
-trait NestedStructsFixture extends BeforeAndAfterAll with SparkTestBase {
+trait NestedStructsFixture extends BeforeAndAfterAll with TZNormalizedSparkTestBase {
 
   this: Suite =>
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/StreamingFixture.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/fixtures/StreamingFixture.scala
@@ -30,9 +30,9 @@ import za.co.absa.enceladus.conformance.interpreter.FeatureSwitches
 import za.co.absa.enceladus.conformance.streaming.{InfoDateFactory, InfoVersionFactory}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-trait StreamingFixture extends AnyFunSuite with SparkTestBase with MockitoSugar {
+trait StreamingFixture extends AnyFunSuite with TZNormalizedSparkTestBase with MockitoSugar {
   private val menasBaseUrls = List.empty[String]
   implicit val cmd: ConformanceConfig = ConformanceConfig(reportVersion = Some(1), reportDate = "2020-03-23")
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
@@ -23,12 +23,11 @@ import za.co.absa.enceladus.conformance.config.ConformanceConfig
 import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches, RuleValidators}
 import za.co.absa.enceladus.conformance.samples.CastingRuleSamples
 import za.co.absa.enceladus.dao.MenasDAO
-import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase}
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.validation.ValidationLevel
 import za.co.absa.spark.commons.utils.JsonUtils
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class CastingRuleSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with HadoopFsTestBase {
+class CastingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with HadoopFsTestBase {
   private val ruleName = "Casting rule"
   private val columnName = "dummy"
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CoalesceRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CoalesceRuleSuite.scala
@@ -21,7 +21,7 @@ import CoalesceRuleSuite._
 import za.co.absa.enceladus.conformance.samples.DeepArraySamples
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule.{CoalesceConformanceRule, DropConformanceRule, LiteralConformanceRule}
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
 object CoalesceRuleSuite {
   private case class ShopItem(id: String, itemName: String, itemDescription: String, qty: Long)
@@ -83,7 +83,7 @@ object CoalesceRuleSuite {
   )
 }
 
-class CoalesceRuleSuite extends AnyFunSuite with SparkTestBase with TestRuleBehaviors {
+class CoalesceRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with TestRuleBehaviors {
   test("Coalesce conformance rule on root level fields") {
     val inputDf: DataFrame = spark.createDataFrame(shopItems)
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/ConcatenationRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/ConcatenationRuleSuite.scala
@@ -20,9 +20,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.samples.DeepArraySamples
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule.{ConcatenationConformanceRule, UppercaseConformanceRule}
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class ConcatenationRuleSuite extends AnyFunSuite with SparkTestBase with TestRuleBehaviors {
+class ConcatenationRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with TestRuleBehaviors {
   private val concatRule = ConcatenationConformanceRule(order = 1, outputColumn = "CombinedName",
     controlCheckpoint = false, Seq("name", "city", "address"))
   private val concatArrayRule = ConcatenationConformanceRule(order = 2, outputColumn = "rooms.CombinedLabel",

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/DropRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/DropRuleSuite.scala
@@ -21,9 +21,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.samples.DeepArraySamples
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule.DropConformanceRule
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class DropRuleSuite extends AnyFunSuite with SparkTestBase with TestRuleBehaviors {
+class DropRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with TestRuleBehaviors {
   // scalastyle:off line.size.limit
 
   private val dropRule = DropConformanceRule(order = 1, controlCheckpoint = false, outputColumn = "name" )

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/FillNullsRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/FillNullsRuleSuite.scala
@@ -20,9 +20,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.samples.DeepArraySamples
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule.FillNullsConformanceRule
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class FillNullsRuleSuite extends AnyFunSuite with SparkTestBase with TestRuleBehaviors {
+class FillNullsRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with TestRuleBehaviors {
   // scalastyle:off line.size.limit
 
   private val fillNullsRule = FillNullsConformanceRule(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/LiteralRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/LiteralRuleSuite.scala
@@ -20,9 +20,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.samples.DeepArraySamples
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule.LiteralConformanceRule
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class LiteralRuleSuite extends AnyFunSuite with SparkTestBase with TestRuleBehaviors {
+class LiteralRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with TestRuleBehaviors {
   // scalastyle:off line.size.limit
 
   private val literalRule = LiteralConformanceRule(order = 1, outputColumn = "System", controlCheckpoint = false, value = "FA")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
@@ -24,11 +24,10 @@ import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, Feature
 import za.co.absa.enceladus.conformance.samples.NegationRuleSamples
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.{Dataset => ConfDataset}
-import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase}
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.validation.ValidationLevel
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class NegationRuleSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with HadoopFsTestBase {
+class NegationRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with HadoopFsTestBase {
 
   import spark.implicits._
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/RuleOptimizationSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/RuleOptimizationSuite.scala
@@ -21,10 +21,9 @@ import za.co.absa.enceladus.conformance.interpreter.rules.mapping.MappingRuleInt
 import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches, InterpreterContext, Never}
 import za.co.absa.enceladus.model.conformanceRule.{ConformanceRule, MappingConformanceRule}
 import za.co.absa.enceladus.conformance.samples.TradeConformance._
-import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, TZNormalizedSparkTestBase}
 
-class RuleOptimizationSuite extends AnyFunSuite with SparkTestBase with HadoopFsTestBase{
+class RuleOptimizationSuite extends AnyFunSuite with TZNormalizedSparkTestBase with HadoopFsTestBase{
 
   private val schemaJson =
     """{

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/RulesSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/RulesSuite.scala
@@ -24,10 +24,10 @@ import za.co.absa.enceladus.conformance.interpreter.{ExplosionState, Interpreter
 import za.co.absa.enceladus.conformance.samples.EmployeeConformance
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.ConformanceRule
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
 
-class RulesSuite extends AnyFunSuite with SparkTestBase {
+class RulesSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
 
   private val dummyInterpreter = new RuleInterpreter {
     override def conformanceRule: Option[ConformanceRule] = None

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/SingleColumnRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/SingleColumnRuleSuite.scala
@@ -20,9 +20,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.samples.DeepArraySamples
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule.SingleColumnConformanceRule
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class SingleColumnRuleSuite extends AnyFunSuite with SparkTestBase with TestRuleBehaviors {
+class SingleColumnRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with TestRuleBehaviors {
   // scalastyle:off line.size.limit
 
   private val singleColumnRule = SingleColumnConformanceRule(order = 1, controlCheckpoint = false, "conformedId", "id", "id2")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/SparkSessionRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/SparkSessionRuleSuite.scala
@@ -19,9 +19,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.samples.DeepArraySamples
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule.SparkSessionConfConformanceRule
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class SparkSessionRuleSuite extends AnyFunSuite with SparkTestBase with TestRuleBehaviors {
+class SparkSessionRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with TestRuleBehaviors {
   // scalastyle:off line.size.limit
 
   private val sparkSessionRule = SparkSessionConfConformanceRule(order = 1, outputColumn = "TimeZone", controlCheckpoint = false, sparkConfKey = "spark.sql.session.timeZone")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/TestRuleBehaviors.scala
@@ -23,11 +23,10 @@ import za.co.absa.enceladus.conformance.config.ConformanceConfig
 import za.co.absa.enceladus.conformance.interpreter.{DynamicInterpreter, FeatureSwitches}
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
-import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase}
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.validation.ValidationLevel
-import za.co.absa.spark.commons.test.SparkTestBase
 
-trait TestRuleBehaviors  extends AnyFunSuite with SparkTestBase with LoggerTestBase with HadoopFsTestBase {
+trait TestRuleBehaviors  extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with HadoopFsTestBase {
 
   def conformanceRuleShouldMatchExpected(inputDf: DataFrame,
                                          inputDataset: Dataset,

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/UppercaseRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/UppercaseRuleSuite.scala
@@ -20,9 +20,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.samples.DeepArraySamples
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule.UppercaseConformanceRule
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class UppercaseRuleSuite extends AnyFunSuite with SparkTestBase with TestRuleBehaviors {
+class UppercaseRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with TestRuleBehaviors {
   // scalastyle:off line.size.limit
 
   private val uppercaseRule = UppercaseConformanceRule(order = 1, outputColumn = "ConformedName", controlCheckpoint = false, inputColumn = "name")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/custom/CustomRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/custom/CustomRuleSuite.scala
@@ -26,15 +26,14 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.conformanceRule.ConformanceRule
 import za.co.absa.enceladus.model.{conformanceRule, Dataset => ConfDataset}
 import za.co.absa.enceladus.utils.error.ErrorMessage
-import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, TZNormalizedSparkTestBase}
 
 case class MyCustomRule(
   order:             Int,
   outputColumn:      String,
   controlCheckpoint: Boolean, // this requires manual instantiation of control framework
   myCustomField:     String) extends CustomConformanceRule {
-  def getInterpreter() = MyCustomRuleInterpreter(this)
+  def getInterpreter(): MyCustomRuleInterpreter = MyCustomRuleInterpreter(this)
 
   override def withUpdatedOrder(newOrder: Int): conformanceRule.ConformanceRule = copy(order = newOrder)
 }
@@ -57,7 +56,7 @@ case class MyCustomRuleInterpreter(rule: MyCustomRule) extends RuleInterpreter {
 case class Mine(id: Int)
 case class MineConfd(id: Int, myOutputCol: Double, errCol: Seq[ErrorMessage])
 
-class CustomRuleSuite extends AnyFunSuite with SparkTestBase with HadoopFsTestBase  {
+class CustomRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with HadoopFsTestBase  {
   import spark.implicits._
 
   // we may WANT to enable control framework & spline here
@@ -70,7 +69,7 @@ class CustomRuleSuite extends AnyFunSuite with SparkTestBase with HadoopFsTestBa
 
   val inputData: DataFrame = spark.createDataFrame(Seq(Mine(1), Mine(4), Mine(9), Mine(16)))
 
-  val conformanceDef = ConfDataset(
+  val conformanceDef: ConfDataset = ConfDataset(
     name = "My dummy conformance workflow", // whatever here
     version = 0, //whatever here
     hdfsPath = "/a/b/c",

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/JoinMappingRuleInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/JoinMappingRuleInterpreterSuite.scala
@@ -20,9 +20,9 @@ import za.co.absa.enceladus.conformance.datasource.DataSource
 import za.co.absa.enceladus.conformance.interpreter.rules.ValidationException
 import za.co.absa.enceladus.conformance.samples.EmployeeConformance
 import za.co.absa.enceladus.model.conformanceRule.MappingConformanceRule
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class JoinMappingRuleInterpreterSuite extends AnyFunSuite with SparkTestBase {
+class JoinMappingRuleInterpreterSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
   test("Mapping rule fields existence validation test") {
 
     val df = DataSource.getDataFrame(EmployeeConformance.employeeDS.hdfsPath, "2017-11-01", "{0}/{1}/{2}")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingInterpreterSuite.scala
@@ -19,10 +19,9 @@ import org.apache.commons.io.IOUtils
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.{NestedTestCaseFactory, SimpleTestCaseFactory}
-import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase}
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 
-trait MappingInterpreterSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with BeforeAndAfterAll with HadoopFsTestBase{
+trait MappingInterpreterSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with BeforeAndAfterAll with HadoopFsTestBase{
 
   protected val simpleTestCaseFactory = new SimpleTestCaseFactory()
   protected val nestedTestCaseFactory = new NestedTestCaseFactory()

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleSuite.scala
@@ -21,10 +21,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
 import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.SimpleTestCaseFactory
 import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.SimpleTestCaseFactory._
-import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase}
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 
-class MappingRuleSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with BeforeAndAfterAll with HadoopFsTestBase {
+class MappingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with BeforeAndAfterAll with HadoopFsTestBase {
   private val testCaseFactory = new SimpleTestCaseFactory()
 
   override def beforeAll(): Unit = {

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolAsciiSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolAsciiSuite.scala
@@ -24,11 +24,11 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.standardization.fixtures.TempFileFixture
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
+
 import java.nio.charset.StandardCharsets
 
-import za.co.absa.spark.commons.test.SparkTestBase
-
-class StandardizationCobolAsciiSuite extends FixtureAnyFunSuite with SparkTestBase with TempFileFixture with MockitoSugar {
+class StandardizationCobolAsciiSuite extends FixtureAnyFunSuite with TZNormalizedSparkTestBase with TempFileFixture with MockitoSugar {
 
   type FixtureParam = String
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolEbcdicSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationCobolEbcdicSuite.scala
@@ -24,9 +24,9 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.standardization.fixtures.TempFileFixture
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class StandardizationCobolEbcdicSuite extends FixtureAnyFunSuite with SparkTestBase with TempFileFixture with MockitoSugar {
+class StandardizationCobolEbcdicSuite extends FixtureAnyFunSuite with TZNormalizedSparkTestBase with TempFileFixture with MockitoSugar {
 
   type FixtureParam = String
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationExecutionSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationExecutionSuite.scala
@@ -17,7 +17,6 @@ package za.co.absa.enceladus.standardization
 
 import java.io.File
 import java.nio.file.Files
-
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
@@ -43,13 +42,12 @@ import za.co.absa.enceladus.model.{Dataset, Run, SplineReference}
 import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.utils.config.PathWithFs
 import za.co.absa.enceladus.utils.fs.FileReader
-import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
-import za.co.absa.spark.commons.test.SparkTestBase
 
 import scala.util.control.NonFatal
 
-class StandardizationExecutionSuite extends AnyFlatSpec with Matchers with SparkTestBase with HadoopFsTestBase with MockitoSugar {
+class StandardizationExecutionSuite extends AnyFlatSpec with Matchers with TZNormalizedSparkTestBase with HadoopFsTestBase with MockitoSugar {
 
   private implicit val defaults: Defaults = GlobalDefaults
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationFixedWidthSuite.scala
@@ -24,12 +24,12 @@ import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
 import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
 import za.co.absa.enceladus.utils.fs.FileReader
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationFixedWidthSuite extends AnyFunSuite with SparkTestBase with MockitoSugar{
+class StandardizationFixedWidthSuite extends AnyFunSuite with TZNormalizedSparkTestBase with MockitoSugar{
   private implicit val udfLibrary: UDFLibrary = new UDFLibrary()
   private val argsBase = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
     "--menas-auth-keytab src/test/resources/user.keytab.example " +

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationJsonSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationJsonSuite.scala
@@ -24,12 +24,12 @@ import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
 import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
 import za.co.absa.enceladus.utils.fs.FileReader
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationJsonSuite extends AnyFunSuite with SparkTestBase with MockitoSugar{
+class StandardizationJsonSuite extends AnyFunSuite with TZNormalizedSparkTestBase with MockitoSugar{
   private implicit val udfLibrary:UDFLibrary = new UDFLibrary()
   private implicit val defaults: Defaults = GlobalDefaults
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationParquetSuite.scala
@@ -16,7 +16,6 @@
 package za.co.absa.enceladus.standardization
 
 import java.util.UUID
-
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.FixtureAnyFunSuite
@@ -32,10 +31,10 @@ import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserExcepti
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import org.apache.spark.sql.functions.{col, to_timestamp}
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationParquetSuite extends FixtureAnyFunSuite with SparkTestBase with TempFileFixture with MockitoSugar  {
+class StandardizationParquetSuite extends FixtureAnyFunSuite with TZNormalizedSparkTestBase with TempFileFixture with MockitoSugar  {
   type FixtureParam = String
 
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationRerunSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationRerunSuite.scala
@@ -16,7 +16,6 @@
 package za.co.absa.enceladus.standardization
 
 import java.nio.charset.StandardCharsets
-
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -29,12 +28,12 @@ import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.standardization.fixtures.TempFileFixture
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
 import za.co.absa.enceladus.utils.error.ErrorMessage
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.ValidationException
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationRerunSuite extends FixtureAnyFunSuite with SparkTestBase with TempFileFixture with MockitoSugar {
+class StandardizationRerunSuite extends FixtureAnyFunSuite with TZNormalizedSparkTestBase with TempFileFixture with MockitoSugar {
 
   import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationXmlSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationXmlSuite.scala
@@ -25,12 +25,12 @@ import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
 import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationXmlSuite extends AnyFunSuite with SparkTestBase with MockitoSugar{
+class StandardizationXmlSuite extends AnyFunSuite with TZNormalizedSparkTestBase with MockitoSugar{
   private implicit val udfLibrary:UDFLibrary = new UDFLibrary()
   private implicit val defaults: Defaults = GlobalDefaults
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/config/StandardizationParserSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/config/StandardizationParserSuite.scala
@@ -16,14 +16,13 @@
 package za.co.absa.enceladus.standardization.config
 
 import java.time.ZonedDateTime
-
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.dao.auth.{MenasKerberosCredentials, MenasPlainCredentials}
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.StandardizationExecution
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class StandardizationParserSuite extends AnyFunSuite with SparkTestBase {
+class StandardizationParserSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
 
   private val year = "2018"
   private val month = "12"

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/csv/NullValueStandardizationCsvSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/csv/NullValueStandardizationCsvSuite.scala
@@ -18,7 +18,6 @@ package za.co.absa.enceladus.standardization.csv
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.funsuite.AnyFunSuite
-import za.co.absa.atum.utils.SparkTestBase
 import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.StandardizationPropertiesProvider
@@ -26,11 +25,12 @@ import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
 import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
 import za.co.absa.enceladus.utils.fs.FileReader
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 
-class NullValueStandardizationCsvSuite  extends AnyFunSuite with SparkTestBase with MockitoSugar {
+class NullValueStandardizationCsvSuite  extends AnyFunSuite with TZNormalizedSparkTestBase with MockitoSugar {
   private implicit val udfLibrary: UDFLibrary = new UDFLibrary()
   private val argsBase = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
     "--menas-auth-keytab src/test/resources/user.keytab.example --raw-format csv --delimiter :")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/csv/WhiteSpaceStandardizationCsvSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/csv/WhiteSpaceStandardizationCsvSuite.scala
@@ -25,13 +25,13 @@ import za.co.absa.enceladus.standardization.config.StandardizationConfig
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreter
 import za.co.absa.enceladus.standardization.interpreter.stages.PlainSchemaGenerator
 import za.co.absa.enceladus.utils.fs.FileReader
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
 case class Person(id: String, first_name: String, last_name: String)
 
-class WhiteSpaceStandardizationCsvSuite  extends AnyFunSuite with SparkTestBase with MockitoSugar {
+class WhiteSpaceStandardizationCsvSuite  extends AnyFunSuite with TZNormalizedSparkTestBase with MockitoSugar {
   private implicit val udfLibrary: UDFLibrary = new UDFLibrary()
   private val argsBase = ("--dataset-name Foo --dataset-version 1 --report-date 2020-06-22 --report-version 1 " +
     "--menas-auth-keytab src/test/resources/user.keytab.example --raw-format csv --delimiter :")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/fixtures/CsvFileFixture.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/fixtures/CsvFileFixture.scala
@@ -17,7 +17,6 @@ package za.co.absa.enceladus.standardization.fixtures
 
 import java.io.File
 import java.nio.charset.{Charset, StandardCharsets}
-
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.mockito.scalatest.MockitoSugar
@@ -25,9 +24,9 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.standardization.StandardizationPropertiesProvider
 import za.co.absa.enceladus.standardization.config.StandardizationConfig
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-trait CsvFileFixture extends MockitoSugar with TempFileFixture with SparkTestBase {
+trait CsvFileFixture extends MockitoSugar with TempFileFixture with TZNormalizedSparkTestBase {
   private implicit val dao: MenasDAO = mock[MenasDAO]
   private val standardizationReader = new StandardizationPropertiesProvider()
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/CounterPartySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/CounterPartySuite.scala
@@ -18,15 +18,14 @@ package za.co.absa.enceladus.standardization.interpreter
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.utils.error.ErrorMessage
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
 case class Root(ConformedParty: Party, errCol: Seq[ErrorMessage] = Seq.empty)
 case class Party(key: Integer, clientKeys1: Seq[String], clientKeys2: Seq[String])
 
-class CounterPartySuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class CounterPartySuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
 
   private implicit val defaults: Defaults = GlobalDefaults
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/DateTimeSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/DateTimeSuite.scala
@@ -16,7 +16,6 @@
 package za.co.absa.enceladus.standardization.interpreter
 
 import java.sql.{Date, Timestamp}
-
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.scalatest.funsuite.AnyFunSuite
@@ -24,15 +23,14 @@ import za.co.absa.enceladus.standardization.interpreter.stages.SchemaChecker
 import za.co.absa.enceladus.standardization.samples.TestSamples
 import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.fs.FileReader
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.field.FieldValidationFailure
 import za.co.absa.enceladus.utils.validation.{SchemaValidator, ValidationError, ValidationException, ValidationWarning}
-import za.co.absa.spark.commons.test.SparkTestBase
 
 
-class DateTimeSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class DateTimeSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
 
   private implicit val defaults: Defaults = GlobalDefaults

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/SampleDataSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/SampleDataSuite.scala
@@ -19,12 +19,11 @@ import org.apache.spark.sql.types.{DataType, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.standardization.samples.{StdEmployee, TestSamples}
 import za.co.absa.enceladus.utils.fs.FileReader
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class SampleDataSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class SampleDataSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   private implicit val defaults: Defaults = GlobalDefaults
 
   test("Simple Example Test") {

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -20,13 +20,12 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.standardization.interpreter.StandardizationInterpreterSuite._
 import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.fs.FileReader
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.spark.commons.utils.JsonUtils
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationInterpreterSuite  extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class StandardizationInterpreterSuite  extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
@@ -19,16 +19,15 @@ import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.enceladus.common.error.ErrorMessageFactory
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.ValidationException
 import za.co.absa.spark.commons.utils.JsonUtils
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with Matchers {
+class StandardizationInterpreter_ArraySuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with Matchers {
   import spark.implicits._
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
@@ -19,13 +19,12 @@ import org.apache.spark.sql.types.{BinaryType, Metadata, MetadataBuilder, Struct
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.enceladus.utils.error.ErrorMessage
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.ValidationException
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with Matchers {
+class StandardizationInterpreter_BinarySuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with Matchers {
 
   import spark.implicits._
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -16,16 +16,14 @@
 package za.co.absa.enceladus.standardization.interpreter
 
 import java.sql.Date
-
 import org.apache.spark.sql.types.{DateType, MetadataBuilder, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.utils.error.ErrorMessage
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
@@ -17,17 +17,15 @@ package za.co.absa.enceladus.standardization.interpreter
 
 import java.text.{DecimalFormat, NumberFormat}
 import java.util.Locale
-
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.schema.MetadataKeys
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -19,12 +19,11 @@ import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.schema.MetadataKeys
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
@@ -17,17 +17,15 @@ package za.co.absa.enceladus.standardization.interpreter
 
 import java.text.{DecimalFormat, NumberFormat}
 import java.util.Locale
-
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.schema.MetadataKeys
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase{
+class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase{
 
   import spark.implicits._
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -16,16 +16,14 @@
 package za.co.absa.enceladus.standardization.interpreter
 
 import java.sql.Timestamp
-
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType, TimestampType}
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.utils.error.ErrorMessage
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StdInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StdInterpreterSuite.scala
@@ -16,15 +16,13 @@
 package za.co.absa.enceladus.standardization.interpreter
 
 import java.sql.{Date, Timestamp}
-
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.utils.error.ErrorMessage
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
 case class ErrorPreserve(a: String, b: String, errCol: List[ErrorMessage])
 case class ErrorPreserveStd(a: String, b: Int, errCol: List[ErrorMessage])
@@ -36,7 +34,7 @@ case class MyWrapperStd(counterparty: MyHolder, errCol: Seq[ErrorMessage])
 case class Time(id: Int, date: String, timestamp: String)
 case class StdTime(id: Int, date: Date, timestamp: Timestamp, errCol: List[ErrorMessage])
 
-class StdInterpreterSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
+class StdInterpreterSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
   private implicit val defaults: Defaults = GlobalDefaults
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/PlainSchemaGeneratorSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/PlainSchemaGeneratorSuite.scala
@@ -17,9 +17,9 @@ package za.co.absa.enceladus.standardization.interpreter.stages
 
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class PlainSchemaGeneratorSuite extends AnyFunSuite with SparkTestBase {
+class PlainSchemaGeneratorSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
   private val schema = StructType(Seq(
     StructField("a", IntegerType, nullable = false),
     StructField("b", IntegerType, nullable = false, new MetadataBuilder().putString("meta", "data").build),

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/SchemaCheckerSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/SchemaCheckerSuite.scala
@@ -18,9 +18,9 @@ package za.co.absa.enceladus.standardization.interpreter.stages
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.utils.fs.FileReader
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class SchemaCheckerSuite extends AnyFunSuite with SparkTestBase {
+class SchemaCheckerSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
   test("Bug") {
     val sourceFile = FileReader.readFileAsString("src/test/resources/data/bug.json")
     val schema = DataType.fromJson(sourceFile).asInstanceOf[StructType]

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuite.scala
@@ -17,15 +17,13 @@ package za.co.absa.enceladus.standardization.interpreter.stages
 
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
-import za.co.absa.enceladus.utils.types.TypedStructField.TypedStructFieldTagged
-import za.co.absa.enceladus.utils.types.parsers.NumericParser
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.{UDFLibrary, UDFResult}
-import za.co.absa.spark.commons.test.SparkTestBase
 
 import scala.util.Success
 
-class TypeParserSuite extends AnyFunSuite with SparkTestBase {
+class TypeParserSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary
   private implicit val defaults: Defaults = GlobalDefaults

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuiteTemplate.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/stages/TypeParserSuiteTemplate.scala
@@ -17,18 +17,17 @@ package za.co.absa.enceladus.standardization.interpreter.stages
 
 import java.security.InvalidParameterException
 import java.sql.{Date, Timestamp}
-
 import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.enceladus.standardization.interpreter.dataTypes.ParseOutput
 import za.co.absa.enceladus.standardization.interpreter.stages.TypeParserSuiteTemplate._
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.enceladus.utils.time.DateTimePattern
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults, TypedStructField}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
-import za.co.absa.spark.commons.test.SparkTestBase
 
-trait TypeParserSuiteTemplate extends AnyFunSuite with SparkTestBase {
+trait TypeParserSuiteTemplate extends AnyFunSuite with TZNormalizedSparkTestBase {
 
   private implicit val udfLib: UDFLibrary = new UDFLibrary
   private implicit val defaults: Defaults = GlobalDefaults

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/TZNormalizedSparkTestBase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/TZNormalizedSparkTestBase.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.utils.testUtils
+
+import org.apache.spark.sql.SparkSession
+import za.co.absa.enceladus.utils.time.TimeZoneNormalizer
+import za.co.absa.spark.commons.test.{SparkTestBase, SparkTestConfig}
+
+trait TZNormalizedSparkTestBase extends SparkTestBase {
+  override protected def initSpark(implicit sparkConfig: SparkTestConfig): SparkSession = {
+    val result = super.initSpark
+
+    //TODO make conditional on empty SparkTestBase.timezone, once SparkCommons 0.3.0 will have been released
+    TimeZoneNormalizer.normalizeAll(result)
+
+    result
+  }
+}

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/broadcast/BroadcastUtilsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/broadcast/BroadcastUtilsSuite.scala
@@ -19,12 +19,11 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.enceladus.utils.error.Mapping
-import za.co.absa.enceladus.utils.testUtils.LoggerTestBase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 
 import scala.collection.mutable
 
-class BroadcastUtilsSuite extends AnyWordSpec with SparkTestBase with LoggerTestBase {
+class BroadcastUtilsSuite extends AnyWordSpec with TZNormalizedSparkTestBase with LoggerTestBase {
 
   import spark.implicits._
 

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/broadcast/LocalMappingTableSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/broadcast/LocalMappingTableSuite.scala
@@ -18,10 +18,10 @@ package za.co.absa.enceladus.utils.broadcast
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.NumericType
 import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.spark.commons.utils.JsonUtils
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class LocalMappingTableSuite extends AnyWordSpec with SparkTestBase {
+class LocalMappingTableSuite extends AnyWordSpec with TZNormalizedSparkTestBase {
 
   import spark.implicits._
 

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/fs/HdfsUtilsSpec.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/fs/HdfsUtilsSpec.scala
@@ -16,17 +16,15 @@
 package za.co.absa.enceladus.utils.fs
 
 import java.io.FileNotFoundException
-
 import org.apache.hadoop.fs.Path
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import za.co.absa.enceladus.utils.testUtils.HadoopFsTestBase
-import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, TZNormalizedSparkTestBase}
 
 /**
   * Unit tests for File system utils
   */
-class HdfsUtilsSpec extends AnyWordSpec with Matchers with SparkTestBase with HadoopFsTestBase {
+class HdfsUtilsSpec extends AnyWordSpec with Matchers with TZNormalizedSparkTestBase with HadoopFsTestBase {
 
   "splitUriPath" should {
     "split URI and path" in {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/implicits/DataFrameImplicitsSuite.scala
@@ -16,10 +16,10 @@
 package za.co.absa.enceladus.utils.implicits
 
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
-import za.co.absa.spark.commons.test.SparkTestBase
 
-class DataFrameImplicitsSuite extends AnyFunSuite with SparkTestBase  {
+class DataFrameImplicitsSuite extends AnyFunSuite with TZNormalizedSparkTestBase  {
   import spark.implicits._
 
   private val columnName = "data"

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/schema/SparkUtilsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/schema/SparkUtilsSuite.scala
@@ -19,10 +19,10 @@ import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{BooleanType, LongType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
-import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.enceladus.utils.schema.SparkUtils.DataFrameWithEnhancements
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
-class SparkUtilsSuite extends AnyFunSuite with SparkTestBase {
+class SparkUtilsSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
 
   import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/ArrayTransformationsSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/transformations/ArrayTransformationsSuite.scala
@@ -16,10 +16,9 @@
 package za.co.absa.enceladus.utils.transformations
 
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 
 import scala.util.Random
-import org.apache.spark.sql.functions._
-import za.co.absa.spark.commons.test.SparkTestBase
 
 case class InnerStruct(a: Int, b: String = null)
 case class OuterStruct(id: Int, vals: Seq[InnerStruct])
@@ -37,7 +36,7 @@ case class MyC2(something: Int, somethingByTwo: Int)
 case class Nested2Levels(a: List[List[Option[Int]]])
 case class Nested1Level(a: List[Option[Int]])
 
-class ArrayTransformationsSuite extends AnyFunSuite with SparkTestBase {
+class ArrayTransformationsSuite extends AnyFunSuite with TZNormalizedSparkTestBase {
 
   private val inputData = (0 to 10).toList.map(x => (x, Random.shuffle((0 until x).toList)))
   private val inputDataOrig = OuterStruct(-1, null) :: inputData.map({ case (x, vals) => OuterStruct(x, vals.map(InnerStruct(_))) })


### PR DESCRIPTION
* New class `TZNormalizedSparkTestBase` used over all tests instead of `SparkTestBase`

Closes #2027