### PR TITLE
#2131 Remove CSRF token and JWT in cookies

### DIFF
--- a/dao/src/main/scala/za/co/absa/enceladus/dao/rest/AuthClient.scala
+++ b/dao/src/main/scala/za/co/absa/enceladus/dao/rest/AuthClient.scala
@@ -88,14 +88,11 @@ sealed abstract class AuthClient(username: String, restTemplate: RestTemplate, a
   private def getAuthHeaders(response: ResponseEntity[String]): HttpHeaders = {
     val headers = response.getHeaders
     val jwt = headers.get("JWT").asScala.head
-    val csrfToken = headers.get("X-CSRF-TOKEN").asScala.head
 
     log.info(s"JWT: $jwt")
-    log.info(s"CSRF Token: $csrfToken")
 
     val resultHeaders = new HttpHeaders()
     resultHeaders.add("JWT", jwt)
-    resultHeaders.add("X-CSRF-TOKEN", csrfToken)
     resultHeaders
   }
 

--- a/dao/src/test/scala/za/co/absa/enceladus/dao/rest/auth/AuthClientSuite.scala
+++ b/dao/src/test/scala/za/co/absa/enceladus/dao/rest/auth/AuthClientSuite.scala
@@ -46,17 +46,14 @@ abstract class AuthClientSuite() extends AnyWordSpec
   s"Calling authenticate()" should {
     "return authentication headers on 200 OK" in {
       val jwt = "jwt"
-      val csrfToken = "csrf-token"
 
       val responseHeaders = new LinkedMultiValueMap[String, String]
       responseHeaders.add("jwt", jwt)
-      responseHeaders.add("x-csrf-token", csrfToken)
 
       setUpSuccessfulAuthRequest(responseHeaders)
 
       val expected = new HttpHeaders()
       expected.add("jwt", jwt)
-      expected.add("x-csrf-token", csrfToken)
 
       val response = authClient.authenticate()
 

--- a/menas/ui/components/login/loginDetail.controller.js
+++ b/menas/ui/components/login/loginDetail.controller.js
@@ -139,7 +139,6 @@ sap.ui.define([
         this.byId("password").setValue("");
         let jwt = xhr.getResponseHeader("JWT");
         localStorage.setItem("jwtToken", jwt);
-        setCookie("JWT", jwt, 1);
         Functions.ajax("/user/info", "GET", {}, (oInfo) => {
           model.setProperty("/userInfo", oInfo);
           model.setProperty("/menasVersion", oInfo.menasVersion);

--- a/menas/ui/components/login/loginDetail.controller.js
+++ b/menas/ui/components/login/loginDetail.controller.js
@@ -137,9 +137,7 @@ sap.ui.define([
 
       let fnSuccess = (result, status, xhr) => {
         this.byId("password").setValue("");
-        let csrfToken = xhr.getResponseHeader("X-CSRF-TOKEN");
         let jwt = xhr.getResponseHeader("JWT");
-        localStorage.setItem("csrfToken", csrfToken);
         localStorage.setItem("jwtToken", jwt);
         setCookie("JWT", jwt, 1);
         Functions.ajax("/user/info", "GET", {}, (oInfo) => {

--- a/menas/ui/components/schema/schemaDetail.controller.js
+++ b/menas/ui/components/schema/schemaDetail.controller.js
@@ -162,12 +162,7 @@ sap.ui.define([
       if (this.validateSchemaFileUplaod()) {
         const oFileUpload = this.byId("fileUploader");
         sap.ui.core.BusyIndicator.show();
-        // include CSRF token here - it may have changed between sessions
         oFileUpload.removeAllHeaderParameters();
-        oFileUpload.addHeaderParameter(new sap.ui.unified.FileUploaderParameter({
-          name: "X-CSRF-TOKEN",
-          value: localStorage.getItem("csrfToken")
-        }));
         oFileUpload.addHeaderParameter(new sap.ui.unified.FileUploaderParameter({
           name: "JWT",
           value: localStorage.getItem("jwtToken")
@@ -196,8 +191,7 @@ sap.ui.define([
           contentType: 'application/x-www-form-urlencoded',
           context: this, // becomes the result of "this" in handleRemoteLoad*Complete
           headers: {
-            "JWT": localStorage.getItem("jwtToken"),
-            'X-CSRF-TOKEN': localStorage.getItem("csrfToken")
+            "JWT": localStorage.getItem("jwtToken")
           },
           complete: this.handleRemoteLoadFromSubjectNameComplete
         });
@@ -228,9 +222,6 @@ sap.ui.define([
         data: $.param(data),
         contentType: 'application/x-www-form-urlencoded',
         context: this, // becomes the result of "this" in handleRemoteLoad*Complete
-        headers: {
-          'X-CSRF-TOKEN': localStorage.getItem("csrfToken")
-        },
         complete: this.handleRemoteLoadFromUrlComplete
       });
     },
@@ -399,8 +390,7 @@ sap.ui.define([
         url: window.apiUrl + "/schema/features",
         type: 'GET',
         headers: {
-          "JWT": localStorage.getItem("jwtToken"),
-          'X-CSRF-TOKEN': localStorage.getItem("csrfToken")
+          "JWT": localStorage.getItem("jwtToken")
         },
         context: this,
         complete: this.handleRegistryIntegrationResponse

--- a/menas/ui/generic/functions.js
+++ b/menas/ui/generic/functions.js
@@ -14,7 +14,6 @@
  */
 
 var Functions = new function () {
-  this.csrfHeader = "X-CSRF-TOKEN";
   this.jwtHeader = "JWT"
 
   this.ajax = function (sPath, sMethod, oData, fnSuccess, fnError, oControl) {
@@ -30,10 +29,7 @@ var Functions = new function () {
 
     return $.ajax(window.apiUrl + sPath, {
       beforeSend: (oJqXHR, oSettings) => {
-          let csrfToken = localStorage.getItem("csrfToken");
           let jwtToken = localStorage.getItem("jwtToken");
-          console.log("CSRF: " + this.csrfHeader + " -> " + csrfToken);
-          oJqXHR.setRequestHeader(this.csrfHeader, csrfToken);
           oJqXHR.setRequestHeader(this.jwtHeader, jwtToken);
       },
       complete: function () {

--- a/menas/ui/service/GenericService.js
+++ b/menas/ui/service/GenericService.js
@@ -34,8 +34,7 @@ var GenericService = new function () {
       return v ? v[2] : null;
     }
 
-    let cookie = getCookie("JWT");
-    let jwt = cookie ? cookie : localStorage.getItem("jwtToken");
+    let jwt = localStorage.getItem("jwtToken");
 
     $.ajax(window.apiUrl + "/user/info", {
       headers: {
@@ -94,7 +93,6 @@ var GenericService = new function () {
   this.clearSession = function (sLogoutMessage) {
     model().setProperty("/userInfo", {});
     localStorage.clear();
-    document.cookie = `JWT=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=${window.location.pathname.slice(0, -1)}`;
     eventBus.publish("nav", "logout");
     if (sLogoutMessage) {
       sap.m.MessageToast.show(sLogoutMessage, {

--- a/menas/ui/service/RestDAO.js
+++ b/menas/ui/service/RestDAO.js
@@ -20,7 +20,6 @@ class RestClient {
   static get(url, shouldUseCache = false) {
     let request = {
       headers: {
-        "X-CSRF-TOKEN": localStorage.getItem("csrfToken"),
         "JWT": localStorage.getItem("jwtToken")
       },
       url: window.apiUrl + url,
@@ -34,7 +33,6 @@ class RestClient {
     let requestUrl = isWeb ? url : (window.apiUrl + url);
     let request = {
       headers: {
-        "X-CSRF-TOKEN": localStorage.getItem("csrfToken"),
         "JWT": localStorage.getItem("jwtToken")
       },
       url: requestUrl,
@@ -50,7 +48,6 @@ class RestClient {
       data: JSON.stringify(data),
       contentType: "application/json",
       headers: {
-        "X-CSRF-TOKEN": localStorage.getItem("csrfToken"),
         "JWT": localStorage.getItem("jwtToken")
       },
     });
@@ -64,7 +61,6 @@ class RestClient {
       data: JSON.stringify(data),
       contentType: "application/json",
       headers: {
-        "X-CSRF-TOKEN": localStorage.getItem("csrfToken"),
         "JWT": localStorage.getItem("jwtToken")
       }
     });
@@ -76,7 +72,6 @@ class RestClient {
       url: window.apiUrl + url,
       type: "DELETE",
       headers: {
-        "X-CSRF-TOKEN": localStorage.getItem("csrfToken"),
         "JWT": localStorage.getItem("jwtToken")
       }
     });

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/MvcConfig.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/MvcConfig.scala
@@ -18,7 +18,7 @@ package za.co.absa.enceladus.rest_api
 import org.springframework.context.annotation.Configuration
 import org.springframework.format.FormatterRegistry
 import org.springframework.web.servlet.config.annotation.{CorsRegistry, ViewControllerRegistry, WebMvcConfigurer}
-import za.co.absa.enceladus.rest_api.auth.AuthConstants.{CsrfTokenKey, JwtKey}
+import za.co.absa.enceladus.rest_api.auth.AuthConstants.JwtKey
 import za.co.absa.enceladus.rest_api.utils.converters.StringToValidationKindConverter
 
 @Configuration
@@ -29,7 +29,7 @@ class MvcConfig extends WebMvcConfigurer {
 
   override def addCorsMappings(registry: CorsRegistry): Unit = {
     registry.addMapping("/**")
-      .exposedHeaders(JwtKey, CsrfTokenKey)
+      .exposedHeaders(JwtKey)
       .allowedMethods("PUT", "GET", "DELETE", "OPTIONS", "PATCH", "POST")
       .allowedHeaders("*")
       .allowedOrigins("*")

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/auth/AuthConstants.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/auth/AuthConstants.scala
@@ -32,6 +32,5 @@ class AuthConstants @Autowired()() {
 object AuthConstants {
 
   val JwtKey: String = "JWT"
-  val CsrfTokenKey: String = "X-CSRF-TOKEN"
   val RolesKey: String = "Roles"
 }

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/auth/MenasAuthenticationSuccessHandler.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/auth/MenasAuthenticationSuccessHandler.scala
@@ -15,8 +15,6 @@
 
 package za.co.absa.enceladus.rest_api.auth
 
-import java.util.UUID
-
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import org.joda.time.{DateTime, DateTimeZone, Hours}
 import org.springframework.beans.factory.annotation.{Autowired, Value}
@@ -42,8 +40,6 @@ class MenasAuthenticationSuccessHandler @Autowired()(jwtFactory: JwtFactory,
                                        response: HttpServletResponse,
                                        authentication: Authentication): Unit = {
     val user = authentication.getPrincipal.asInstanceOf[UserDetails]
-    val csrfToken = UUID.randomUUID().toString
-    response.addHeader(CsrfTokenKey, csrfToken)
 
     val expiry = Hours.hours(jwtLifespanHours).toStandardSeconds
     val jwtExpirationTime = DateTime.now(DateTimeZone.forID(timezone)).plus(expiry).toDate
@@ -61,7 +57,6 @@ class MenasAuthenticationSuccessHandler @Autowired()(jwtFactory: JwtFactory,
       .jwtBuilder()
       .setSubject(user.getUsername)
       .setExpiration(jwtExpirationTime)
-      .claim(CsrfTokenKey, csrfToken)
       .claim(RolesKey, filteredGroups)
       .compact()
 

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/auth/jwt/JwtAuthenticationFilter.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/auth/jwt/JwtAuthenticationFilter.scala
@@ -54,13 +54,7 @@ class JwtAuthenticationFilter @Autowired()(jwtFactory: JwtFactory) extends OnceP
         case Failure(exception) =>
           logger.warn(s"JWT authentication failed $exception")
           None
-        case Success(jwtClaims) =>
-          if (isCsrfSafe(request, jwtClaims)) {
-            Option(parseJwtClaims(jwtClaims))
-          } else {
-            logger.warn("JWT authentication failed: Incorrect CSRF token")
-            None
-          }
+        case Success(jwtClaims) => Option(parseJwtClaims(jwtClaims))
       }
     }
   }
@@ -78,17 +72,6 @@ class JwtAuthenticationFilter @Autowired()(jwtFactory: JwtFactory) extends OnceP
     .fold(Seq.empty[String])(_.asScala.toSeq)
 
     groups.map(k => new SimpleGrantedAuthority(k)).asJava
-  }
-
-  private def isCsrfSafe(request: HttpServletRequest, jwtClaims: Claims): Boolean = {
-    request.getMethod.toUpperCase match {
-      case "GET" => true
-      case _     =>
-        val csrfToken = Option(request.getHeader(CsrfTokenKey))
-        val jwtCsrfToken = jwtClaims.get(CsrfTokenKey, classOf[String])
-        csrfToken.contains(jwtCsrfToken)
-    }
-
   }
 
   private def getJwt(request: HttpServletRequest): Option[String] = {

--- a/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/BaseRestApiTest.scala
+++ b/rest-api/src/test/scala/za/co/absa/enceladus/rest_api/integration/controllers/BaseRestApiTest.scala
@@ -81,10 +81,8 @@ abstract class BaseRestApiTest(loginPath: String, apiPath: String) extends BaseR
     val response = restTemplate.postForEntity(loginUrl, HttpEntity.EMPTY, classOf[String])
 
     val jwtToken = response.getHeaders.get("jwt").get(0)
-    val csrfToken = response.getHeaders.get("X-CSRF-TOKEN").get(0)
     val headers = new HttpHeaders()
     headers.add("jwt", jwtToken)
-    headers.add("X-CSRF-TOKEN", csrfToken)
     headers
   }
 


### PR DESCRIPTION
- removed CSRF token from JWT claims and local storage as it is needed when JWT is set in HttpOnly cookie, and currently in Enceladus JWT is saved on frontend side in local storage (so CSRF doesn't seem to be possible)
- removed setting JWT in cookies explicitly on frontend side as this doesn't seem to be useful

Closes #2131 