### PR TITLE
Feature/2060 pagination

### DIFF
--- a/data-model/src/main/scala/za/co/absa/enceladus/model/test/factories/DatasetFactory.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/test/factories/DatasetFactory.scala
@@ -18,7 +18,7 @@ package za.co.absa.enceladus.model.test.factories
 import za.co.absa.enceladus.model.Dataset
 import za.co.absa.enceladus.model.conformanceRule._
 import za.co.absa.enceladus.model.menas.MenasReference
-import za.co.absa.enceladus.model.versionedModel.VersionedSummary
+import za.co.absa.enceladus.model.versionedModel.{NamedVersion, VersionedSummary}
 
 import java.time.ZonedDateTime
 
@@ -132,6 +132,10 @@ object DatasetFactory extends EntityFactory[Dataset] {
 
   def toSummary(dataset: Dataset): VersionedSummary = {
     VersionedSummary(dataset.name, dataset.version, Set(dataset.disabled))
+  }
+
+  def toNamedVersion(dataset: Dataset): NamedVersion = {
+    toSummary(dataset).toNamedVersion
   }
 
 }

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/versionedModel/NamedVersion.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/versionedModel/NamedVersion.scala
@@ -18,4 +18,4 @@ package za.co.absa.enceladus.model.versionedModel
 /**
  * V3 Wrapper for [[za.co.absa.enceladus.model.versionedModel.VersionedSummary]]
  */
