### PR TITLE
#2105 Change `menas.rest` to `enceladus.rest` in Github Pages

### DIFF
--- a/_data/configuration_3_0_0.yml
+++ b/_data/configuration_3_0_0.yml
@@ -29,28 +29,28 @@
   - name: max.processing.partition.size
     options:
       - name: non-negative long integer
-        description: 'Maximal size (in bytes) for the processing partition, which would influence the written parquet file size 
+        description: 'Maximal size (in bytes) for the processing partition, which would influence the written parquet file size
         <b>NB! Experimental - sizes might still not fulfill the requested limits</b>'
-  - name: menas.rest.uri
+  - name: enceladus.rest.uri
     options:
     - name: string with URLs
-      description: 'Comma-separated list of URLs where Menas will be looked for. E.g.:
-        <code>http://example.com/menas1,http://domain.com:8080/menas2</code>'
-  - name: menas.rest.retryCount
+      description: 'Comma-separated list of URLs where REST API will be looked for. E.g.:
+        <code>http://example.com/rest_api1,http://domain.com:8080/rest_api2</code>'
+  - name: enceladus.rest.retryCount
     options:
       - name: non-negative integer
-        description: Each of the <code>menas.rest.uri</code> URLs can be tried multiple times for fault-tolerance
-  - name: menas.rest.availability.setup
+        description: Each of the <code>enceladus.rest.uri</code> URLs can be tried multiple times for fault-tolerance
+  - name: enceladus.rest.availability.setup
     options:
       - name: <i>roundrobin</i>
-        description: "(default) Starts from a random URL from the <code>menas.rest.uri</code> list, if it fails the next
+        description: "(default) Starts from a random URL from the <code>enceladus.rest.uri</code> list, if it fails the next
          one is tried, if last is reached start from 0 until all are tried"
       - name: <i>fallback</i>
         description: "Always starts from the first URL, and only if it fails the second follows etc."
   - name: min.processing.partition.size
     options:
       - name: non-negative long integer
-        description: 'Minimal size (in bytes) for the processing partition, which would influence the written parquet file size 
+        description: 'Minimal size (in bytes) for the processing partition, which would influence the written parquet file size
         <b>NB! Experimental - sizes might still not fulfill the requested limits</b>'
   - name: standardization.defaultTimestampTimeZone.default
     options:

--- a/_docs/3.0.0/usage/run.md
+++ b/_docs/3.0.0/usage/run.md
@@ -35,7 +35,7 @@ For description of requirements and deployment see the [README.md][project-readm
 --deploy-mode <client/cluster> \
 --driver-cores <num> \
 --driver-memory <num>G \
---conf "spark.driver.extraJavaOptions=-Dmenas.rest.uri=<menas_api_uri:port> -Dstandardized.hdfs.path=<path_for_standardized_output>-{0}-{1}-{2}-{3} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name> -Dhdp.version=<hadoop_version>" \
+--conf "spark.driver.extraJavaOptions=-Denceladus.rest.uri=<enceladus_api_uri:port> -Dstandardized.hdfs.path=<path_for_standardized_output>-{0}-{1}-{2}-{3} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name> -Dhdp.version=<hadoop_version>" \
 --class za.co.absa.enceladus.standardization.StandardizationJob \
 <spark-jobs_<build_version>.jar> \
 --menas-auth-keytab <path_to_keytab_file> \
@@ -61,7 +61,7 @@ For description of requirements and deployment see the [README.md][project-readm
 --driver-cores <num> \
 --driver-memory <num>G \
 --conf 'spark.ui.port=29000' \
---conf "spark.driver.extraJavaOptions=-Dmenas.rest.uri=<menas_api_uri:port> -Dstandardized.hdfs.path=<path_of_standardized_input>-{0}-{1}-{2}-{3} -Dconformance.mappingtable.pattern=reportDate={0}-{1}-{2} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name>" -Dhdp.version=<hadoop_version> \
+--conf "spark.driver.extraJavaOptions=-Denceladus.rest.uri=<enceladus_api_uri:port> -Dstandardized.hdfs.path=<path_of_standardized_input>-{0}-{1}-{2}-{3} -Dconformance.mappingtable.pattern=reportDate={0}-{1}-{2} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name>" -Dhdp.version=<hadoop_version> \
 --packages za.co.absa:enceladus-parent:<version>,za.co.absa:enceladus-conformance:<version> \
 --class za.co.absa.enceladus.conformance.DynamicConformanceJob \
 <spark-jobs_<build_version>.jar> \
@@ -82,7 +82,7 @@ For description of requirements and deployment see the [README.md][project-readm
 --deploy-mode <client/cluster> \
 --driver-cores <num> \
 --driver-memory <num>G \
---conf "spark.driver.extraJavaOptions=-Dmenas.rest.uri=<menas_api_uri:port> -Dstandardized.hdfs.path=<path_for_standardized_output>-{0}-{1}-{2}-{3} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name> -Dhdp.version=<hadoop_version>" \
+--conf "spark.driver.extraJavaOptions=-Denceladus.rest.uri=<enceladus_api_uri:port> -Dstandardized.hdfs.path=<path_for_standardized_output>-{0}-{1}-{2}-{3} -Dspline.mongodb.url=<mongo_url_for_spline> -Dspline.mongodb.name=<spline_database_name> -Dhdp.version=<hadoop_version>" \
 --class za.co.absa.enceladus.standardization_conformance.StandardizationAndConformanceJob \
 <spark-jobs_<build_version>.jar> \
 --menas-auth-keytab <path_to_keytab_file> \


### PR DESCRIPTION
[#2105] Documentation (3.0.0) of spark-jobs that described `menas.rest`-prefixed confs has been updated as these now describe `enceladus.rest`-prefixed confs.