### PR TITLE
#2121 Implement retries quadratic+randomised backoff mechanism

### DIFF
--- a/dao/src/main/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCaller.scala
+++ b/dao/src/main/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCaller.scala
@@ -65,7 +65,7 @@ object CrossHostApiCaller {
   }
 
   private def quadraticRandomizedRetryBackoffStrategy(retryNumber: Int): Unit = {
-    val inSeconds: Double = retryNumber * retryNumber + Random.nextDouble()
+    val inSeconds: Double = retryNumber * retryNumber + retryNumber * Random.nextDouble()
     val inMillis = inSeconds * 1000
     Thread.sleep(inMillis.toLong)
   }

--- a/dao/src/main/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCaller.scala
+++ b/dao/src/main/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCaller.scala
@@ -36,7 +36,8 @@ object CrossHostApiCaller {
       apiBaseUrls: Seq[String],
       urlsRetryCount: Int,
       startWith: Option[Int],
-      optionallyRetryableExceptions: Set[OptRetryableExceptions]
+      optionallyRetryableExceptions: Set[OptRetryableExceptions],
+      retryBackoffStrategy: Int => Unit
   ): CrossHostApiCaller = {
     val maxTryCount: Int = (if (urlsRetryCount < 0) {
       logger.warn(
@@ -48,16 +49,25 @@ object CrossHostApiCaller {
       urlsRetryCount
     }) + 1
     val currentHostIndex = startWith.getOrElse(Random.nextInt(Math.max(apiBaseUrls.size, 1)))
-    new CrossHostApiCaller(apiBaseUrls.toVector, maxTryCount, currentHostIndex, optionallyRetryableExceptions)
+    new CrossHostApiCaller(
+      apiBaseUrls.toVector, maxTryCount, currentHostIndex, optionallyRetryableExceptions, retryBackoffStrategy
+    )
   }
 
   def apply(
       apiBaseUrls: Seq[String],
       urlsRetryCount: Int = DefaultUrlsRetryCount,
       startWith: Option[Int] = None,
-      optionallyRetryableExceptions: Set[OptRetryableExceptions] = Set.empty
+      optionallyRetryableExceptions: Set[OptRetryableExceptions] = Set.empty,
+      retryBackoffStrategy: Int => Unit = quadraticRandomizedRetryBackoffStrategy
    ): CrossHostApiCaller = {
-    createInstance(apiBaseUrls, urlsRetryCount, startWith, optionallyRetryableExceptions)
+    createInstance(apiBaseUrls, urlsRetryCount, startWith, optionallyRetryableExceptions, retryBackoffStrategy)
+  }
+
+  private def quadraticRandomizedRetryBackoffStrategy(retryNumber: Int): Unit = {
+    val inSeconds: Double = retryNumber * retryNumber + Random.nextDouble()
+    val inMillis = inSeconds * 1000
+    Thread.sleep(inMillis.toLong)
   }
 }
 
@@ -65,7 +75,8 @@ protected class CrossHostApiCaller private(
     apiBaseUrls: Vector[String],
     maxTryCount: Int,
     private var currentHostIndex: Int,
-    optionallyRetryableExceptions: Set[OptRetryableExceptions]
+    optionallyRetryableExceptions: Set[OptRetryableExceptions],
+    retryBackoffStrategy: Int => Unit
 )
   extends ApiCaller {
 
@@ -103,11 +114,13 @@ protected class CrossHostApiCaller private(
       result match {
         case Failure(e: RestApiException) if retryableExceptions.contains(e.getClass) && attemptNumber < maxTryCount =>
           logFailure(e, url, attemptNumber, None)
+          retryBackoffStrategy(attemptNumber)
           attempt(url, attemptNumber + 1, urlsTried)
 
         case Failure(e: RestApiException) if retryableExceptions.contains(e.getClass) && urlsTried < baseUrlsCount =>
           val nextUrl = nextBaseUrl()
           logFailure(e, url, attemptNumber, Option(nextUrl))
+          retryBackoffStrategy(1) // to have small delay between trying different URLs
           attempt(nextUrl, 1, urlsTried + 1)
 
         case _ => result

--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCallerSuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCallerSuite.scala
@@ -24,7 +24,7 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
 
   private val restClient = mock[RestClient]
 
-  private def zeroWaitRetryBackoffStrategy(retryNumber: Int): Unit = {}
+  private def zeroWaitRetryBackoffStrategy(retryNumber: Int): Int = 0
 
   before {
     Mockito.reset(restClient)
@@ -151,6 +151,89 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
         Mockito.verify(restClient, Mockito.times(3)).sendGet[String]("b")
         Mockito.verify(restClient, Mockito.never()).sendGet[String]("c")
       }
+
+      "retryBackoffStrategy is called with retry number increasing by 1 in each attempt on single URI retrying" in {
+        val mockedRetryBackoffStrategy = mock[Int => Int]
+        Mockito
+          .when(restClient.sendGet[String]("a"))
+          .thenThrow(new ResourceAccessException("Something went wrong A"))
+          .thenThrow(new ResourceAccessException("Something went wrong A"))
+          .thenThrow(new ResourceAccessException("Something went wrong A"))
+          .thenReturn("success")
+
+        CrossHostApiCaller(
+          Vector("a"),
+          3,
+          Some(0),
+          Set(classOf[OptionallyRetryableException.ForbiddenException]),
+          retryBackoffStrategy = mockedRetryBackoffStrategy
+        ).call { str =>
+          restClient.sendGet[String](str)
+        }
+
+        val inOrder = Mockito.inOrder(mockedRetryBackoffStrategy)
+        inOrder.verify(mockedRetryBackoffStrategy).apply(1)
+        inOrder.verify(mockedRetryBackoffStrategy).apply(2)
+        inOrder.verify(mockedRetryBackoffStrategy).apply(3)
+        inOrder.verify(mockedRetryBackoffStrategy, Mockito.never()).apply(4)
+      }
+
+      "retryBackoffStrategy is called with retry number = 1 when switching URIs" in {
+        val mockedRetryBackoffStrategy = mock[Int => Int]
+        Mockito
+          .when(restClient.sendGet[String]("a"))
+          .thenThrow(new ResourceAccessException("Something went wrong A"))
+        Mockito
+          .when(restClient.sendGet[String]("b"))
+          .thenReturn("success")
+
+        CrossHostApiCaller(
+          Vector("a", "b"),
+          0,
+          Some(0),
+          Set(classOf[OptionallyRetryableException.ForbiddenException]),
+          retryBackoffStrategy = mockedRetryBackoffStrategy
+        ).call { str =>
+          restClient.sendGet[String](str)
+        }
+
+        val inOrder = Mockito.inOrder(mockedRetryBackoffStrategy)
+        inOrder.verify(mockedRetryBackoffStrategy).apply(1)
+        inOrder.verify(mockedRetryBackoffStrategy, Mockito.never()).apply(2)
+      }
+
+      "retryBackoffStrategy is called with retry number starting again from 1 when using next URI" in {
+        val mockedRetryBackoffStrategy = mock[Int => Int]
+        Mockito
+          .when(restClient.sendGet[String]("a"))
+          .thenThrow(new ResourceAccessException("Something went wrong A"))
+          .thenThrow(new ResourceAccessException("Something went wrong A"))
+          .thenThrow(new ResourceAccessException("Something went wrong A"))
+        Mockito
+          .when(restClient.sendGet[String]("b"))
+          .thenThrow(new ResourceAccessException("Something went wrong B"))
+          .thenThrow(new ResourceAccessException("Something went wrong B"))
+          .thenReturn("success")
+
+        CrossHostApiCaller(
+          Vector("a", "b"),
+          2,
+          Some(0),
+          Set(classOf[OptionallyRetryableException.ForbiddenException]),
+          retryBackoffStrategy = mockedRetryBackoffStrategy
+        ).call { str =>
+          restClient.sendGet[String](str)
+        }
+
+        val inOrder = Mockito.inOrder(mockedRetryBackoffStrategy)
+        inOrder.verify(mockedRetryBackoffStrategy).apply(1)
+        inOrder.verify(mockedRetryBackoffStrategy).apply(2)
+        inOrder.verify(mockedRetryBackoffStrategy, Mockito.never()).apply(3)
+        // times 2 because one time in between URIs switch, and another after switched to new URI and failed
+        inOrder.verify(mockedRetryBackoffStrategy, Mockito.times(2)).apply(1)
+        inOrder.verify(mockedRetryBackoffStrategy).apply(2)
+        inOrder.verify(mockedRetryBackoffStrategy, Mockito.never()).apply(3)
+      }
     }
 
     "propagate the exception" when {
@@ -239,6 +322,21 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
         }
         exception.getMessage should be ("0")
       }
+    }
+  }
+
+  "CrossHostApiCaller::quadraticRandomizedRetryBackoffStrategy" should {
+    "return number of milliseconds that are in range bounded by 1000 * (x^2 + x*random_0_to_1)" in {
+      val when0 = CrossHostApiCaller.quadraticRandomizedRetryBackoffStrategy(0)
+      when0 shouldEqual 0
+
+      val when1 = CrossHostApiCaller.quadraticRandomizedRetryBackoffStrategy(1)
+      when1 should be >= 1000
+      when1 should be <= 2000
+
+      val when5 = CrossHostApiCaller.quadraticRandomizedRetryBackoffStrategy(5)
+      when5 should be >= 25000
+      when5 should be <= 30000
     }
   }
 

