### PR TITLE
#2154 CVE fix: Atum updated to v3.9.0

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -42,17 +42,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.spark.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>
-            <version>${jackson.spark.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.spark.datatype.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security.kerberos</groupId>

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.spark.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>
-            <version>${jackson.spark.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/Dataset.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/Dataset.scala
@@ -131,7 +131,7 @@ case class Dataset(name: String,
     val conformanceJsonList: ArrayNode = objectMapperBase.valueToTree(conformance.toArray)
     val propertiesJsonList: ObjectNode = objectMapperBase.valueToTree(propertiesAsMap)
 
-    val objectItemMapper = objectMapperRoot.`with`("item")
+    val objectItemMapper = objectMapperRoot.withObject("/item")
 
     objectItemMapper.put("name", name)
     description.map(d => objectItemMapper.put("description", d))

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/Exportable.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/Exportable.scala
@@ -30,7 +30,7 @@ trait Exportable {
   @JsonIgnore
   protected lazy val objectMapperRoot: ObjectNode = {
     val mapperBase = objectMapperBase.createObjectNode()
-    mapperBase.`with`("metadata").put("exportVersion", ModelVersion)
+    mapperBase.withObject("/metadata").put("exportVersion", ModelVersion)
     mapperBase
   }
 

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/MappingTable.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/MappingTable.scala
@@ -91,7 +91,7 @@ case class MappingTable(name: String,
   override def exportItem(): String = {
     val defaultMappingValueJsonList: ArrayNode = objectMapperBase.valueToTree(defaultMappingValue.toArray)
 
-    val objectItemMapper = objectMapperRoot.`with`("item")
+    val objectItemMapper = objectMapperRoot.withObject("/item")
 
     objectItemMapper.put("name", name)
     description.map(d => objectItemMapper.put("description", d))

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/Schema.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/Schema.scala
@@ -72,7 +72,7 @@ case class Schema(name: String,
   override def exportItem(): String = {
     val fieldsJsonList: ArrayNode = objectMapperBase.valueToTree(fields.toArray)
 
-    val objectItemMapper = objectMapperRoot.`with`("item")
+    val objectItemMapper = objectMapperRoot.withObject("/item")
 
     objectItemMapper.put("name", name)
     description.map(d => objectItemMapper.put("description", d))

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/properties/PropertyDefinition.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/properties/PropertyDefinition.scala
@@ -100,7 +100,7 @@ case class PropertyDefinition(name: String,
     val propertyTypeJson: ObjectNode = objectMapperBase.valueToTree(propertyType)
     val essentialityJson: ObjectNode = objectMapperBase.valueToTree(essentiality)
 
-    val objectItemMapper = objectMapperRoot.`with`("item")
+    val objectItemMapper = objectMapperRoot.withObject("/item")
 
     objectItemMapper.put("name", name)
     description.map(d => objectItemMapper.put("description", d))

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/test/factories/DatasetFactory.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/test/factories/DatasetFactory.scala
@@ -45,7 +45,7 @@ object DatasetFactory extends EntityFactory[Dataset] {
                       userLocked: Option[String] = None,
                       conformance: List[ConformanceRule] = List(),
                       parent: Option[Reference] = None,
-                      properties: Option[Map[String, String]] = Some(Map())): Dataset = {
+                      properties: Option[Map[String, String]] = Some(Map.empty)): Dataset = {
 
     Dataset(name, version, description, hdfsPath, hdfsPublishPath, schemaName,
       schemaVersion, dateCreated, userCreated, lastUpdated, userUpdated,

--- a/data-model/src/test/scala/za/co/absa/enceladus/model/conformanceRule/ConformanceRuleTest.scala
+++ b/data-model/src/test/scala/za/co/absa/enceladus/model/conformanceRule/ConformanceRuleTest.scala
@@ -67,7 +67,7 @@ class ConformanceRuleTest extends AnyWordSpec with Matchers {
     val rule = MappingConformanceRule(order = 5, controlCheckpoint = true, outputColumn = "conformed_country",
       additionalColumns = None,
       mappingTable = "country", mappingTableVersion = 0, attributeMappings = Map("country_code" -> "country"),
-      targetAttribute = "country_name", overrideMappingTableOwnFilter = Some(false))
+      targetAttribute = "country_name", overrideMappingTableOwnFilter = Some(false)) // Some(false) is correct the default
     val json = """{"_t":"MappingConformanceRule","order":5,"controlCheckpoint":true,"mappingTable":"country","mappingTableVersion":0,"attributeMappings":{"country_code":"country"},"targetAttribute":"country_name","outputColumn":"conformed_country","additionalColumns":null,"isNullSafe":false}"""
     assertDeserialization(rule, json)
   }

--- a/migrations/pom.xml
+++ b/migrations/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
 
         <!-- MONGO -->

--- a/pom.xml
+++ b/pom.xml
@@ -173,9 +173,8 @@
         <hadoop.version>3.3.4</hadoop.version>
         <htrace.version>3.1.0-incubating</htrace.version>
         <httpclient.version>4.4.1</httpclient.version>
-        <jackson.spark.datatype.version>2.12.6</jackson.spark.datatype.version>
-        <jackson.spark.version>2.12.6</jackson.spark.version>
         <jackson.version>2.12.6</jackson.version>
+        <jackson.databind.version>2.12.6</jackson.databind.version>
         <jjwt.version>0.10.7</jjwt.version>
         <json4s.version>3.5.3</json4s.version>
         <junit.version>4.11</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <abris.version>6.2.0</abris.version>
         <absa.commons.version>1.1.0</absa.commons.version>
         <absa.spark.commons.version>0.4.0</absa.spark.commons.version>
-        <atum.version>3.8.3</atum.version>
+        <atum.version>3.9.0</atum.version>
         <bower.chart.js.version>2.7.3</bower.chart.js.version>
         <bson.codec.jsr310.version>3.5.4</bson.codec.jsr310.version>
         <cobrix.version>2.4.2</cobrix.version>
@@ -173,8 +173,8 @@
         <hadoop.version>3.3.4</hadoop.version>
         <htrace.version>3.1.0-incubating</htrace.version>
         <httpclient.version>4.4.1</httpclient.version>
-        <jackson.version>2.12.6</jackson.version>
-        <jackson.databind.version>2.12.6</jackson.databind.version>
+        <jackson.version>2.14.1</jackson.version>
+        <jackson.databind.version>2.14.1</jackson.databind.version>
         <jjwt.version>0.10.7</jjwt.version>
         <json4s.version>3.5.3</json4s.version>
         <junit.version>4.11</junit.version>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This PR increases the version of the Atum library to v3.9.0. (internally, that solves a couple of CVEs - details: https://github.com/AbsaOSS/atum/issues/150)

Test-ran on localhost, `_INFO` files appearing correctly both in std and conf outputs as expected.

Closes #2154.