### PR TITLE
Bugfix/2132 swagger wrong params

### DIFF
--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/SpringFoxConfig.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/SpringFoxConfig.scala
@@ -17,7 +17,8 @@ package za.co.absa.enceladus.rest_api
 
 import com.google.common.base.Predicate
 import com.google.common.base.Predicates.or
-import org.springframework.context.annotation.{Bean, Configuration, Primary, Profile}
+import org.springframework.context.annotation.{Bean, Configuration}
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import springfox.documentation.builders.PathSelectors.regex
 import springfox.documentation.builders.{ApiInfoBuilder, RequestHandlerSelectors}
 import springfox.documentation.spi.DocumentationType
@@ -40,6 +41,7 @@ class SpringFoxConfig extends ProjectMetadata {
 
     new Docket(DocumentationType.SWAGGER_2)
       .apiInfo(apiInfo(isDev))
+      .ignoredParameterTypes(classOf[AuthenticationPrincipal]) // excludes params as AccountNotLocket, etc. See #2132
       .select
       .apis(RequestHandlerSelectors.any)
       .paths(filteredPaths(isDev))

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/MappingTableController.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/MappingTableController.scala
@@ -37,9 +37,9 @@ class MappingTableController @Autowired() (mappingTableService: MappingTableServ
   @PostMapping(path = Array("/updateDefaults"))
   @ResponseStatus(HttpStatus.OK)
   def updateDefaults(@AuthenticationPrincipal user: UserDetails,
-    @RequestBody upd: GenericObject[Array[DefaultValue]]): CompletableFuture[MappingTable] = {
-    mappingTableService.updateDefaults(user.getUsername, upd.id.name,
-      upd.id.version, upd.value.toList).map {
+    @RequestBody updatedDefaults: GenericObject[Array[DefaultValue]]): CompletableFuture[MappingTable] = {
+    mappingTableService.updateDefaults(user.getUsername, updatedDefaults.id.name,
+      updatedDefaults.id.version, updatedDefaults.value.toList).map {
         case Some(entity) => entity._1 // v2 disregarding validation
         case None         => throw notFound()
       }

--- a/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/VersionedModelController.scala
+++ b/rest-api/src/main/scala/za/co/absa/enceladus/rest_api/controllers/VersionedModelController.scala
@@ -37,10 +37,17 @@ abstract class VersionedModelController[C <: VersionedModel with Product with Au
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  @GetMapping(Array("/list", "/list/{searchQuery}"))
+  @GetMapping(Array("/list"))
   @ResponseStatus(HttpStatus.OK)
-  def getList(@PathVariable searchQuery: Optional[String]): CompletableFuture[Seq[VersionedSummaryV2]] = {
-    versionedModelService.getLatestVersionsSummarySearch(searchQuery.toScalaOption, None, None) // V2 knows no skip/limit
+  def getList(): CompletableFuture[Seq[VersionedSummaryV2]] = {
+    versionedModelService.getLatestVersionsSummarySearch(None, None, None) // V2 knows no skip/limit
+      .map(_.map(_.toV2))
+  }
+
+  @GetMapping(Array("/list/{searchQuery}"))
+  @ResponseStatus(HttpStatus.OK)
+  def getListQuery(@PathVariable searchQuery: String): CompletableFuture[Seq[VersionedSummaryV2]] = {
+    versionedModelService.getLatestVersionsSummarySearch(Some(searchQuery), None, None) // V2 knows no skip/limit
       .map(_.map(_.toV2))
   }
 

--- a/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkJobRunnerMethods.scala
+++ b/utils/src/main/scala/za/co/absa/enceladus/utils/testUtils/SparkJobRunnerMethods.scala
@@ -33,7 +33,7 @@ trait SparkJobRunnerMethods {
       if (jobClassSymbol.isModuleClass) {
         jobClass.getField("MODULE$").get(jobClass)
       } else {
-        jobClass.newInstance
+        jobClass.getDeclaredConstructor().newInstance() // jobClass.newInstance() raises deprecation warnings
       }
 
     jobInstance.asInstanceOf[MainClass].main(Array.empty)


### PR DESCRIPTION
This PR aims to solve issue #2132.

A few Swagger-documentation issues has been fixed, specifically:

## V2 API `/edit` multiendpoint
 - originally, this endpoint covered both `/edit` and `/edit/{searchQuery}` together, which resulted in incorrect required `searchQuery` param on `/edit`. Divided into two, now behaves correctly
![api-v2-schema-list](https://user-images.githubusercontent.com/4457378/207038543-1074f83b-931f-4afa-9ab4-dca2f29abb45.png)
![api-v2-schema-list-query](https://user-images.githubusercontent.com/4457378/207038538-30ea04f7-51d9-4887-8f92-67d39948c3e9.png)

## Unwanted `@AuthenticationPrincipal` fields were present
 - `@AuthenticationPrincipal UserDetails` API parameter introduced unwanted
`accountNonExpired`, `accountNonLocked`, `credentialsNonExpired`, `authorities[0].authority` fields in Swagger. An `ignore` has been added for this parameter.

![auth-principal-fields-removed](https://user-images.githubusercontent.com/4457378/207049650-4e8a0293-c15e-4575-8e5f-9104c7f32e9f.png)


Closes #2132