### PR TITLE
#2213 Explicitly disable control metrics at the end of the job.

### DIFF
--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/StandardizationAndConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/StandardizationAndConformanceJob.scala
@@ -24,6 +24,7 @@ import za.co.absa.enceladus.utils.config.ConfigReader
 import za.co.absa.enceladus.utils.modules.SourcePhase
 import za.co.absa.enceladus.utils.types.{Defaults, DefaultsByFormat}
 import za.co.absa.enceladus.utils.udf.UDFLibrary
+import za.co.absa.atum.AtumImplicits._
 
 object StandardizationAndConformanceJob extends StandardizationAndConformanceExecution {
   private val jobName = "Enceladus Standardization&Conformance"
@@ -60,6 +61,7 @@ object StandardizationAndConformanceJob extends StandardizationAndConformanceExe
       // post processing deliberately rereads the output ... same as above
       runPostProcessing(SourcePhase.Conformance, preparationResult, cmd)
     } finally {
+      spark.disableControlMeasuresTracking()
       finishJob(cmd)
     }
   }

--- a/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/StandardizationAndConformanceJob.scala
+++ b/spark-jobs/src/main/scala/za/co/absa/enceladus/standardization_conformance/StandardizationAndConformanceJob.scala
@@ -61,7 +61,7 @@ object StandardizationAndConformanceJob extends StandardizationAndConformanceExe
       // post processing deliberately rereads the output ... same as above
       runPostProcessing(SourcePhase.Conformance, preparationResult, cmd)
     } finally {
-      spark.disableControlMeasuresTracking()
+      spark.disableControlMeasuresTracking() //disabling Atum to enable running the whole process again, with fresh initialization
       finishJob(cmd)
     }
   }


### PR DESCRIPTION
This is needed when the main method can be invoked more than once externally.

The PR fixes running multiple Standardization+Conformance jobs from a single Spark session via Pramen. If this patch is not applied, the second and other pipelines will fail with "control metrics already initialized" exception.

This was tested end to end.
![Screenshot 2024-03-05 at 13 07 00](https://github.com/AbsaOSS/enceladus/assets/4082463/64d2bc2e-3fee-40ce-a11b-e628218bdae5)
