### PR TITLE
#2112 Fix `and` and `or` functions in DataFrameFilter

### DIFF
--- a/data-model/src/main/scala/za/co/absa/enceladus/model/dataFrameFilter/package.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/dataFrameFilter/package.scala
@@ -40,7 +40,7 @@ package object dataFrameFilter {
     @JsonIgnore def filter: Column
     @JsonIgnore def or(otherFilter: DataFrameFilter): DataFrameFilter = {
       (this, otherFilter) match {
-        case (a: OrJoinedFilters, b: OrJoinedFilters) => OrJoinedFilters(a.filterItems & b.filterItems)
+        case (a: OrJoinedFilters, b: OrJoinedFilters) => OrJoinedFilters(a.filterItems union b.filterItems)
         case (a: OrJoinedFilters, b) => a.copy(filterItems = a.filterItems + b)
         case (a, b: OrJoinedFilters) => b.copy(filterItems = b.filterItems + a)
         case (a, b) => OrJoinedFilters(Set(a, b))
@@ -48,7 +48,7 @@ package object dataFrameFilter {
     }
     @JsonIgnore def and(otherFilter: DataFrameFilter): DataFrameFilter = {
       (this, otherFilter) match {
-        case (a: AndJoinedFilters, b: AndJoinedFilters) => AndJoinedFilters(a.filterItems & b.filterItems)
+        case (a: AndJoinedFilters, b: AndJoinedFilters) => AndJoinedFilters(a.filterItems union b.filterItems)
         case (a: AndJoinedFilters, b) => a.copy(filterItems = a.filterItems + b)
         case (a, b: AndJoinedFilters) => b.copy(filterItems = b.filterItems + a)
         case (a, b) => AndJoinedFilters(Set(a, b))

--- a/data-model/src/test/scala/za/co/absa/enceladus/model/dataFrameFilter/DataFrameFilterSuite.scala
+++ b/data-model/src/test/scala/za/co/absa/enceladus/model/dataFrameFilter/DataFrameFilterSuite.scala
@@ -67,6 +67,50 @@ class DataFrameFilterSuite extends AnyFunSuite {
     assert(filterExpr2.semanticEquals(expected))
   }
 
+  test("Two OR filters joined with an `or` condition") {
+    val leftF1 = DiffersFilter("column1", "v1")
+    val leftF2 = EqualsFilter("column1", "v1")
+    val childOrLeft = OrJoinedFilters(Set(leftF1, leftF2))
+
+    val rightF1 = DiffersFilter("column2", "v2")
+    val rightF2 = EqualsFilter("column2", "v2")
+    val rightF3 = EqualsFilter("column1", "v1")
+    val childOrRight = OrJoinedFilters(Set(rightF1, rightF2, rightF3))
+
+    val parentOr = childOrLeft or childOrRight
+
+    val actualFilterExpr = parentOr.filter.expr
+
+    val expected = ((col("column1") =!= lit("v1")) or
+      (col("column1") === lit("v1")) or
+      (col("column2") =!= lit("v2")) or
+      (col("column2") === lit("v2"))).expr
+
+    assert(actualFilterExpr semanticEquals expected)
+  }
+
+  test("Two AND filters joined with an `and` condition") {
+    val leftF1 = DiffersFilter("column1", "v1")
+    val leftF2 = EqualsFilter("column1", "v1")
+    val childAndLeft = AndJoinedFilters(Set(leftF1, leftF2))
+
+    val rightF1 = DiffersFilter("column2", "v2")
+    val rightF2 = EqualsFilter("column2", "v2")
+    val rightF3 = EqualsFilter("column1", "v1")
+    val childAndRight = AndJoinedFilters(Set(rightF1, rightF2, rightF3))
+
+    val parentAnd = childAndLeft and childAndRight
+
+    val actualFilterExpr = parentAnd.filter.expr
+
+    val expected = ((col("column1") =!= lit("v1")) and
+      (col("column1") === lit("v1")) and
+      (col("column2") =!= lit("v2")) and
+      (col("column2") === lit("v2"))).expr
+
+    assert(actualFilterExpr semanticEquals expected)
+  }
+
   test("Filter with or within and") {
     val f1 = EqualsFilter("column1", "v1")
     val f2 = EqualsFilter("column2", "2", IntegerType)


### PR DESCRIPTION
Changed set `&` to `union` in `and` and `or` functions in case two `AND`/`OR` filters are joined.

Fixes #2112 