### PR TITLE
#2105 Change spark-jobs config keys prefix from `menas.rest` to `enceladus.rest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ password=changeme
 --deploy-mode <client/cluster> \
 --driver-cores <num> \
 --driver-memory <num>G \
---conf "spark.driver.extraJavaOptions=-Dmenas.rest.uri=<menas_api_uri:port> -Dstandardized.hdfs.path=<path_for_standardized_output>-{0}-{1}-{2}-{3} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name> -Dhdp.version=<hadoop_version>" \
+--conf "spark.driver.extraJavaOptions=-Denceladus.rest.uri=<rest_api_uri:port> -Dstandardized.hdfs.path=<path_for_standardized_output>-{0}-{1}-{2}-{3} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name> -Dhdp.version=<hadoop_version>" \
 --class za.co.absa.enceladus.standardization.StandardizationJob \
 <spark-jobs_<build_version>.jar> \
 --menas-auth-keytab <path_to_keytab_file> \
@@ -162,7 +162,7 @@ password=changeme
 --driver-cores <num> \
 --driver-memory <num>G \
 --conf 'spark.ui.port=29000' \
---conf "spark.driver.extraJavaOptions=-Dmenas.rest.uri=<menas_api_uri:port> -Dstandardized.hdfs.path=<path_of_standardized_input>-{0}-{1}-{2}-{3} -Dconformance.mappingtable.pattern=reportDate={0}-{1}-{2} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name>" -Dhdp.version=<hadoop_version> \
+--conf "spark.driver.extraJavaOptions=-Denceladus.rest.uri=<rest_api_uri:port> -Dstandardized.hdfs.path=<path_of_standardized_input>-{0}-{1}-{2}-{3} -Dconformance.mappingtable.pattern=reportDate={0}-{1}-{2} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name>" -Dhdp.version=<hadoop_version> \
 --packages za.co.absa:enceladus-parent:<version>,za.co.absa:enceladus-conformance:<version> \
 --class za.co.absa.enceladus.conformance.DynamicConformanceJob \
 <spark-jobs_<build_version>.jar> \
@@ -182,7 +182,7 @@ password=changeme
 --deploy-mode <client/cluster> \
 --driver-cores <num> \
 --driver-memory <num>G \
---conf "spark.driver.extraJavaOptions=-Dmenas.rest.uri=<menas_api_uri:port> -Dstandardized.hdfs.path=<path_for_standardized_output>-{0}-{1}-{2}-{3} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name> -Dhdp.version=<hadoop_version>" \
+--conf "spark.driver.extraJavaOptions=-Denceladus.rest.uri=<rest_api_uri:port> -Dstandardized.hdfs.path=<path_for_standardized_output>-{0}-{1}-{2}-{3} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name> -Dhdp.version=<hadoop_version>" \
 --class za.co.absa.enceladus.standardization_conformance.StandardizationAndConformanceJob \
 <spark-jobs_<build_version>.jar> \
 --menas-auth-keytab <path_to_keytab_file> \

--- a/examples/data/e2e_tests/test_jsons/castingConformanceRuleTest.json
+++ b/examples/data/e2e_tests/test_jsons/castingConformanceRuleTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/castingConformanceRule/std",

--- a/examples/data/e2e_tests/test_jsons/coalesceConformanceRuleTest.json
+++ b/examples/data/e2e_tests/test_jsons/coalesceConformanceRuleTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/coalesceConformanceRule/std",

--- a/examples/data/e2e_tests/test_jsons/concatenationConformanceRuleTest.json
+++ b/examples/data/e2e_tests/test_jsons/concatenationConformanceRuleTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/concatenationConformanceRule/std",

--- a/examples/data/e2e_tests/test_jsons/literalConformanceRuleTest.json
+++ b/examples/data/e2e_tests/test_jsons/literalConformanceRuleTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/literalConformanceRule/std",

--- a/examples/data/e2e_tests/test_jsons/mappingConformanceRuleTest.json
+++ b/examples/data/e2e_tests/test_jsons/mappingConformanceRuleTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/mappingConformanceRule/std",

--- a/examples/data/e2e_tests/test_jsons/negationConformanceRuleTest.json
+++ b/examples/data/e2e_tests/test_jsons/negationConformanceRuleTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/negationConformanceRule/std",