-case class NamedVersion(name: String, version: Int, disabled: Boolean)
+case class NamedVersion(name: String, version: Int, disabled: Boolean = false)

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/VersionedModelController.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/VersionedModelController.scala
@@ -40,7 +40,7 @@ abstract class VersionedModelController[C <: VersionedModel with Product with Au
   @GetMapping(Array("/list", "/list/{searchQuery}"))
   @ResponseStatus(HttpStatus.OK)
   def getList(@PathVariable searchQuery: Optional[String]): CompletableFuture[Seq[VersionedSummaryV2]] = {
-    versionedModelService.getLatestVersionsSummarySearch(searchQuery.toScalaOption)
+    versionedModelService.getLatestVersionsSummarySearch(searchQuery.toScalaOption, None, None) // V2 knows no skip/limit
       .map(_.map(_.toV2))
   }
 

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/v3/PaginatedController.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/v3/PaginatedController.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.rest_api.controllers.v3
+
+import za.co.absa.enceladus.rest_api.controllers.v3.PaginatedController._
+import za.co.absa.enceladus.rest_api.utils.implicits._
+
+import java.util.Optional
+import scala.util.{Failure, Success, Try}
+
+
+object PaginatedController {
+  val DefaultOffset: Int = 0
+  val DefaultLimit: Int = 20
+}
+
+trait PaginatedController {
+
+  /**
+   * Offset value is extracted from `optField`, otherwise
+   * [[za.co.absa.enceladus.rest_api.controllers.v3.PaginatedController#DefaultOffset]] is returned
+   */
+  protected def extractOffsetOrDefault(optField: Optional[String]): Int = extractOffsetOrDefault(optField.toScalaOption)
+
+  /**
+   * Offset value is extracted from `optField`, otherwise
+   * [[za.co.absa.enceladus.rest_api.controllers.v3.PaginatedController#DefaultOffset]] is returned
+   */
+  protected def extractOffsetOrDefault(optField: Option[String]): Int = {
+    extractDefinedValueOrDefault(optField, DefaultOffset)
+  }
+
+  /**
+   * Limit value is extracted from `optField`, otherwise
+   * [[za.co.absa.enceladus.rest_api.controllers.v3.PaginatedController#DefaultLimit]] is returned
+   */
+  protected def extractLimitOrDefault(optField: Optional[String]): Int = extractLimitOrDefault(optField.toScalaOption)
+
+  /**
+   * Limit value is extracted from `optField`, otherwise
+   * [[za.co.absa.enceladus.rest_api.controllers.v3.PaginatedController#DefaultLimit]] is returned
+   */
+  protected def extractLimitOrDefault(optField: Option[String]): Int = {
+    extractDefinedValueOrDefault(optField, DefaultLimit)
+  }
+
+
+  /**
+   * For the `optField` we try to extract int value
+   * @param optField value to attempt to extract from
+   * @param defaultValue value to use if extraction fails
+   * @return On extraction success, `extractedIntValue` is returned, otherwise (empty or invalid) `defaultValue` is returned.
+   */
+  protected def extractDefinedValueOrDefault(optField: Option[String], defaultValue: Int): Int = {
+    optField match {
+      case None => defaultValue
+      case Some(intAsString) => Try(intAsString.toInt) match {
+        case Success(value) => value
+        case Failure(_) => defaultValue
+      }
+    }
+  }
+
+}

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/v3/VersionedModelControllerV3.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/v3/VersionedModelControllerV3.scala
@@ -24,7 +24,7 @@ import za.co.absa.enceladus.model.menas.audit._
 import za.co.absa.enceladus.model.versionedModel._
 import za.co.absa.enceladus.model.{ExportableObject, UsedIn, Validation}
 import za.co.absa.enceladus.rest_api.controllers.BaseController
-import za.co.absa.enceladus.rest_api.controllers.v3.VersionedModelControllerV3.{DefaultLimit, DefaultOffset, LatestKey}
+import za.co.absa.enceladus.rest_api.controllers.v3.VersionedModelControllerV3.LatestKey
 import za.co.absa.enceladus.rest_api.exceptions.NotFoundException
 import za.co.absa.enceladus.rest_api.models.rest.{DisabledPayload, Paginated}
 import za.co.absa.enceladus.rest_api.services.v3.VersionedModelServiceV3
@@ -39,12 +39,10 @@ import scala.util.{Failure, Success, Try}
 object VersionedModelControllerV3 {
   final val LatestKey = "latest"
 
-  val DefaultLimit: Int = 20
-  val DefaultOffset: Int = 0
 }
 
 abstract class VersionedModelControllerV3[C <: VersionedModel with Product
-  with Auditable[C]](versionedModelService: VersionedModelServiceV3[C]) extends BaseController {
+  with Auditable[C]](versionedModelService: VersionedModelServiceV3[C]) extends BaseController with PaginatedController {
 
   import za.co.absa.enceladus.rest_api.utils.implicits._
 
@@ -56,8 +54,8 @@ abstract class VersionedModelControllerV3[C <: VersionedModel with Product
   def getList(@RequestParam searchQuery: Optional[String],
               @RequestParam offset: Optional[String],
               @RequestParam limit: Optional[String]): CompletableFuture[Paginated[NamedVersion]] = {
-    val extractedOffset = extractDefinedValueOrDefault(offset.toScalaOption, DefaultOffset)
-    val extractedLimit = extractDefinedValueOrDefault(limit.toScalaOption, DefaultLimit)
+    val extractedOffset = extractOffsetOrDefault(offset)
+    val extractedLimit = extractLimitOrDefault(limit)
 
     // crazy idea: how to find out if result of limit X got truncated? Fetch X+1 and strip if needed :)
     versionedModelService.getLatestVersionsSummarySearch(searchQuery.toScalaOption, Some(extractedOffset), Some(extractedLimit + 1))
@@ -65,23 +63,6 @@ abstract class VersionedModelControllerV3[C <: VersionedModel with Product
         val namedVersions = summaries.map(_.toNamedVersion)
         Paginated.truncateToPaginated(namedVersions, extractedOffset, extractedLimit)
       }
-    // todo add pagination wrapper with info (at least truncated:bool, perhaps even page size (limit) and skip size (offset)
-  }
-
-  /**
-   * For the `optField` we try to extract int value
-   * @param optField value to attempt to extract from
-   * @param defaultValue value to use if extraction fails
-   * @return On extraction success, `extractedIntValue` is returned, otherwise (empty or invalid) `defaultValue` is returned.
-   */
-  protected def extractDefinedValueOrDefault(optField: Option[String], defaultValue: Int): Int = {
-    optField match {
-      case None => defaultValue
-      case Some(intAsString) => Try(intAsString.toInt) match {
-        case Success(value) => value
-        case Failure(_) => defaultValue
-      }
-    }
   }
 
   @GetMapping(Array("/{name}"))

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/models/rest/Paginated.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/models/rest/Paginated.scala
@@ -15,15 +15,16 @@
 
 package za.co.absa.enceladus.rest_api.models.rest
 
-case class Paginated[T](page: Seq[T], offset:Int, limit: Int, truncated: Boolean)
+case class Paginated[T](page: Seq[T], offset: Int, limit: Int, truncated: Boolean)
 
 object Paginated {
 
   /**
    * Wraps data in Paginated and possibly truncates the data to fit the limit. `truncated` flag is set based on that.
-   * @param data data to be embedded and truncated to length of `limit`
+   *
+   * @param data   data to be embedded and truncated to length of `limit`
    * @param offset is only passed to the wrapper object, has no effect to data
-   * @param limit passed to the wrapper object and it used for truncating the data
+   * @param limit  passed to the wrapper object and it used for truncating the data
    * @tparam T
    * @return truncated data wrapped in Paginated - `truncated` is true if data truncated, false otherwise.
    */

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/models/rest/Paginated.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/models/rest/Paginated.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.rest_api.models.rest
+
+case class Paginated[T](page: Seq[T], offset:Int, limit: Int, truncated: Boolean)
+
+object Paginated {
+
+  /**
+   * Wraps data in Paginated and possibly truncates the data to fit the limit. `truncated` flag is set based on that.
+   * @param data data to be embedded and truncated to length of `limit`
+   * @param offset is only passed to the wrapper object, has no effect to data
+   * @param limit passed to the wrapper object and it used for truncating the data
+   * @tparam T
+   * @return truncated data wrapped in Paginated - `truncated` is true if data truncated, false otherwise.
+   */
+  def truncateToPaginated[T](data: Seq[T], offset: Int, limit: Int): Paginated[T] = {
+    if (data.length <= limit) {
+      Paginated(data, offset, limit, truncated = false)
+    } else {
+      Paginated(data.take(limit), offset, limit, truncated = true)
+    }
+
+  }
+}

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/repositories/VersionedMongoRepository.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/repositories/VersionedMongoRepository.scala
@@ -73,11 +73,17 @@ abstract class VersionedMongoRepository[C <: VersionedModel](mongoDb: MongoDatab
       ),
       sort(Sorts.ascending("_id"))
     ) ++
-      offset.map(skipVal => Seq(Aggregates.skip(skipVal))).getOrElse(Seq.empty) ++
+      offset.map(skipVal => Seq(Aggregates.skip(skipVal))).getOrElse(Seq.empty) ++ // todo reconsider using skip for performance?
       limit.map(limitVal => Seq(Aggregates.limit(limitVal))).getOrElse(Seq.empty)
 
     collection.aggregate[VersionedSummaryV2](pipeline).toFuture()
       .map(_.map(summaryV2 => VersionedSummary(summaryV2._id, summaryV2.latestVersion, Set(false)))) // because of the notDisabled filter
+
+    // todo, consider setting limit to batchsize, e.g. ?
+//    val aggregate =  collection.aggregate[VersionedSummaryV2](pipeline)
+//    limit.map(aggregate.batchSize).getOrElse(aggregate) // for defined limit, set batchsize to match
+//      .toFuture()
+//      .map(_.map(summaryV2 => VersionedSummary(summaryV2._id, summaryV2.latestVersion, Set(false)))) // because of the notDisabled filter
   }
 
   def getLatestVersions(missingProperty: Option[String]): Future[Seq[C]] = {

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/services/VersionedModelService.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/services/VersionedModelService.scala
@@ -40,8 +40,10 @@ trait VersionedModelService[C <: VersionedModel with Product with Auditable[C]]
 
   private[services] val logger = LoggerFactory.getLogger(this.getClass)
 
-  def getLatestVersionsSummarySearch(searchQuery: Option[String]): Future[Seq[VersionedSummary]] = {
-    mongoRepository.getLatestVersionsSummarySearch(searchQuery)
+  def getLatestVersionsSummarySearch(searchQuery: Option[String],
+                                     offset: Option[Int],
+                                     limit: Option[Int]): Future[Seq[VersionedSummary]] = {
+    mongoRepository.getLatestVersionsSummarySearch(searchQuery, offset, limit)
   }
 
   def getLatestVersions(): Future[Seq[C]] = {

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/services/v3/RunServiceV3.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/services/v3/RunServiceV3.scala
@@ -68,8 +68,10 @@ class RunServiceV3 @Autowired()(runMongoRepository: RunMongoRepositoryV3, datase
 
   def getRunSummaries(datasetName: Option[String] = None,
                       datasetVersion: Option[Int] = None,
-                      startDate: Option[String] = None): Future[Seq[RunSummary]] = {
-    runMongoRepository.getRunSummaries(datasetName, datasetVersion, startDate)
+                      startDate: Option[String] = None,
+                      offset: Option[Int],
+                      limit: Option[Int]): Future[Seq[RunSummary]] = {
+    runMongoRepository.getRunSummaries(datasetName, datasetVersion, startDate, offset, limit)
   }
 
   override def addCheckpoint(datasetName: String, datasetVersion: Int, runId: Int, newCheckpoint: Checkpoint): Future[Run] = {

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/services/v3/RunServiceV3.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/services/v3/RunServiceV3.scala
@@ -59,9 +59,11 @@ class RunServiceV3 @Autowired()(runMongoRepository: RunMongoRepositoryV3, datase
                                 datasetVersion: Option[Int] = None,
                                 startDate: Option[String] = None,
                                 sparkAppId: Option[String] = None,
-                                uniqueId: Option[String] = None
+                                uniqueId: Option[String] = None,
+                                offset: Option[Int],
+                                limit: Option[Int]
                                ): Future[Seq[RunSummary]] = {
-    runMongoRepository.getRunSummariesLatestOfEach(datasetName, datasetVersion, startDate, sparkAppId, uniqueId)
+    runMongoRepository.getRunSummariesLatestOfEach(datasetName, datasetVersion, startDate, sparkAppId, uniqueId, offset, limit)
   }
 
   def getRunSummaries(datasetName: Option[String] = None,

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/SchemaApiFeaturesIntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/SchemaApiFeaturesIntegrationSuite.scala
@@ -28,7 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.{HttpStatus, MediaType}
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
-import za.co.absa.enceladus.restapi.TestResourcePath
+import za.co.absa.enceladus.rest_api.TestResourcePath
 import za.co.absa.enceladus.rest_api.integration.fixtures._
 import za.co.absa.enceladus.rest_api.models.rest.RestResponse
 import za.co.absa.enceladus.rest_api.models.rest.errors.{SchemaFormatError, SchemaParsingError}
@@ -40,7 +40,6 @@ import za.co.absa.enceladus.model.menas.MenasReference
 import za.co.absa.enceladus.model.test.factories.{AttachmentFactory, DatasetFactory, MappingTableFactory, SchemaFactory}
 import za.co.absa.enceladus.model.{Schema, UsedIn, Validation}
 import za.co.absa.enceladus.rest_api.exceptions.EntityInUseException
-import za.co.absa.enceladus.restapi.TestResourcePath
 
 import scala.collection.immutable.HashMap
 

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/package.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/package.scala
@@ -64,7 +64,8 @@ package object controllers {
     }
 
     /**
-     * TestPaginated contains pages in an Array, that cannot be compare by ==, this matcher circumvents that
+     * TestPaginated contains pages in an Array, that cannot be compare by ==, this matcher comparest the content of
+     * the data arrays
      * @param expectedPagination
      * @tparam T
      * @return

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/package.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/package.scala
@@ -40,7 +40,7 @@ package object controllers {
     def truncated: Boolean
   }
 
-  trait CustomMatchers {
+  trait TestPaginatedMatchers {
 
     import org.scalatest._
     import matchers._
@@ -74,5 +74,5 @@ package object controllers {
     }
   }
 
-  object CustomMatchers extends CustomMatchers
+  object TestPaginatedMatchers extends TestPaginatedMatchers
 }

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/DatasetControllerV3IntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/DatasetControllerV3IntegrationSuite.scala
@@ -30,7 +30,7 @@ import za.co.absa.enceladus.model.properties.propertyType.EnumPropertyType
 import za.co.absa.enceladus.model.test.factories.{DatasetFactory, MappingTableFactory, PropertyDefinitionFactory, SchemaFactory}
 import za.co.absa.enceladus.model.versionedModel.NamedVersion
 import za.co.absa.enceladus.model.{Dataset, UsedIn, Validation}
-import za.co.absa.enceladus.rest_api.integration.controllers.CustomMatchers.conformTo
+import za.co.absa.enceladus.rest_api.integration.controllers.TestPaginatedMatchers.conformTo
 import za.co.absa.enceladus.rest_api.integration.controllers.{BaseRestApiTestV3, toExpected}
 import za.co.absa.enceladus.rest_api.integration.fixtures._
 import za.co.absa.enceladus.rest_api.models.rest.{DisabledPayload, Paginated}

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/DatasetControllerV3IntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/DatasetControllerV3IntegrationSuite.scala
@@ -31,8 +31,7 @@ import za.co.absa.enceladus.model.test.factories.{DatasetFactory, MappingTableFa
 import za.co.absa.enceladus.model.versionedModel.NamedVersion
 import za.co.absa.enceladus.model.{Dataset, UsedIn, Validation}
 import za.co.absa.enceladus.rest_api.integration.controllers.CustomMatchers.conformTo
-import za.co.absa.enceladus.rest_api.integration.controllers.v3.DatasetControllerV3IntegrationSuite._
-import za.co.absa.enceladus.rest_api.integration.controllers.{BaseRestApiTestV3, TestPaginated, toExpected}
+import za.co.absa.enceladus.rest_api.integration.controllers.{BaseRestApiTestV3, toExpected}
 import za.co.absa.enceladus.rest_api.integration.fixtures._
 import za.co.absa.enceladus.rest_api.models.rest.{DisabledPayload, Paginated}
 
@@ -62,7 +61,6 @@ class DatasetControllerV3IntegrationSuite extends BaseRestApiTestV3 with BeforeA
   s"GET $apiUrl" should {
     "return 200" when {
       "paginated dataset by default params (offset=0, limit=20)" in {
-        import za.co.absa.enceladus.rest_api.integration.controllers.CustomMatchers
         schemaFixture.add(SchemaFactory.getDummySchema("dummySchema"))
         val datasetsA = (1 to 15).map(i => DatasetFactory.getDummyDataset(name = "dsA", version = i))
         val datasetA2disabled = DatasetFactory.getDummyDataset(name = "dsA2", version = 1, disabled = true) // skipped in listing
@@ -1221,17 +1219,5 @@ class DatasetControllerV3IntegrationSuite extends BaseRestApiTestV3 with BeforeA
 }
 
 object DatasetControllerV3IntegrationSuite {
-  case class TestPaginatedNamedVersion(page: Array[NamedVersion], offset: Int, limit: Int, truncated: Boolean)
-    extends TestPaginated[NamedVersion] {
 
-    override def toString: String = {
-      s"TestPaginatedNamedVersion(page=${page.mkString("[", ",", "]")},offset=$offset,limit=$limit,truncated=$truncated)"
-    }
-  }
-
-  implicit class PaginatedExt(val expected: Paginated[NamedVersion]) extends AnyVal {
-    def asTestPaginated: TestPaginatedNamedVersion = {
-      TestPaginatedNamedVersion(expected.page.toArray, expected.offset, expected.limit, expected.truncated)
-    }
-  }
 }

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/MappingTableControllerV3IntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/MappingTableControllerV3IntegrationSuite.scala
@@ -32,7 +32,7 @@ import za.co.absa.enceladus.rest_api.integration.controllers.{BaseRestApiTestV3,
 import za.co.absa.enceladus.rest_api.integration.fixtures._
 import za.co.absa.enceladus.rest_api.models.rest.{DisabledPayload, Paginated}
 import za.co.absa.enceladus.rest_api.exceptions.EntityInUseException
-import za.co.absa.enceladus.rest_api.integration.controllers.CustomMatchers.conformTo
+import za.co.absa.enceladus.rest_api.integration.controllers.TestPaginatedMatchers.conformTo
 
 
 @RunWith(classOf[SpringRunner])

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/MappingTableControllerV3IntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/MappingTableControllerV3IntegrationSuite.scala
@@ -26,11 +26,13 @@ import za.co.absa.enceladus.model.conformanceRule.MappingConformanceRule
 import za.co.absa.enceladus.model.dataFrameFilter._
 import za.co.absa.enceladus.model.menas.MenasReference
 import za.co.absa.enceladus.model.test.factories.{DatasetFactory, MappingTableFactory, SchemaFactory}
+import za.co.absa.enceladus.model.versionedModel.NamedVersion
 import za.co.absa.enceladus.model.{DefaultValue, MappingTable, UsedIn, Validation}
 import za.co.absa.enceladus.rest_api.integration.controllers.{BaseRestApiTestV3, toExpected}
 import za.co.absa.enceladus.rest_api.integration.fixtures._
-import za.co.absa.enceladus.rest_api.models.rest.DisabledPayload
+import za.co.absa.enceladus.rest_api.models.rest.{DisabledPayload, Paginated}
 import za.co.absa.enceladus.rest_api.exceptions.EntityInUseException
+import za.co.absa.enceladus.rest_api.integration.controllers.CustomMatchers.conformTo
 
 
 @RunWith(classOf[SpringRunner])
@@ -51,6 +53,65 @@ class MappingTableControllerV3IntegrationSuite extends BaseRestApiTestV3 with Be
 
   // fixtures are cleared after each test
   override def fixtures: List[FixtureService[_]] = List(mappingTableFixture, schemaFixture, datasetFixture)
+
+  // scalastyle:off magic.number - the test deliberately contains test actual data (no need for DRY here)
+  s"GET $apiUrl" should {
+    "return 200" when {
+      "paginated mappingTable by default params (offset=0, limit=20)" in {
+        schemaFixture.add(SchemaFactory.getDummySchema("dummySchema"))
+        val mappingTablesA = (1 to 15).map(i => MappingTableFactory.getDummyMappingTable(name = "mtA", version = i))
+        val mappingTableA2disabled = MappingTableFactory.getDummyMappingTable(name = "mtA2", version = 1, disabled = true) // skipped in listing
+        val mappingTablesB2M = ('B' to 'V').map(suffix => MappingTableFactory.getDummyMappingTable(name = s"mt$suffix"))
+        mappingTableFixture.add(mappingTablesA: _*)
+        mappingTableFixture.add(mappingTableA2disabled)
+        mappingTableFixture.add(mappingTablesB2M: _*)
+
+        val response = sendGet[TestPaginatedNamedVersion](s"$apiUrl")
+        assertOk(response)
+        response.getBody should conformTo(Paginated(offset = 0, limit = 20, truncated = true, page = Seq(
+          NamedVersion("mtA", 15), NamedVersion("mtB", 1), NamedVersion("mtC", 1), NamedVersion("mtD", 1), NamedVersion("mtE", 1),
+          NamedVersion("mtF", 1), NamedVersion("mtG", 1), NamedVersion("mtH", 1), NamedVersion("mtI", 1), NamedVersion("mtJ", 1),
+          NamedVersion("mtK", 1), NamedVersion("mtL", 1), NamedVersion("mtM", 1), NamedVersion("mtN", 1), NamedVersion("mtO", 1),
+          NamedVersion("mtP", 1), NamedVersion("mtQ", 1), NamedVersion("mtR", 1), NamedVersion("mtS", 1), NamedVersion("mtT", 1)
+          // U, V are on the page 2
+        )).asTestPaginated)
+      }
+
+      "paginated mappingTables with custom pagination (offset=10, limit=5)" in {
+        schemaFixture.add(SchemaFactory.getDummySchema("dummySchema"))
+        val mappingTablesA2o = ('A' to 'O').map(suffix => MappingTableFactory.getDummyMappingTable(name = s"mt$suffix"))
+        mappingTableFixture.add(mappingTablesA2o: _*)
+
+        val response = sendGet[TestPaginatedNamedVersion](s"$apiUrl?offset=10&limit=5")
+        assertOk(response)
+        response.getBody should conformTo(Paginated(offset = 10, limit = 5, truncated = false, page = Seq(
+          // A-E = page 1
+          // F-J = page 2
+          NamedVersion("mtK", 1), NamedVersion("mtL", 1), NamedVersion("mtM", 1), NamedVersion("mtN", 1), NamedVersion("mtO", 1)
+          // no truncation
+        )).asTestPaginated)
+      }
+      "paginated mappingTables as serialized string" in {
+        schemaFixture.add(SchemaFactory.getDummySchema("dummySchema"))
+        val mappingTablesA2o = ('A' to 'D').map(suffix => MappingTableFactory.getDummyMappingTable(name = s"mt$suffix"))
+        mappingTableFixture.add(mappingTablesA2o: _*)
+
+        val response = sendGet[String](s"$apiUrl?limit=3")
+        assertOk(response)
+        response.getBody shouldBe
+          """{"page":[
+            |{"name":"mtA","version":1,"disabled":false},
+            |{"name":"mtB","version":1,"disabled":false},
+            |{"name":"mtC","version":1,"disabled":false}
+            |],
+            |"offset":0,
+            |"limit":3,
+            |"truncated":true
+            |}
+            |""".stripMargin.replace("\n", "")
+      }
+    }
+  }
 
   s"POST $apiUrl" should {
     "return 400" when {

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/PropertyDefinitionControllerV3IntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/PropertyDefinitionControllerV3IntegrationSuite.scala
@@ -30,7 +30,7 @@ import za.co.absa.enceladus.model.test.factories.{DatasetFactory, PropertyDefini
 import za.co.absa.enceladus.model.versionedModel.NamedVersion
 import za.co.absa.enceladus.model.{UsedIn, Validation}
 import za.co.absa.enceladus.rest_api.exceptions.EntityInUseException
-import za.co.absa.enceladus.rest_api.integration.controllers.CustomMatchers.conformTo
+import za.co.absa.enceladus.rest_api.integration.controllers.TestPaginatedMatchers.conformTo
 import za.co.absa.enceladus.rest_api.integration.controllers.{BaseRestApiTestV3, toExpected}
 import za.co.absa.enceladus.rest_api.integration.fixtures._
 import za.co.absa.enceladus.rest_api.models.rest.{DisabledPayload, Paginated}

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/PropertyDefinitionControllerV3IntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/PropertyDefinitionControllerV3IntegrationSuite.scala
@@ -23,16 +23,17 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
-import za.co.absa.enceladus.model.{UsedIn, Validation}
 import za.co.absa.enceladus.model.menas.MenasReference
 import za.co.absa.enceladus.model.properties.PropertyDefinition
 import za.co.absa.enceladus.model.properties.propertyType.{EnumPropertyType, StringPropertyType}
 import za.co.absa.enceladus.model.test.factories.{DatasetFactory, PropertyDefinitionFactory}
 import za.co.absa.enceladus.model.versionedModel.NamedVersion
+import za.co.absa.enceladus.model.{UsedIn, Validation}
 import za.co.absa.enceladus.rest_api.exceptions.EntityInUseException
+import za.co.absa.enceladus.rest_api.integration.controllers.CustomMatchers.conformTo
 import za.co.absa.enceladus.rest_api.integration.controllers.{BaseRestApiTestV3, toExpected}
 import za.co.absa.enceladus.rest_api.integration.fixtures._
-import za.co.absa.enceladus.rest_api.models.rest.DisabledPayload
+import za.co.absa.enceladus.rest_api.models.rest.{DisabledPayload, Paginated}
 
 @RunWith(classOf[SpringRunner])
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -50,6 +51,61 @@ class PropertyDefinitionControllerV3IntegrationSuite extends BaseRestApiTestV3 w
   // fixtures are cleared after each test
   override def fixtures: List[FixtureService[_]] = List(propertyDefinitionFixture, datasetFixture)
 
+  // scalastyle:off magic.number - the test deliberately contains test actual data (no need for DRY here)
+  s"GET $apiUrl" should {
+    "return 200" when {
+      "paginated propDef by default params (offset=0, limit=20)" in {
+        val propDefsA = (1 to 15).map(i => PropertyDefinitionFactory.getDummyPropertyDefinition(name = "pdA", version = i))
+        val propDefA2disabled = PropertyDefinitionFactory.getDummyPropertyDefinition(name = "pdA2", version = 1, disabled = true) // skipped in listing
+        val propDefsB2M = ('B' to 'V').map(suffix => PropertyDefinitionFactory.getDummyPropertyDefinition(name = s"pd$suffix"))
+        propertyDefinitionFixture.add(propDefsA: _*)
+        propertyDefinitionFixture.add(propDefA2disabled)
+        propertyDefinitionFixture.add(propDefsB2M: _*)
+
+        val response = sendGet[TestPaginatedNamedVersion](s"$apiUrl")
+        assertOk(response)
+        response.getBody should conformTo(Paginated(offset = 0, limit = 20, truncated = true, page = Seq(
+          NamedVersion("pdA", 15), NamedVersion("pdB", 1), NamedVersion("pdC", 1), NamedVersion("pdD", 1), NamedVersion("pdE", 1),
+          NamedVersion("pdF", 1), NamedVersion("pdG", 1), NamedVersion("pdH", 1), NamedVersion("pdI", 1), NamedVersion("pdJ", 1),
+          NamedVersion("pdK", 1), NamedVersion("pdL", 1), NamedVersion("pdM", 1), NamedVersion("pdN", 1), NamedVersion("pdO", 1),
+          NamedVersion("pdP", 1), NamedVersion("pdQ", 1), NamedVersion("pdR", 1), NamedVersion("pdS", 1), NamedVersion("pdT", 1)
+          // U, V are on the page 2
+        )).asTestPaginated)
+      }
+
+      "paginated propDefs with custom pagination (offset=10, limit=5)" in {
+        val propDefsA2o = ('A' to 'O').map(suffix => PropertyDefinitionFactory.getDummyPropertyDefinition(name = s"pd$suffix"))
+        propertyDefinitionFixture.add(propDefsA2o: _*)
+
+        val response = sendGet[TestPaginatedNamedVersion](s"$apiUrl?offset=10&limit=5")
+        assertOk(response)
+        response.getBody should conformTo(Paginated(offset = 10, limit = 5, truncated = false, page = Seq(
+          // A-E = page 1
+          // F-J = page 2
+          NamedVersion("pdK", 1), NamedVersion("pdL", 1), NamedVersion("pdM", 1), NamedVersion("pdN", 1), NamedVersion("pdO", 1)
+          // no truncation
+        )).asTestPaginated)
+      }
+      "paginated propDefs as serialized string" in {
+        val propDefsA2o = ('A' to 'D').map(suffix => PropertyDefinitionFactory.getDummyPropertyDefinition(name = s"pd$suffix"))
+        propertyDefinitionFixture.add(propDefsA2o: _*)
+
+        val response = sendGet[String](s"$apiUrl?limit=3")
+        assertOk(response)
+        response.getBody shouldBe
+          """{"page":[
+            |{"name":"pdA","version":1,"disabled":false},
+            |{"name":"pdB","version":1,"disabled":false},
+            |{"name":"pdC","version":1,"disabled":false}
+            |],
+            |"offset":0,
+            |"limit":3,
+            |"truncated":true
+            |}
+            |""".stripMargin.replace("\n", "")
+      }
+    }
+  }
 
   private def minimalPdCreatePayload(name: String, suggestedValue: Option[String]) = {
     val suggestedValuePart = suggestedValue match {

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/SchemaControllerV3IntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/SchemaControllerV3IntegrationSuite.scala
@@ -33,7 +33,7 @@ import za.co.absa.enceladus.model.versionedModel.NamedVersion
 import za.co.absa.enceladus.model.{Schema, SchemaField, UsedIn, Validation}
 import za.co.absa.enceladus.rest_api.TestResourcePath
 import za.co.absa.enceladus.rest_api.exceptions.EntityInUseException
-import za.co.absa.enceladus.rest_api.integration.controllers.CustomMatchers.conformTo
+import za.co.absa.enceladus.rest_api.integration.controllers.TestPaginatedMatchers.conformTo
 import za.co.absa.enceladus.rest_api.integration.controllers.{BaseRestApiTestV3, toExpected}
 import za.co.absa.enceladus.rest_api.integration.fixtures._
 import za.co.absa.enceladus.rest_api.models.rest.errors.{SchemaFormatError, SchemaParsingError}

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/SchemaControllerV3IntegrationSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/SchemaControllerV3IntegrationSuite.scala
@@ -37,7 +37,7 @@ import za.co.absa.enceladus.rest_api.models.rest.{DisabledPayload, RestResponse}
 import za.co.absa.enceladus.rest_api.models.rest.errors.{SchemaFormatError, SchemaParsingError}
 import za.co.absa.enceladus.rest_api.repositories.RefCollection
 import za.co.absa.enceladus.rest_api.utils.SchemaType
-import za.co.absa.enceladus.restapi.TestResourcePath
+import za.co.absa.enceladus.rest_api.TestResourcePath
 
 import java.io.File
 import java.nio.file.{Files, Path}

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/package.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/package.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.rest_api.integration.controllers
+
+import za.co.absa.enceladus.model.versionedModel.NamedVersion
+import za.co.absa.enceladus.rest_api.models.rest.Paginated
+
+package object v3 {
+
+  case class TestPaginatedNamedVersion(page: Array[NamedVersion], offset: Int, limit: Int, truncated: Boolean)
+    extends TestPaginated[NamedVersion] {
+
+    override def toString: String = {
+      s"TestPaginatedNamedVersion(page=${page.mkString("[", ",", "]")},offset=$offset,limit=$limit,truncated=$truncated)"
+    }
+  }
+
+  implicit class PaginatedExt(val expected: Paginated[NamedVersion]) extends AnyVal {
+    def asTestPaginated: TestPaginatedNamedVersion = {
+      TestPaginatedNamedVersion(expected.page.toArray, expected.offset, expected.limit, expected.truncated)
+    }
+  }
+
+}

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/package.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/v3/package.scala
@@ -16,21 +16,43 @@
 package za.co.absa.enceladus.rest_api.integration.controllers
 
 import za.co.absa.enceladus.model.versionedModel.NamedVersion
+import za.co.absa.enceladus.rest_api.controllers.v3.PaginatedController
+import za.co.absa.enceladus.rest_api.models.RunSummary
 import za.co.absa.enceladus.rest_api.models.rest.Paginated
 
 package object v3 {
 
-  case class TestPaginatedNamedVersion(page: Array[NamedVersion], offset: Int, limit: Int, truncated: Boolean)
-    extends TestPaginated[NamedVersion] {
+  case class TestPaginatedNamedVersion(page: Array[NamedVersion],
+                                       offset: Int = PaginatedController.DefaultOffset,
+                                       limit: Int = PaginatedController.DefaultLimit,
+                                       truncated: Boolean = false) extends TestPaginated[NamedVersion] {
 
     override def toString: String = {
+      // just to print nicely, not directly used for comparisons
       s"TestPaginatedNamedVersion(page=${page.mkString("[", ",", "]")},offset=$offset,limit=$limit,truncated=$truncated)"
     }
   }
 
-  implicit class PaginatedExt(val expected: Paginated[NamedVersion]) extends AnyVal {
+  implicit class PaginatedExtNamedVersion(val expected: Paginated[NamedVersion]) extends AnyVal {
     def asTestPaginated: TestPaginatedNamedVersion = {
       TestPaginatedNamedVersion(expected.page.toArray, expected.offset, expected.limit, expected.truncated)
+    }
+  }
+
+  case class TestPaginatedRunSummary(page: Array[RunSummary],
+                                     offset: Int = PaginatedController.DefaultOffset,
+                                     limit: Int = PaginatedController.DefaultLimit,
+                                     truncated: Boolean = false) extends TestPaginated[RunSummary] {
+
+    override def toString: String = {
+      // just to print nicely, not directly used for comparisons
+      s"TestPaginatedRunSummary(page=${page.mkString("[", ",", "]")},offset=$offset,limit=$limit,truncated=$truncated)"
+    }
+  }
+
+  implicit class PaginatedExtRunSummary(val expected: Paginated[RunSummary]) extends AnyVal {
+    def asTestPaginated: TestPaginatedRunSummary = {
+      TestPaginatedRunSummary(expected.page.toArray, expected.offset, expected.limit, expected.truncated)
     }
   }
 

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/package.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/package.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.enceladus
 
-package object restapi {
+package object rest_api { //scalastyle:ignore package.object.name - conforms to the package name
 
   /**
    * Resource paths of files for schema testing

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/utils/parsers/SchemaParserSuite.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/utils/parsers/SchemaParserSuite.scala
@@ -24,7 +24,7 @@ import org.mockito.scalatest.MockitoSugar
 import org.scalatest.Inside
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.cobrix.cobol.parser.exceptions.SyntaxErrorException
-import za.co.absa.enceladus.restapi.TestResourcePath
+import za.co.absa.enceladus.rest_api.TestResourcePath
 import za.co.absa.enceladus.rest_api.models.rest.exceptions.SchemaParsingException
 import za.co.absa.enceladus.rest_api.utils.SchemaType
 import za.co.absa.enceladus.rest_api.utils.converters.SparkMenasSchemaConvertor


### PR DESCRIPTION
_(In progress)_

This PR adds pagination functionality to listing entities, specifically to (with both optional params `offset` (default: `0`) and `limit` (default: `20`) - default applied if param is not specified or is invalid):
 - `GET /api-v3/{datasets|schemas|mapping-tables|property-defintions}[?offset=X][&limit=Y]`
 - `GET /api-v3/runs[?offset=X][&limit=Y]`
 - `GET /runs/{datasetName}[?offset=X][&limit=Y]`
 - `GET /runs/{datasetName}/{datasetVersion}[?offset=X][&limit=Y]`

with the responses being wrapped in the `Paginated` case class (yields the data `page` , used `offset`, used `limit` and `truncated` boolean flag to signify whether there is more data to be retrieved).

## Examples

### Datasets example
`GET api-v3/datasets/?limit=3` ->

```json
{
  "page": [
    {"name": "dsA", "version": 1, "disabled": false},
    {"name": "dsB", "version": 1, "disabled": false},
    {"name": "dsC", "version": 1, "disabled": false}
  ],
  "offset": 0,
  "limit": 3,
  "truncated": true
}
```
(JSON was manually prettified, originally it is compacted)

### Runs example:
`GET api-v3/runs/dataset1?offset=3&limit=2` ->
```json
{
  "page": [
    {
      "datasetName": "dataset1",
      "datasetVersion": 4,
      "runId": 2,
      "status": "allSucceeded",
      "startDateTime": "04-12-2017 16:19:17 +0200",
      "runUniqueId": "20aa6300-f0e2-4432-a3f3-28c36da20a0d"
    },
    {
      "datasetName": "dataset1",
      "datasetVersion": 5,
      "runId": 1,
      "status": "allSucceeded",
      "startDateTime": "04-12-2017 16:19:17 +0200",
      "runUniqueId": "0559f3c4-907d-4cbf-981f-85d2b7e7b283"
    }
  ],
  "offset": 3,
  "limit": 2,
  "truncated": true
}
```
(JSON was manually prettified, originally it is compacted)



Closes #2060.