### PR TITLE
#2204: In release 2.27.2 Jackons was erroneously downgraded, which causes issues in Menas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,9 +162,9 @@
         <hadoop.version>2.8.5</hadoop.version>
         <htrace.version>3.1.0-incubating</htrace.version>
         <httpclient.version>4.4.1</httpclient.version>
-        <jackson.spark.datatype.version>2.6.7</jackson.spark.datatype.version>
-        <jackson.spark.version>2.6.7</jackson.spark.version>
-        <jackson.version>2.6.7</jackson.version>
+        <jackson.spark.datatype.version>2.10.4</jackson.spark.datatype.version>
+        <jackson.spark.version>2.10.4</jackson.spark.version>
+        <jackson.version>2.10.4</jackson.version>
         <jjwt.version>0.10.7</jjwt.version>
         <junit.version>4.11</junit.version>
         <kafka.spark.version>0-10</kafka.spark.version>


### PR DESCRIPTION
* Jackson versions upgraded to 2.10.4

Closes #2204