--- a/examples/data/e2e_tests/test_jsons/singleColumnConformanceRuleTest.json
+++ b/examples/data/e2e_tests/test_jsons/singleColumnConformanceRuleTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/singleColumnConformanceRule/std",

--- a/examples/data/e2e_tests/test_jsons/stdNfDnTest.json
+++ b/examples/data/e2e_tests/test_jsons/stdNfDnTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/std_nf_dn/std",

--- a/examples/data/e2e_tests/test_jsons/stdNfDyTest.json
+++ b/examples/data/e2e_tests/test_jsons/stdNfDyTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/std_nf_dy/std",

--- a/examples/data/e2e_tests/test_jsons/stdNtDnTest.json
+++ b/examples/data/e2e_tests/test_jsons/stdNtDnTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/std_nt_dn/std",

--- a/examples/data/e2e_tests/test_jsons/stdNtDyTest.json
+++ b/examples/data/e2e_tests/test_jsons/stdNtDyTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/std_nt_dy/std",

--- a/examples/data/e2e_tests/test_jsons/uppercaseConformanceRuleTest.json
+++ b/examples/data/e2e_tests/test_jsons/uppercaseConformanceRuleTest.json
@@ -2,7 +2,7 @@
 {
     "vars": {
       "spark-submit": "spark-submit --num-executors 2 --executor-memory 2G --deploy-mode client",
-      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Dmenas.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
+      "spark-conf": "--conf 'spark.driver.extraJavaOptions=-Denceladus.rest.uri=http://localhost:8080/menas/api -Dspline.mongodb.name=spline -Dspline.mongodb.url=mongodb://127.0.0.1:27017/ -Denceladus.recordId.generation.strategy=stableHashId'",
       "enceladus-job-jar": "spark-jobs/target/spark-jobs-2.19.0-SNAPSHOT.jar",
       "credentials": "--menas-credentials-file ~/.ssh/menasCredential.properties",
       "ref-std-data-path": "/ref/uppercaseConformanceRule/std",

--- a/examples/src/main/resources/application.conf.template
+++ b/examples/src/main/resources/application.conf.template
@@ -14,7 +14,7 @@
 
 # The REST API URI can specify multiple semi-colon-separated base URIs
 # each can have multiple comma-separated hosts, these are used for fault-tolerance
-enceladus.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,host2:9000/menas"
+enceladus.rest.uri="http://localhost:8080,host2:9000/rest_api;https://localhost:8080,host2:9000/rest_api"
 
 # system-wide time zone
 timezone="UTC"

--- a/examples/src/main/resources/application.conf.template
+++ b/examples/src/main/resources/application.conf.template
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The Menas URI can specify multiple semi-colon-separated base URIs
+# The REST API URI can specify multiple semi-colon-separated base URIs
 # each can have multiple comma-separated hosts, these are used for fault-tolerance
-menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,host2:9000/menas"
+enceladus.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,host2:9000/menas"
 
 # system-wide time zone
 timezone="UTC"

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample2.scala
@@ -41,7 +41,7 @@ object CustomRuleSample2 extends CustomRuleSampleFs {
   def main(args: Array[String]) {
     // scalastyle:off magic.number
     val conf = ConfigFactory.load()
-    val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
+    val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("enceladus.rest.uri"))
     val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/main/resources/user.keytab.example")
     implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample3.scala
@@ -36,7 +36,7 @@ object CustomRuleSample3 extends CustomRuleSampleFs {
 
   def main(args: Array[String]): Unit = {
     val conf = ConfigFactory.load()
-    val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
+    val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("enceladus.rest.uri"))
     val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/main/resources/user.keytab.example")
     implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)

--- a/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
+++ b/examples/src/main/scala/za/co/absa/enceladus/examples/CustomRuleSample4.scala
@@ -141,7 +141,7 @@ object CustomRuleSample4 extends CustomRuleSampleFs {
     val cmd: CmdConfigLocal = getCmdLineArguments(args)
 
     val conf = ConfigFactory.load()
-    val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
+    val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("enceladus.rest.uri"))
     val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/main/resources/user.keytab.example")
     implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
     implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)

--- a/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/XPadCustomConformanceRuleSuite.scala
+++ b/examples/src/test/scala/za/co/absa/enceladus/examples/interpreter/rules/custom/XPadCustomConformanceRuleSuite.scala
@@ -183,7 +183,7 @@ class RpadCustomConformanceRuleSuite extends AnyFunSuite with TZNormalizedSparkT
   import spark.implicits._
 
   private val conf = ConfigFactory.load()
-  private val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("menas.rest.uri"))
+  private val menasBaseUrls = MenasConnectionStringParser.parse(conf.getString("enceladus.rest.uri"))
   private val meansCredentials = MenasKerberosCredentials("user@EXAMPLE.COM", "src/test/resources/user.keytab.example")
   implicit val progArgs: ConformanceConfig = ConformanceConfig() // here we may need to specify some parameters (for certain rules)
   implicit val dao: MenasDAO = RestDaoFactory.getInstance(meansCredentials, menasBaseUrls) // you may have to hard-code your own implementation here (if not working with menas)

--- a/rest-api/src/main/resources/scheduling/oozie/workflow_template.xml
+++ b/rest-api/src/main/resources/scheduling/oozie/workflow_template.xml
@@ -32,7 +32,7 @@
                 --num-executors $stdNumExecutors
                 --executor-memory $stdExecutorMemory
                 --driver-cores $driverCores
-                --conf $sparkConfQuotesspark.driver.extraJavaOptions=-Dmenas.rest.uri='$menasRestURI' -Dspline.producer.url='$lineageWriteApiUrl' -Dlog4j.configuration='spark-log4j.properties'$sparkConfQuotes $splineMode
+                --conf $sparkConfQuotesspark.driver.extraJavaOptions=-Denceladus.rest.uri='$menasRestURI' -Dspline.producer.url='$lineageWriteApiUrl' -Dlog4j.configuration='spark-log4j.properties'$sparkConfQuotes $splineMode
                 $extraSparkConfString
             </spark-opts>
             <arg>-D</arg>
@@ -62,7 +62,7 @@
                 --num-executors $confNumExecutors
                 --executor-memory $confExecutorMemory
                 --driver-cores $driverCores
-                --conf $sparkConfQuotesspark.driver.extraJavaOptions=-Dmenas.rest.uri='$menasRestURI' -Dspline.producer.url='$lineageWriteApiUrl' -Dlog4j.configuration='spark-log4j.properties' -Dconformance.mappingtable.pattern='$mappingTablePattern'$sparkConfQuotes $splineModeConf
+                --conf $sparkConfQuotesspark.driver.extraJavaOptions=-Denceladus.rest.uri='$menasRestURI' -Dspline.producer.url='$lineageWriteApiUrl' -Dlog4j.configuration='spark-log4j.properties' -Dconformance.mappingtable.pattern='$mappingTablePattern'$sparkConfQuotes $splineModeConf
                 $extraSparkConfString
             </spark-opts>
             <arg>-D</arg>

--- a/spark-jobs/src/main/resources/reference.conf
+++ b/spark-jobs/src/main/resources/reference.conf
@@ -20,16 +20,16 @@
 
 # IMPORTANT. Add all sensitive configuration keys to Constants.ConfigKeysToRedact.
 
-# The Menas URI can specify multiple semi-colon-separated base URIs
+# The REST API URI can specify multiple semi-colon-separated base URIs
 # each can have multiple comma-separated hosts, these are used for fault-tolerance
-menas.rest.uri="http://localhost:8080,host2:9000/menas;https://localhost:8080,host2:9000/menas"
+enceladus.rest.uri="http://localhost:8080,host2:9000/rest_api;https://localhost:8080,host2:9000/rest_api"
 # Each of the above uris can be tried multiple times for fault-tolerance (optional)
-menas.rest.retryCount=0
-# The following value can be either `roundrobin` or `fallback`. It specifies in which order the Menas URLs will be used
+enceladus.rest.retryCount=0
+# The following value can be either `roundrobin` or `fallback`. It specifies in which order the REST API URLs will be used
 # - roundrobin - a random URL from the list is used, if it fails the next one is tried, if last is reached start from 0 until all are tried
 # - fallback - the first URL is used, and only if it fails the second follows etc.
 
-menas.rest.availability.setup="roundrobin"
+enceladus.rest.availability.setup="roundrobin"
 
 # 'enceladus_record_id' with an id can be added containing either true UUID, always the same IDs (row-hash-based) or the
 # column will not be added at all. Allowed values: "uuid", "stableHashId", "none"

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/common/CommonJobExecution.scala
@@ -56,9 +56,9 @@ trait CommonJobExecution extends ProjectMetadata {
 
   protected val log: Logger = LoggerFactory.getLogger(this.getClass)
   protected val configReader: ConfigReader = new ConfigReader()
-  protected val menasBaseUrls: List[String] = MenasConnectionStringParser.parse(configReader.getString("menas.rest.uri"))
-  protected val menasUrlsRetryCount: Option[Int] = configReader.getIntOption("menas.rest.retryCount")
-  protected val menasSetup: String = configReader.getString("menas.rest.availability.setup")
+  protected val menasBaseUrls: List[String] = MenasConnectionStringParser.parse(configReader.getString("enceladus.rest.uri"))
+  protected val menasUrlsRetryCount: Option[Int] = configReader.getIntOption("enceladus.rest.retryCount")
+  protected val menasSetup: String = configReader.getString("enceladus.rest.availability.setup")
   protected var secureConfig: Map[String, String] = Map.empty
 
   protected def obtainSparkSession[T](jobName: String)(implicit cmd: JobConfigParser[T]): SparkSession = {

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformance.scala
@@ -101,7 +101,7 @@ class HyperConformance (menasBaseUrls: List[String],
  * See https://github.com/AbsaOSS/hyperdrive#configuration for instructions how the component needs to be configured in Hyperdrive.
  * Example values are given below:
  * {{{
- * menas.rest.uri=http://localhost:8080
+ * enceladus.rest.uri=http://localhost:8080
  * dataset.name=example
  * dataset.version=1
  * report.date=2020-01-29

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/conformance/HyperConformanceAttributes.scala
@@ -20,9 +20,9 @@ import za.co.absa.hyperdrive.ingestor.api.{HasComponentAttributes, PropertyMetad
 object HyperConformanceAttributes {
 
   // Configuration keys expected to be set up when running Conformance as a Transformer component for Hyperdrive
-  val menasUriKey = "menas.rest.uri"
-  val menasUriRetryCountKey = "menas.rest.retryCount"
-  val menasAvailabilitySetupKey = "menas.rest.availability.setup"
+  val menasUriKey = "enceladus.rest.uri"
+  val menasUriRetryCountKey = "enceladus.rest.retryCount"
+  val menasAvailabilitySetupKey = "enceladus.rest.availability.setup"
   val menasCredentialsFileKey = "menas.credentials.file"
   val menasAuthKeytabKey = "menas.auth.keytab"
   val datasetNameKey = "dataset.name"

--- a/spark-jobs/src/test/resources/application.conf
+++ b/spark-jobs/src/test/resources/application.conf
@@ -13,7 +13,7 @@
 
 enceladus.version=${project.version}
 
-menas.rest.uri="http://localhost:8080/menas/api"
+enceladus.rest.uri="http://localhost:8080/menas/api"
 
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"
 

--- a/spark-jobs/src/test/resources/application.conf
+++ b/spark-jobs/src/test/resources/application.conf
@@ -13,7 +13,7 @@
 
 enceladus.version=${project.version}
 
-enceladus.rest.uri="http://localhost:8080/menas/api"
+enceladus.rest.uri="http://localhost:8080/rest_api"
 
 standardized.hdfs.path="/tmp/conformance-output/standardized-{0}-{1}-{2}-{3}"
 


### PR DESCRIPTION
As requested in #2105, configuration keys (spark-jobs) with prefix `menas.rest` have been changed to have prefix `enceladus.rest` instead.

Note: this PR only changes these configurations, code refactoring to remove other mentions of Menas when REST API is intended should also be covered, in another issue/PR.

## Release notes suggestion
spark-jobs: Configuration keys starting with `menas.rest` were changed to `enceladus.rest`.