### PR TITLE
#2095 Menas UI: landing page button order changed

### DIFF
--- a/menas/ui/components/home/landingPage.view.xml
+++ b/menas/ui/components/home/landingPage.view.xml
@@ -30,13 +30,13 @@
             <Panel width="auto" class="sapUiResponsiveMargin" headerText="Totals" height="20rem">
                 <FlexBox height="100px" alignItems="Start" justifyContent="Center" class="sapUiResponsiveMargin">
                     <items>
-                        <GenericTile header="Datasets" class="sapUiResponsiveMargin" press="masterNavigate">
+                        <GenericTile header="Runs" class="sapUiResponsiveMargin" press="masterNavigate">
                             <customData>
-                                <core:CustomData key="target" value="datasets"></core:CustomData>
+                                <core:CustomData key="target" value="runs"></core:CustomData>
                             </customData>
                             <tileContent>
                                 <TileContent>
-                                    <NumericContent icon="sap-icon://database" value="{path: '/landingPageInfo/totalNumberDatasets', formatter: '.tileNumberFormatter'}"></NumericContent>
+                                    <NumericContent icon="sap-icon://physical-activity" value="{path: '/landingPageInfo/totalNumberRuns', formatter: '.tileNumberFormatter'}"></NumericContent>
                                 </TileContent>
                             </tileContent>
                         </GenericTile>
@@ -50,6 +50,16 @@
                                 </TileContent>
                             </tileContent>
                         </GenericTile>
+                        <GenericTile header="Datasets" class="sapUiResponsiveMargin" press="masterNavigate">
+                            <customData>
+                                <core:CustomData key="target" value="datasets"></core:CustomData>
+                            </customData>
+                            <tileContent>
+                                <TileContent>
+                                    <NumericContent icon="sap-icon://database" value="{path: '/landingPageInfo/totalNumberDatasets', formatter: '.tileNumberFormatter'}"></NumericContent>
+                                </TileContent>
+                            </tileContent>
+                        </GenericTile>
                         <GenericTile header="Mapping Tables" class="sapUiResponsiveMargin" press="masterNavigate">
                             <customData>
                                 <core:CustomData key="target" value="mappingTables"></core:CustomData>
@@ -60,16 +70,6 @@
                                 </TileContent>
                             </tileContent>
                         </GenericTile>
-                        <GenericTile header="Runs" class="sapUiResponsiveMargin" press="masterNavigate">
-                            <customData>
-                                <core:CustomData key="target" value="runs"></core:CustomData>
-                            </customData>
-                            <tileContent>
-                                <TileContent>
-                                    <NumericContent icon="sap-icon://physical-activity" value="{path: '/landingPageInfo/totalNumberRuns', formatter: '.tileNumberFormatter'}"></NumericContent>
-                                </TileContent>
-                            </tileContent>
-                        </GenericTile>
                         <GenericTile header="Dataset Properties" class="sapUiResponsiveMargin" press="masterNavigate">
                             <customData>
                                 <core:CustomData key="target" value="properties"></core:CustomData>
@@ -77,8 +77,6 @@
                             <tileContent>
                                 <TileContent>
                                     <NumericContent icon="sap-icon://multi-select" value="{path: '/landingPageInfo/totalNumberProperties', formatter: '.tileNumberFormatter'}"></NumericContent>
-                                </TileContent>
-                                <TileContent>
                                 </TileContent>
                             </tileContent>
                         </GenericTile>


### PR DESCRIPTION
As requested in #2095, the order of the buttons on the lading page has been changed as follows:
1. Runs
2. Schemas
3. Datasets
4. Mapping Tables
5. Dataset Properties

## Showcase

### Before
![landing-buttons-order-before](https://user-images.githubusercontent.com/4457378/179996938-126598f1-f60d-4377-a31b-2037f7fe72d1.png)

### After
![landing-buttons-order-after](https://user-images.githubusercontent.com/4457378/179996976-db545a56-3b17-4afb-a837-aeef9457a5b3.png)

Closes #2095,

## Release notes suggestion
Menas UI: Lading page buttons order has been changed to conform the order of items in the left-side menu.