--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCallerSuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/CrossHostApiCallerSuite.scala
@@ -24,6 +24,8 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
 
   private val restClient = mock[RestClient]
 
+  private def zeroWaitRetryBackoffStrategy(retryNumber: Int): Unit = {}
+
   before {
     Mockito.reset(restClient)
   }
@@ -46,7 +48,10 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
         Mockito.when(restClient.sendGet[String]("a")).thenReturn("success")
 
         val result = CrossHostApiCaller(
-          Vector("a", "b", "c"), DefaultUrlsRetryCount, startWith = Some(0)
+          Vector("a", "b", "c"),
+          DefaultUrlsRetryCount,
+          startWith = Some(0),
+          retryBackoffStrategy = zeroWaitRetryBackoffStrategy
         ).call { str =>
           restClient.sendGet[String](str)
         }
@@ -62,7 +67,12 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
           .thenThrow(RetryableException.DaoException("Something went wrong B"))
           .thenReturn("success")
 
-        val result = CrossHostApiCaller(Vector("a", "b", "c"), 2, Some(0)).call { str =>
+        val result = CrossHostApiCaller(
+          Vector("a", "b", "c"),
+          2,
+          Some(0),
+          retryBackoffStrategy = zeroWaitRetryBackoffStrategy
+        ).call { str =>
           restClient.sendGet[String](str)
         }
 
@@ -79,7 +89,12 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
           .thenThrow(RetryableException.DaoException("Something went wrong B"))
         Mockito.when(restClient.sendGet[String]("c")).thenReturn("success")
 
-        val result = CrossHostApiCaller(Vector("a", "b", "c"), -2, Some(0)).call { str =>
+        val result = CrossHostApiCaller(
+          Vector("a", "b", "c"),
+          -2,
+          Some(0),
+          retryBackoffStrategy = zeroWaitRetryBackoffStrategy
+        ).call { str =>
           restClient.sendGet[String](str)
         }
 
@@ -98,7 +113,11 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
           .thenReturn("success")
 
         val result = CrossHostApiCaller(
-          Vector("a", "b", "c"), 2, Some(0), Set(classOf[OptionallyRetryableException.NotFoundException])
+          Vector("a", "b", "c"),
+          2,
+          Some(0),
+          Set(classOf[OptionallyRetryableException.NotFoundException]),
+          retryBackoffStrategy = zeroWaitRetryBackoffStrategy
         ).call { str =>
           restClient.sendGet[String](str)
         }
@@ -118,7 +137,11 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
           .thenReturn("success")
 
         val result = CrossHostApiCaller(
-          Vector("a", "b", "c"), 2, Some(0), Set(classOf[OptionallyRetryableException.ForbiddenException])
+          Vector("a", "b", "c"),
+          2,
+          Some(0),
+          Set(classOf[OptionallyRetryableException.ForbiddenException]),
+          retryBackoffStrategy = zeroWaitRetryBackoffStrategy
         ).call { str =>
           restClient.sendGet[String](str)
         }
@@ -140,7 +163,12 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
           .thenThrow(RetryableException.DaoException("Something went wrong C"))
 
         val exception = intercept[RetryableException.DaoException] {
-          CrossHostApiCaller(Vector("a", "b", "c"), 0, Some(0)).call { str =>
+          CrossHostApiCaller(
+            Vector("a", "b", "c"),
+            0,
+            Some(0),
+            retryBackoffStrategy = zeroWaitRetryBackoffStrategy
+          ).call { str =>
             restClient.sendGet[String](str)
           }
         }
@@ -160,7 +188,12 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
           .thenThrow(RetryableException.DaoException("Something went wrong C"))
 
         val exception = intercept[RetryableException.DaoException] {
-          CrossHostApiCaller(Vector("a", "b", "c"), 1, Some(0)).call { str =>
+          CrossHostApiCaller(
+            Vector("a", "b", "c"),
+            1,
+            Some(0),
+            retryBackoffStrategy = zeroWaitRetryBackoffStrategy
+          ).call { str =>
             restClient.sendGet[String](str)
           }
         }
@@ -180,7 +213,12 @@ class CrossHostApiCallerSuite extends BaseTestSuite {
         )
 
         val exception = intercept[NotRetryableException.AuthenticationException] {
-          CrossHostApiCaller(Vector("a", "b", "c"), 0, Some(0)).call { str =>
+          CrossHostApiCaller(
+            Vector("a", "b", "c"),
+            0,
+            Some(0),
+            retryBackoffStrategy = zeroWaitRetryBackoffStrategy
+          ).call { str =>
             restClient.sendGet[String](str)
           }
         }

--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/RestDaoFactorySuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/RestDaoFactorySuite.scala
@@ -61,7 +61,7 @@ class RestDaoFactorySuite extends AnyWordSpec with Matchers with ArgumentMatcher
               any[Int],
               any[Option[Int]],
               any[Set[OptionallyRetryableException.OptRetryableExceptions]],
-              any[Int => Unit]
+              any[Int => Int]
             )
           ).thenReturn(fooCrossHostApiCaller)
           val restDao = RestDaoFactory.getInstance(plainCredentials, menasApiBaseUrls)
@@ -80,7 +80,7 @@ class RestDaoFactorySuite extends AnyWordSpec with Matchers with ArgumentMatcher
               any[Int],
               any[Option[Int]],
               any[Set[OptionallyRetryableException.OptRetryableExceptions]],
-              any[Int => Unit]
+              any[Int => Int]
             )
           ).thenReturn(fooCrossHostApiCaller)
           val plainCredentials = MenasPlainCredentials("user", "changeme")
@@ -101,7 +101,7 @@ class RestDaoFactorySuite extends AnyWordSpec with Matchers with ArgumentMatcher
               any[Int],
               any[Option[Int]],
               any[Set[OptionallyRetryableException.OptRetryableExceptions]],
-              any[Int => Unit]
+              any[Int => Int]
             )
           ).thenReturn(fooCrossHostApiCaller)
           val restDao = RestDaoFactory.getInstance(plainCredentials, menasApiBaseUrls)

