### PR TITLE
#2182 fixing unmoored doc, reverting to 3.0.0-SNAPSHOT

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dao/src/main/scala/za/co/absa/enceladus/dao/rest/RestClient.scala
+++ b/dao/src/main/scala/za/co/absa/enceladus/dao/rest/RestClient.scala
@@ -83,7 +83,7 @@ protected class RestClient(authClient: AuthClient,
 
     val statusCode = response.getStatusCode
 
-    /**
+    /*
      * This function handles unauthorized response by trying to authenticate
      * (if there are still some retries attempt left) - this might be due to an expired session.
      *

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/migrations-cli/pom.xml
+++ b/migrations-cli/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/migrations/pom.xml
+++ b/migrations/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/plugins-api/pom.xml
+++ b/plugins-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/plugins-builtin/pom.xml
+++ b/plugins-builtin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>za.co.absa.enceladus</groupId>
     <artifactId>parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Enceladus</name>
     <description>Enceladus is a Dynamic Conformance Engine which allows data from different formats to be standardized to parquet and conformed to group-accepted common reference.</description>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <scala.xml.version>1.0.6</scala.xml.version>

--- a/spark-jobs/pom.xml
+++ b/spark-jobs/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>za.co.absa.enceladus</groupId>
         <artifactId>parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>


### PR DESCRIPTION
Closes #2182 

An "unmoored" doc addressed - my understanding is that the issue is a local method being java/scala-documented.

Version reversed to 3.0.0-SNAPSHOT