### PR TITLE
#2199: Counting runs count takes too much MongoDB CPU

### DIFF
--- a/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/MongoRepository.scala
+++ b/menas/src/main/scala/za/co/absa/enceladus/menas/repositories/MongoRepository.scala
@@ -48,7 +48,7 @@ abstract class MongoRepository[C](mongoDb: MongoDatabase)(implicit ct: ClassTag[
   }
 
   def count(): Future[Long] = {
-    collection.countDocuments().toFuture()
+    collection.estimatedDocumentCount().toFuture()
   }
 
   private[repositories] def getNameFilter(name: String): Bson = {


### PR DESCRIPTION
* replaced DB-intensive `documentCount` for `estimatedDocumentCount`

Closes #2199 