### PR TITLE
#2090: Integrate Spark-Commons 0.3.x

### DIFF
--- a/examples/src/test/resources/log4j.properties
+++ b/examples/src/test/resources/log4j.properties
@@ -34,14 +34,3 @@ log4j.appender.forsparksessionbuilder.filter.01.StringToMatch=Using an existing 
 log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch=@log.specialfilters.acceptonmatch@
 log4j.logger.org.apache.spark.sql.SparkSession$Builder=WARN, forsparksessionbuilder
 log4j.additivity.org.apache.spark.sql.SparkSession$Builder=false
-
-# Suppress a spamming warning from CacheManager
-log4j.appender.forcachemanager=org.apache.log4j.ConsoleAppender
-log4j.appender.forcachemanager.target=System.err
-log4j.appender.forcachemanager.layout=org.apache.log4j.PatternLayout
-log4j.appender.forcachemanager.layout.ConversionPattern=@log.pattern@
-log4j.appender.forcachemanager.filter.01=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forcachemanager.filter.01.StringToMatch=Asked to cache already cached data.
-log4j.appender.forcachemanager.filter.01.AcceptOnMatch=@log.specialfilters.acceptonmatch@
-log4j.logger.org.apache.spark.sql.execution.CacheManager=@log.level.base@, forcachemanager
-log4j.additivity.org.apache.spark.sql.execution.CacheManager=false

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <!--dependency versions-->
         <abris.version>3.1.1</abris.version>
         <absa.commons.version>1.0.0</absa.commons.version>
-        <absa.spark.commons.version>0.2.0</absa.spark.commons.version>
+        <absa.spark.commons.version>0.3.1</absa.spark.commons.version>
         <atum.version>3.8.2</atum.version>
         <bower.chart.js.version>2.7.3</bower.chart.js.version>
         <bson.codec.jsr310.version>3.5.4</bson.codec.jsr310.version>

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/DynamicInterpreter.scala
@@ -27,9 +27,10 @@ import za.co.absa.enceladus.conformance.config.ConformanceConfigParser
 import za.co.absa.enceladus.conformance.datasource.PartitioningUtils
 import za.co.absa.enceladus.conformance.interpreter.rules._
 import za.co.absa.enceladus.conformance.interpreter.rules.custom.CustomConformanceRule
-import za.co.absa.enceladus.conformance.interpreter.rules.mapping.{MappingRuleInterpreter, MappingRuleInterpreterBroadcast, MappingRuleInterpreterGroupExplode}
+import za.co.absa.enceladus.conformance.interpreter.rules.mapping.{MappingRuleInterpreter,
+  MappingRuleInterpreterBroadcast, MappingRuleInterpreterGroupExplode}
 import za.co.absa.enceladus.dao.MenasDAO
-import za.co.absa.enceladus.model.conformanceRule.{ConformanceRule, _}
+import za.co.absa.enceladus.model.conformanceRule._
 import za.co.absa.enceladus.model.{Dataset => ConfDataset}
 import za.co.absa.enceladus.utils.config.PathWithFs
 import za.co.absa.enceladus.utils.error.ErrorMessage