--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/RestDaoFactorySuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/RestDaoFactorySuite.scala
@@ -57,7 +57,11 @@ class RestDaoFactorySuite extends AnyWordSpec with Matchers with ArgumentMatcher
         withObjectMocked[CrossHostApiCaller.type] {
           Mockito.when(
             CrossHostApiCaller.apply(
-              any[Seq[String]], any[Int], any[Option[Int]], any[Set[OptionallyRetryableException.OptRetryableExceptions]]
+              any[Seq[String]],
+              any[Int],
+              any[Option[Int]],
+              any[Set[OptionallyRetryableException.OptRetryableExceptions]],
+              any[Int => Unit]
             )
           ).thenReturn(fooCrossHostApiCaller)
           val restDao = RestDaoFactory.getInstance(plainCredentials, menasApiBaseUrls)
@@ -72,7 +76,11 @@ class RestDaoFactorySuite extends AnyWordSpec with Matchers with ArgumentMatcher
         withObjectMocked[CrossHostApiCaller.type] {
           Mockito.when(
             CrossHostApiCaller.apply(
-              any[Seq[String]], any[Int], any[Option[Int]], any[Set[OptionallyRetryableException.OptRetryableExceptions]]
+              any[Seq[String]],
+              any[Int],
+              any[Option[Int]],
+              any[Set[OptionallyRetryableException.OptRetryableExceptions]],
+              any[Int => Unit]
             )
           ).thenReturn(fooCrossHostApiCaller)
           val plainCredentials = MenasPlainCredentials("user", "changeme")
@@ -89,7 +97,11 @@ class RestDaoFactorySuite extends AnyWordSpec with Matchers with ArgumentMatcher
         withObjectMocked[CrossHostApiCaller.type] {
           Mockito.when(
             CrossHostApiCaller.apply(
-              any[Seq[String]], any[Int], any[Option[Int]], any[Set[OptionallyRetryableException.OptRetryableExceptions]]
+              any[Seq[String]],
+              any[Int],
+              any[Option[Int]],
+              any[Set[OptionallyRetryableException.OptRetryableExceptions]],
+              any[Int => Unit]
             )
           ).thenReturn(fooCrossHostApiCaller)
           val restDao = RestDaoFactory.getInstance(plainCredentials, menasApiBaseUrls)


### PR DESCRIPTION
- Added `retryBackoffStrategy` parameter to CrossHostApiCaller constructor
- Used `retryBackoffStrategy` as a step in retrying a call
- Implemented quadratic `retryBackoffStrategy` with randomised addition of 0-1s to delay

Closes #2121 