### PR TITLE
Scala-maven-plugin update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <maven.war.plugin.version>2.2</maven.war.plugin.version>
-        <scala.maven.plugin.version>4.4.0</scala.maven.plugin.version>
+        <scala.maven.plugin.version>4.8.1</scala.maven.plugin.version>
         <scalatest.maven.version>2.0.2</scalatest.maven.version>
         <scoverage.maven.plugin.version>1.3.0</scoverage.maven.plugin.version>
         <!--dependency versions-->


### PR DESCRIPTION
Simple scala-maven-plugin update.

Should not break things.

Unfortunately, on my new environment, I had trouble building Enceladus with the current older version:
```
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.4.0:compile (default) on project utils: Execution default of goal net.alchim31.maven:scala-maven-plugin:4.4.0:compile failed: An API incompatibility was encountered while executing net.alchim31.maven:scala-maven-plugin:4.4.0:compile: java.
lang.NoSuchMethodError: org.fusesource.jansi.AnsiConsole.wrapOutputStream(Ljava/io/OutputStream;)Ljava/io/OutputStream;
```
Using `OpenJDK Runtime Environment (Temurin)(build 1.8.0_362-b09)`, `apache-maven-3.9.1`
