### PR TITLE
#2180 multiline annotations squashed to single line.

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/Dataset.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/Dataset.scala
@@ -84,10 +84,8 @@ case class Dataset(
   @(AosSchema@field)(implementation = classOf[OozieSchedule])
   @BeanProperty schedule: Option[OozieSchedule] = None, //To be used for backward versioning compatibility
 
-  @(AosSchema@field)(implementation = classOf[java.util.Map[String, String]], example = "{" +
-    "\"field1\": \"value1\"," +
-    "\"field2\": \"value2\"" +
-    "}")
+  @(AosSchema@field)(implementation = classOf[java.util.Map[String, String]],
+    example = "{\"field1\": \"value1\", \"field2\": \"value2\"}")
   @BeanProperty properties: Option[Map[String, String]] = Some(Map.empty),
 
   @(AosSchema@field)(implementation = classOf[Validation])

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/MappingTable.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/MappingTable.scala
@@ -78,12 +78,8 @@ case class MappingTable(
   @(AosSchema@field)(implementation = classOf[Reference])
   @BeanProperty parent: Option[Reference] = None,
 
-  @(AosSchema@field)(implementation = classOf[DataFrameFilter], example = "{" +
-    "\"_t\": \"EqualsFilter\"," +
-    "\"columnName\": \"exampleColumn1\"," +
-    "\"value\":\"wantedValue1\"," +
-    "\"valueType\": \"string\"" +
-    "}"
+  @(AosSchema@field)(implementation = classOf[DataFrameFilter],
+    example = "{\"_t\": \"EqualsFilter\", \"columnName\": \"exampleColumn1\", \"value\":\"wantedValue1\", \"valueType\": \"string\"}"
   )
   @BeanProperty filter: Option[DataFrameFilter] = None
 ) extends VersionedModel with Auditable[MappingTable] {

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/backend/Reference.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/backend/Reference.scala
@@ -21,11 +21,7 @@ import scala.annotation.meta.field
 import scala.beans.BeanProperty
 
   @AosSchema(implementation = classOf[Reference],
-    example = "{" +
-      "\"collection\": \"dataset\"," +
-      "\"name\": \"Test\"," +
-      "\"version\": 4" +
-    "}"
+    example = "{\"collection\": \"dataset\", \"name\": \"Test\", \"version\": 4}"
   )
 case class Reference(
   @(AosSchema@field)(implementation = classOf[String],  example = "collection1")

--- a/data-model/src/main/scala/za/co/absa/enceladus/model/conformanceRule/package.scala
+++ b/data-model/src/main/scala/za/co/absa/enceladus/model/conformanceRule/package.scala
@@ -116,27 +116,19 @@ package object conformanceRule {
     @(AosSchema@field)(example = "3")
     @BeanProperty mappingTableVersion: Int,
 
-    @(AosSchema@field)(implementation = classOf[java.util.Map[String, String]], example = "{" +
-      "\"field1\": \"mappedField1\"" +
-      "}")
+    @(AosSchema@field)(implementation = classOf[java.util.Map[String, String]], example = "{\"field1\": \"mappedField1\"}")
     @BeanProperty attributeMappings: Map[String, String], // key = mapping table column, value = input df column
     @(AosSchema@field)(example = "CCC")
     @BeanProperty targetAttribute: String,
     @(AosSchema@field)(example = "ConformedCurrencyX")
     @BeanProperty outputColumn: String,
 
-    @(AosSchema@field)(implementation = classOf[java.util.Map[String, String]], example = "{" +
-      "\"newCol\": \"mappedCol1\"" +
-      "}")
+    @(AosSchema@field)(implementation = classOf[java.util.Map[String, String]], example = "{\"newCol\": \"mappedCol1\"}")
     @BeanProperty additionalColumns: Option[Map[String, String]] = None,
     @BeanProperty isNullSafe: Boolean = false,
 
-    @(AosSchema@field)(implementation = classOf[DataFrameFilter], example = "{" +
-      "\"_t\": \"EqualsFilter\"," +
-      "\"columnName\": \"column1\"," +
-      "\"value\": \"soughtAfterValue\"," +
-      "\"valueType\": \"string\"" +
-      "}")
+    @(AosSchema@field)(implementation = classOf[DataFrameFilter],
+      example = "{\"_t\": \"EqualsFilter\", \"columnName\": \"column1\", \"value\": \"soughtAfterValue\", \"valueType\": \"string\"}")
     @BeanProperty mappingTableFilter: Option[DataFrameFilter] = None,
     overrideMappingTableOwnFilter: Option[Boolean] = Some(DefaultOverrideMappingTableOwnFilter)
   ) extends ConformanceRule {

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/migrations-cli/pom.xml
+++ b/migrations-cli/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/migrations/pom.xml
+++ b/migrations/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/plugins-api/pom.xml
+++ b/plugins-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/plugins-builtin/pom.xml
+++ b/plugins-builtin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>za.co.absa.enceladus</groupId>
     <artifactId>parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Enceladus</name>
     <description>Enceladus is a Dynamic Conformance Engine which allows data from different formats to be standardized to parquet and conformed to group-accepted common reference.</description>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <scala.xml.version>1.0.6</scala.xml.version>

--- a/spark-jobs/pom.xml
+++ b/spark-jobs/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>


### PR DESCRIPTION
Closes #2180 
Multiline annotations squashed to single line.
Version reverted to 3.0.0-SNAPSHOT (as 3.0.0 was not yet released due to this error)

After this is merged, I intend to remove the v3.0.0 tag from where it is currently put