@@ -38,6 +39,7 @@ import za.co.absa.enceladus.utils.general.Algorithms
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.spark.commons.utils.explode.ExplosionContext
 import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancementsArrays
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 case class DynamicInterpreter(implicit inputFs: FileSystem) {
   private val log = LoggerFactory.getLogger(this.getClass)
@@ -358,7 +360,7 @@ case class DynamicInterpreter(implicit inputFs: FileSystem) {
       // Cache the data first since Atum will execute an action for each control metric
       val cachedDf = persistStorageLevel match {
         case Some(level) => df.persist(level)
-        case None        => df.cache
+        case None        => df.cacheIfNotCachedYet()
       }
       cachedDf.filter(explodeFilter)
         .setCheckpoint(s"${ictx.jobShortName} (${rule.order}) - ${rule.outputColumn}")

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/OptimizerTimeTracker.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/interpreter/OptimizerTimeTracker.scala
@@ -15,11 +15,12 @@
 
 package za.co.absa.enceladus.conformance.interpreter
 
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
+
 
 class OptimizerTimeTracker(inputDf: DataFrame, isWorkaroundEnabled: Boolean)(implicit spark: SparkSession) {
   import spark.implicits._
@@ -34,7 +35,7 @@ class OptimizerTimeTracker(inputDf: DataFrame, isWorkaroundEnabled: Boolean)(imp
   private val idField1 = inputDf.schema.getClosestUniqueName("tmpId")
   private val idField2 = s"${idField1}_2"
   private val dfWithId = inputDf.withColumn(idField1, lit(1))
-  private val dfJustId = Seq(1).toDF(idField2).cache()
+  private val dfJustId = Seq(1).toDF(idField2).cacheIfNotCachedYet()
 
   /**
     * Returns a dataframe prepared to apply the Catalyst workaround

--- a/spark-jobs/src/test/resources/log4j.properties
+++ b/spark-jobs/src/test/resources/log4j.properties
@@ -38,17 +38,6 @@ log4j.appender.forsparksessionbuilder.filter.01.AcceptOnMatch=@log.specialfilter
 log4j.logger.org.apache.spark.sql.SparkSession$Builder=@log.level.base@, forsparksessionbuilder
 log4j.additivity.org.apache.spark.sql.SparkSession$Builder=false
 
-# Suppress a spamming warning from CacheManager
-log4j.appender.forcachemanager=org.apache.log4j.ConsoleAppender
-log4j.appender.forcachemanager.target=System.err
-log4j.appender.forcachemanager.layout=org.apache.log4j.PatternLayout
-log4j.appender.forcachemanager.layout.ConversionPattern=@log.pattern@
-log4j.appender.forcachemanager.filter.01=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.forcachemanager.filter.01.StringToMatch=Asked to cache already cached data.
-log4j.appender.forcachemanager.filter.01.AcceptOnMatch=@log.specialfilters.acceptonmatch@
-log4j.logger.org.apache.spark.sql.execution.CacheManager=@log.level.base@, forcachemanager
-log4j.additivity.org.apache.spark.sql.execution.CacheManager=false
-
 # Suppress validation error logs from SchemaChecker
 log4j.appender.forschemachecker=org.apache.log4j.ConsoleAppender
 log4j.appender.forschemachecker.target=System.err

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/InterpreterSuite.scala
@@ -29,6 +29,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.utils.fs.FileReader
 import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.validation.ValidationLevel
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class InterpreterSuite extends AnyFunSuite with TZNormalizedSparkTestBase with BeforeAndAfterAll with LoggerTestBase with HadoopFsTestBase {
 
@@ -128,7 +129,7 @@ class InterpreterSuite extends AnyFunSuite with TZNormalizedSparkTestBase with B
       .setControlFrameworkEnabled(enableCF)
       .setBroadcastStrategyMode(Never)
 
-    val conformed = DynamicInterpreter().interpret(TradeConformance.tradeDS, dfs).cache
+    val conformed = DynamicInterpreter().interpret(TradeConformance.tradeDS, dfs).cacheIfNotCachedYet()
 
     val data = conformed.repartition(1).orderBy($"id").toJSON.collect.mkString("\n")
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/CastingRuleSuite.scala
@@ -26,6 +26,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.validation.ValidationLevel
 import za.co.absa.spark.commons.utils.JsonUtils
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class CastingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with HadoopFsTestBase {
   private val ruleName = "Casting rule"
@@ -44,15 +45,12 @@ class CastingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with L
 
     mockWhen(dao.getDataset("Orders Conformance", 1, ValidationLevel.NoValidation)) thenReturn CastingRuleSamples.ordersDS
 
-    val mappingTablePattern = "{0}/{1}/{2}"
-
-    import spark.implicits._
     implicit val featureSwitches: FeatureSwitches = FeatureSwitches()
       .setExperimentalMappingRuleEnabled(experimentalMR)
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val conformed = DynamicInterpreter().interpret(CastingRuleSamples.ordersDS, inputDf).cache
+    val conformed = DynamicInterpreter().interpret(CastingRuleSamples.ordersDS, inputDf).cacheIfNotCachedYet()
 
     val conformedJSON = JsonUtils.prettySparkJSON(conformed.orderBy($"id").toJSON.collect)
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/NegationRuleSuite.scala
@@ -26,6 +26,7 @@ import za.co.absa.enceladus.dao.MenasDAO
 import za.co.absa.enceladus.model.{Dataset => ConfDataset}
 import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.validation.ValidationLevel
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class NegationRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with HadoopFsTestBase {
 
@@ -121,7 +122,7 @@ class NegationRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with 
       .setCatalystWorkaroundEnabled(isCatalystWorkaroundEnabled)
       .setControlFrameworkEnabled(enableCF)
 
-    val conformed = DynamicInterpreter().interpret(enceladusDataset, inputDf).cache
+    val conformed = DynamicInterpreter().interpret(enceladusDataset, inputDf).cacheIfNotCachedYet()
     val conformedJSON = conformed.toJSON.collect().mkString("\n")
     if (conformedJSON != expectedJSON) {
       logger.error("EXPECTED:")

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingGroupExplodeSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingGroupExplodeSuite.scala
@@ -21,6 +21,7 @@ import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.Nest
 import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.SimpleTestCaseFactory.{simpleMappingRule, simpleMappingRuleMultipleOutputs, simpleMappingRuleMultipleOutputsWithDefaults, simpleMappingRuleWithDefaultValue}
 import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.spark.commons.utils.JsonUtils
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class MappingGroupExplodeSuite extends MappingInterpreterSuite {
   import spark.implicits._
@@ -34,7 +35,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -52,7 +53,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum" ,$"conformedNum", $"conformedBool")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -70,7 +71,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -88,7 +89,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum" ,$"conformedNum", $"conformedBool")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -106,7 +107,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum1")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -125,7 +126,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1",
         $"array2", $"errCol", $"conformedNum1", $"conformedInt")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -143,7 +144,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum2")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -161,7 +162,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"conformedNum3", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -180,7 +181,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2",
         $"conformedNum3", $"conformedInt" , $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -198,7 +199,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -216,7 +217,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -234,7 +235,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -252,7 +253,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -270,7 +271,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -288,7 +289,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -306,7 +307,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -324,7 +325,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -342,7 +343,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -360,7 +361,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -378,7 +379,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -398,7 +399,7 @@ class MappingGroupExplodeSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf2)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleBroadcastSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleBroadcastSuite.scala
@@ -21,6 +21,9 @@ import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.Nest
 import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.SimpleTestCaseFactory._
 import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.spark.commons.utils.JsonUtils
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
+
 
 class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
   import spark.implicits._
@@ -34,7 +37,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -52,7 +55,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum" ,$"conformedNum", $"conformedBool")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -70,7 +73,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -88,7 +91,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"int_num", $"long_num", $"str_val", $"errCol", $"conformedIntNum" ,$"conformedNum", $"conformedBool")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -106,7 +109,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum1")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -125,7 +128,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1",
         $"array2", $"errCol", $"conformedNum1", $"conformedInt")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -143,7 +146,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol", $"conformedNum2")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -161,7 +164,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"conformedNum3", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -180,7 +183,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2",
         $"conformedNum3", $"conformedInt" , $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = dfOut.schema.treeString
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -198,7 +201,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -216,7 +219,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array2", $"errCol", $"array1")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -234,7 +237,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -252,7 +255,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -270,7 +273,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -288,7 +291,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -306,7 +309,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -324,7 +327,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -342,7 +345,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -360,7 +363,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -378,7 +381,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())
@@ -398,7 +401,7 @@ class MappingRuleBroadcastSuite extends MappingInterpreterSuite {
 
     val dfOut = DynamicInterpreter().interpret(dataset, inputDf2)
       .select($"id", $"key1", $"key2", $"struct1", $"struct2", $"array1", $"array2", $"errCol")
-      .cache
+      .cacheIfNotCachedYet()
 
     val actualSchema = cleanupContainsNullProperty(dfOut.schema.treeString)
     val actualResults = JsonUtils.prettySparkJSON( dfOut.orderBy("id").toJSON.collect())

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/conformance/interpreter/rules/mapping/MappingRuleSuite.scala
@@ -22,6 +22,7 @@ import za.co.absa.enceladus.conformance.interpreter.DynamicInterpreter
 import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.SimpleTestCaseFactory
 import za.co.absa.enceladus.conformance.interpreter.rules.testcasefactories.SimpleTestCaseFactory._
 import za.co.absa.enceladus.utils.testUtils.{HadoopFsTestBase, LoggerTestBase, TZNormalizedSparkTestBase}
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class MappingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with BeforeAndAfterAll with HadoopFsTestBase {
   private val testCaseFactory = new SimpleTestCaseFactory()
@@ -41,7 +42,7 @@ class MappingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with L
       testCaseFactory.getTestCase(true, false, nonExistentTableMappingRule)
 
     val ex = intercept[AnalysisException] {
-      DynamicInterpreter().interpret(dataset, inputDf).cache
+      DynamicInterpreter().interpret(dataset, inputDf).cacheIfNotCachedYet()
     }
 
     assert(ex.getMessage.contains("Path does not exist"))
@@ -52,7 +53,7 @@ class MappingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with L
       testCaseFactory.getTestCase(false, false, nonExistentTableMappingRule)
 
     val ex = intercept[AnalysisException] {
-      DynamicInterpreter().interpret(dataset, inputDf).cache
+      DynamicInterpreter().interpret(dataset, inputDf).cacheIfNotCachedYet()
     }
 
     assert(ex.getMessage.contains("Path does not exist"))
@@ -63,7 +64,7 @@ class MappingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with L
       testCaseFactory.getTestCase(true, false, emptyTableMappingRule)
 
     val ex = intercept[RuntimeException] {
-      DynamicInterpreter().interpret(dataset, inputDf).cache
+      DynamicInterpreter().interpret(dataset, inputDf).cacheIfNotCachedYet()
     }
 
     assert(ex.getMessage.contains("Unable to read the mapping table"))
@@ -74,7 +75,7 @@ class MappingRuleSuite extends AnyFunSuite with TZNormalizedSparkTestBase with L
       testCaseFactory.getTestCase(false, false, emptyTableMappingRule)
 
     val ex = intercept[RuntimeException] {
-      DynamicInterpreter().interpret(dataset, inputDf).cache
+      DynamicInterpreter().interpret(dataset, inputDf).cacheIfNotCachedYet()
     }
 
     assert(ex.getMessage.contains("Unable to read the mapping table"))

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationRerunSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/StandardizationRerunSuite.scala
@@ -32,6 +32,7 @@ import za.co.absa.enceladus.utils.testUtils.TZNormalizedSparkTestBase
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.ValidationException
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationRerunSuite extends FixtureAnyFunSuite with TZNormalizedSparkTestBase with TempFileFixture with MockitoSugar {
 
@@ -109,7 +110,7 @@ class StandardizationRerunSuite extends FixtureAnyFunSuite with TZNormalizedSpar
 
     val inputDf = getTestDataFrame(tmpFileName, schemaWithStringType)
 
-    val stdDf = StandardizationInterpreter.standardize(inputDf, schema, "").cache()
+    val stdDf = StandardizationInterpreter.standardize(inputDf, schema, "").cacheIfNotCachedYet()
 
     val actualOutput = stdDf.dataAsString(truncate = false)
 
@@ -137,7 +138,7 @@ class StandardizationRerunSuite extends FixtureAnyFunSuite with TZNormalizedSpar
     val inputDf = getTestDataFrame(tmpFileName, schemaStr)
 
     assertThrows[ValidationException] {
-      StandardizationInterpreter.standardize(inputDf, schema, "").cache()
+      StandardizationInterpreter.standardize(inputDf, schema, "").cacheIfNotCachedYet()
     }
   }
 
@@ -162,7 +163,7 @@ class StandardizationRerunSuite extends FixtureAnyFunSuite with TZNormalizedSpar
     val inputDf = getTestDataFrame(tmpFileName, schemaStr)
       .withColumn(ErrorMessage.errorColumnName, typedLit(List[ErrorMessage]()))
 
-    val stdDf = StandardizationInterpreter.standardize(inputDf, schema, "").cache()
+    val stdDf = StandardizationInterpreter.standardize(inputDf, schema, "").cacheIfNotCachedYet()
     val failedRecords = stdDf.filter(size(col(ErrorMessage.errorColumnName)) > 0).count
 
     assert(stdDf.schema.exists(field => field.name == ErrorMessage.errorColumnName))

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/CounterPartySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/CounterPartySuite.scala
@@ -21,6 +21,7 @@ import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 case class Root(ConformedParty: Party, errCol: Seq[ErrorMessage] = Seq.empty)
 case class Party(key: Integer, clientKeys1: Seq[String], clientKeys2: Seq[String])
@@ -52,7 +53,7 @@ class CounterPartySuite extends AnyFunSuite with TZNormalizedSparkTestBase with 
       Root(Party(5, Seq(), null)),
       Root(Party(6, null, null))))
 
-    val std = StandardizationInterpreter.standardize(input, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(input, desiredSchema, "").cacheIfNotCachedYet()
 
     logDataFrameContent(std)
 

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -24,6 +24,7 @@ import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTe
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.spark.commons.utils.JsonUtils
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreterSuite  extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -57,11 +58,11 @@ class StandardizationInterpreterSuite  extends AnyFunSuite with TZNormalizedSpar
 
     val srcString:String = FileReader.readFileAsString("src/test/resources/data/patients.json")
 
-    val src = JsonUtils.getDataFrameFromJson(spark, Seq(srcString))
+    val src = JsonUtils.getDataFrameFromJson(Seq(srcString))
 
     logDataFrameContent(src)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val actualSchema = std.schema.treeString

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
@@ -70,7 +70,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with TZNormalize
       " |    |-- element: timestamp (containsNull = true)"
     )
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     assert(std.schema.treeString == expectedSchema)
     assert(std.dataAsString(false) == expectedData)
   }
@@ -99,7 +99,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with TZNormalize
       " |-- arrayField: array (nullable = true)\n" +
       " |    |-- element: timestamp (containsNull = true)"
     )
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     assert(std.schema.treeString == expectedSchema)
     assert(std.dataAsString(false) == expectedData)
   }
@@ -113,7 +113,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with TZNormalize
     val src = seq.toDF(fieldName)
     val desiredSchema = generateDesiredSchema(TimestampType, s""""${MetadataKeys.Pattern}": "fubar"""")
     val caught = intercept[ValidationException] {
-      StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+      StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     }
 
     caught.getMessage should startWith ("A fatal schema validation error occurred.")
@@ -145,7 +145,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with TZNormalize
         " |    |-- element: integer (containsNull = true)"
     )
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     assert(std.schema.treeString == expectedSchema)
     assert(std.dataAsString(false) == expectedData)
   }
@@ -175,7 +175,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with TZNormalize
         " |    |-- element: float (containsNull = true)"
     )
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     assert(std.schema.treeString == expectedSchema)
     assert(std.dataAsString(false) == expectedData)
   }
@@ -184,7 +184,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with TZNormalize
     val seq = Seq(
       s"""{"$fieldName": [["a", "bb", "ccc"],["1", "12"],["Hello", null, "World"]]}"""
     )
-    val src = JsonUtils.getDataFrameFromJson(spark, seq)
+    val src = JsonUtils.getDataFrameFromJson(seq)
 
     val subArrayJson = """{"type": "array", "elementType": "string", "containsNull": false}"""
     val desiredSchema = generateDesiredSchema(subArrayJson, s""""${MetadataKeys.DefaultValue}": "Nope"""")
@@ -204,7 +204,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with TZNormalize
         " |    |    |-- element: string (containsNull = true)"
     )
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
 
     assert(std.schema.treeString == expectedSchema)
     assert(std.dataAsString(false) == expectedData)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
@@ -23,6 +23,8 @@ import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTe
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
 import za.co.absa.enceladus.utils.validation.ValidationException
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_BinarySuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase with Matchers {
 
@@ -47,7 +49,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with TZNormaliz
     )
 
     val src = seq.toDF(fieldName)
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val result = std.as[BinaryRow].collect().toList
@@ -75,7 +77,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with TZNormaliz
     )
 
     val src = seq.toDF(fieldName)
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val result = std.as[BinaryRow].collect().toList
@@ -93,7 +95,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with TZNormaliz
 
     val src = seq.toDF(fieldName)
     val caught = intercept[ValidationException](
-      StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+      StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     )
 
     caught.errors.length shouldBe 1
@@ -119,7 +121,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with TZNormaliz
       )
 
       val src = seq.toDF(fieldName)
-      val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+      val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
       logDataFrameContent(std)
 
       val result = std.as[BinaryRow].collect().toList
@@ -149,7 +151,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with TZNormaliz
     )
 
     val src = seq.toDF(fieldName)
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val result = std.as[BinaryRow].collect().toList
@@ -182,7 +184,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with TZNormaliz
       )
 
       val src = seq.toDF(fieldName)
-      val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+      val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
       logDataFrameContent(std)
 
       val result = std.as[BinaryRow].collect().toList

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -22,6 +22,7 @@ import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -53,7 +54,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -79,7 +80,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -105,7 +106,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -131,7 +132,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -161,7 +162,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -191,7 +192,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -221,7 +222,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -254,7 +255,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -288,7 +289,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -320,7 +321,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -351,7 +352,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with TZNormalized
 
   val src = seq.toDF(fieldName)
 
-  val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+  val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
   logDataFrameContent(std)
 
   assertResult(exp)(std.as[DateRow].collect().toList)

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
@@ -24,6 +24,7 @@ import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -70,7 +71,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with TZNormali
     val src = seq.toDF("description","small", "big")
     logDataFrameContent(src)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -131,7 +132,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with TZNormali
         ErrorMessage.stdCastErr("big", "NaN")))
     )
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DecimalRow].collect().sortBy(_.description).toList)
@@ -168,7 +169,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with TZNormali
         .build())
     ))
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithAlters, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithAlters, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(
@@ -210,7 +211,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with TZNormali
         .build())
     ))
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithPatterns, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithPatterns, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(
@@ -262,7 +263,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with TZNormali
         .build())
     ))
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithPatterns, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithPatterns, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -22,6 +22,8 @@ import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -66,7 +68,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with TZNorm
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -110,7 +112,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with TZNorm
       FractionalRow("03-Long", Option(-value.toFloat), Option(value.toDouble))
     )
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)
@@ -144,7 +146,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with TZNorm
         ErrorMessage.stdCastErr("doubleField", "NaN")))
     )
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)
@@ -167,7 +169,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with TZNorm
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithInfinity, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchemaWithInfinity, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
@@ -24,6 +24,7 @@ import za.co.absa.enceladus.utils.schema.MetadataKeys
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase{
 
@@ -61,7 +62,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with TZNormal
       .csv(s"${pathToTestData}integral_overflow_test.csv")
     logDataFrameContent(src)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(

--- a/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/spark-jobs/src/test/scala/za/co/absa/enceladus/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -22,6 +22,8 @@ import za.co.absa.enceladus.utils.error.ErrorMessage
 import za.co.absa.enceladus.utils.testUtils.{LoggerTestBase, TZNormalizedSparkTestBase}
 import za.co.absa.enceladus.utils.types.{Defaults, GlobalDefaults}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNormalizedSparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -51,7 +53,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -81,7 +83,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -107,7 +109,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -133,7 +135,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -163,7 +165,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -198,7 +200,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -228,7 +230,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -262,7 +264,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -293,7 +295,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -324,7 +326,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -356,7 +358,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with TZNorma
 
     val src = seq.toDF(fieldName)
 
-    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cache()
+    val std = StandardizationInterpreter.standardize(src, desiredSchema, "").cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     std.show(false)

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -59,7 +59,12 @@
         </dependency>
         <dependency>
             <groupId>za.co.absa</groupId>
-            <artifactId>spark-commons_${scala.compat.version}</artifactId>
+            <artifactId>spark-commons-spark${spark.compat.version}_${scala.compat.version}</artifactId>
+            <version>${absa.spark.commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>za.co.absa</groupId>
+            <artifactId>spark-commons-test_${scala.compat.version}</artifactId>
             <version>${absa.spark.commons.version}</version>
         </dependency>
         <dependency>
@@ -116,6 +121,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/TZNormalizedSparkTestBase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/TZNormalizedSparkTestBase.scala
@@ -23,7 +23,6 @@ trait TZNormalizedSparkTestBase extends SparkTestBase {
   override protected def initSpark(implicit sparkConfig: SparkTestConfig): SparkSession = {
     val result = super.initSpark
 
-    //TODO make conditional on empty SparkTestBase.timezone, once SparkCommons 0.3.0 will have been released
     if (sparkConfig.timezone.isEmpty) {
       TimeZoneNormalizer.normalizeAll(result)
     }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/TZNormalizedSparkTestBase.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/TZNormalizedSparkTestBase.scala
@@ -24,7 +24,9 @@ trait TZNormalizedSparkTestBase extends SparkTestBase {
     val result = super.initSpark
 
     //TODO make conditional on empty SparkTestBase.timezone, once SparkCommons 0.3.0 will have been released
-    TimeZoneNormalizer.normalizeAll(result)
+    if (sparkConfig.timezone.isEmpty) {
+      TimeZoneNormalizer.normalizeAll(result)
+    }
 
     result
   }

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/types/TypedStructField.scala
@@ -26,13 +26,12 @@ import za.co.absa.enceladus.utils.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.enceladus.utils.types.parsers._
 import za.co.absa.enceladus.utils.validation.ValidationIssue
 import za.co.absa.enceladus.utils.validation.field._
-import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldEnhancements
 import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldMetadataEnhancements
 
 import scala.util.{Failure, Success, Try}
 
-sealed abstract class TypedStructField(structField: StructField)(implicit defaults: Defaults)
-  extends StructFieldEnhancements(structField) with Serializable {
+sealed abstract class TypedStructField(val structField: StructField)(implicit defaults: Defaults)
+  extends Serializable {
 
   type BaseType
 
@@ -165,7 +164,7 @@ object TypedStructField {
   def asBinaryTypeStructField(structField: StructField)(implicit defaults: Defaults): BinaryTypeStructField =
     TypedStructField(structField).asInstanceOf[BinaryTypeStructField]
 
-  def unapply[T](typedStructField: TypedStructField): Option[StructField] = Some(typedStructField.structField)
+  def unapply(typedStructField: TypedStructField): Option[StructField] = Some(typedStructField.structField)
 
   abstract class TypedStructFieldTagged[T](structField: StructField)(implicit defaults: Defaults)
     extends TypedStructField(structField) {

--- a/utils/src/test/scala/za/co/absa/enceladus/utils/broadcast/LocalMappingTableSuite.scala
+++ b/utils/src/test/scala/za/co/absa/enceladus/utils/broadcast/LocalMappingTableSuite.scala
@@ -54,7 +54,7 @@ class LocalMappingTableSuite extends AnyWordSpec with TZNormalizedSparkTestBase 
     """{"id":1,"arst":[{"a":"a1","b":11,"c":true}],"val":"v1","sval":{"d":"d1","e":21,"f":true},"flag":true}""" ::
       """{"id":2,"arst":[{"a":"a2","b":12,"c":false}],"val":"v2","sval":{"d":"d2","e":22,"f":false},"flag":true}""" ::
       """{"id":3,"arst":[{"a":"a3","b":13,"c":true}],"val":"v3","sval":{"d":"d3","e":23,"f":true},"flag":true}""" :: Nil
-    val dfComplexMt = JsonUtils.getDataFrameFromJson(spark, complexMt)
+    val dfComplexMt = JsonUtils.getDataFrameFromJson(complexMt)
 
     "be created" when {
       "a simple mapping table dataframe is provided" in {


### PR DESCRIPTION
* integration of Spark-commons and Spark-commons-test 0.3.1
* function `cache` replaced with `cacheIfNotCahcedyet`
* removed filter for test logs of `DataFrame already being cached
* `TZNormalizedSparkTestBase` take into account eventual timezone config

Closes #2090 