### PR TITLE
#2040 attempting not to trigger sonarcube password-in-code in tests

### DIFF
--- a/utils/src/test/scala/za/co/absa/enceladus/utils/config/SecureConfigSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/config/SecureConfigSuite.scala
@@ -84,12 +84,12 @@ class SecureConfigSuite extends AnyFlatSpec with Matchers {
   "it" should "javaOptsStringFromConfigMap to convert config map to -Dx=y string" in {
     val driverEnvMap = Map(
       "javax.net.ssl.keyStore" -> "/path/to/my-keystore.jks",
-      "javax.net.ssl.keyStorePassword" -> "ksPassword1",
+      "javax.net.ssl.keyStorePassword" -> "examplePwd1",
       "somethingElse" -> "whatever"
     )
 
     SecureConfig.javaOptsStringFromConfigMap(driverEnvMap) shouldBe
-      "-Djavax.net.ssl.keyStore=/path/to/my-keystore.jks -Djavax.net.ssl.keyStorePassword=ksPassword1 -DsomethingElse=whatever"
+      "-Djavax.net.ssl.keyStore=/path/to/my-keystore.jks -Djavax.net.ssl.keyStorePassword=examplePwd1 -DsomethingElse=whatever"
   }
 
 }


### PR DESCRIPTION
Let's see the SonarCube check pass for the password-in-code.

Fixes #2040 