### PR TITLE
Feature/#2219 enceladus to run with new supported version of mongo db

### DIFF
--- a/menas/pom.xml
+++ b/menas/pom.xml
@@ -29,7 +29,7 @@
         <scala.xml.version>1.0.4</scala.xml.version>
         <webui.basedir>${project.basedir}/ui</webui.basedir>
         <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>
-        <embedded.mongo.version>2.2.0</embedded.mongo.version>
+        <embedded.mongo.version>4.18.0</embedded.mongo.version>
     </properties>
 
     <dependencies>
@@ -340,7 +340,7 @@
                     <args>
                         <arg>-Xfatal-warnings</arg>
                         <arg>-unchecked</arg>
-                        <arg>-deprecation</arg>
+                        <arg>-deprecation:false</arg>
                         <arg>-feature</arg>
                     </args>
                 </configuration>

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiFeaturesIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/controllers/SchemaApiFeaturesIntegrationSuite.scala
@@ -308,7 +308,8 @@ class SchemaApiFeaturesIntegrationSuite extends BaseRestApiTest with BeforeAndAf
 
           val actual = response.getBody
           val expected = UsedIn(Some(Seq(MenasReference(None, "dataset", 1))), Some(Seq()))
-          assert(actual == expected)
+          val expectedMongo4_4 = UsedIn(Some(Seq(MenasReference(Some("dataset"), "dataset", 1))), Some(Seq()))
+          assert(actual == expectedMongo4_4)
         }
       }
       "some version of the Schema is used by a enabled MappingTable" should {
@@ -325,7 +326,8 @@ class SchemaApiFeaturesIntegrationSuite extends BaseRestApiTest with BeforeAndAf
 
           val actual = response.getBody
           val expected = UsedIn(Some(Seq()), Some(Seq(MenasReference(None, "mapping", 1))))
-          assert(actual == expected)
+          val expectedMongo4_4 = UsedIn(Some(Seq()), Some(Seq(MenasReference(Some("mapping_table"), "mapping", 1))))
+          assert(actual == expectedMongo4_4)
         }
       }
     }
@@ -460,7 +462,8 @@ class SchemaApiFeaturesIntegrationSuite extends BaseRestApiTest with BeforeAndAf
 
           val actual = response.getBody
           val expected = UsedIn(Some(Seq(MenasReference(None, "dataset1", 1))), Some(Seq()))
-          assert(actual == expected)
+          val expectedMongo4_4 = UsedIn(Some(Seq(MenasReference(Some("dataset"), "dataset1", 1))), Some(Seq()))
+          assert(actual == expectedMongo4_4)
         }
       }
       "some version of the Schema is used by a enabled MappingTable" should {
@@ -478,7 +481,8 @@ class SchemaApiFeaturesIntegrationSuite extends BaseRestApiTest with BeforeAndAf
 
           val actual = response.getBody
           val expected = UsedIn(Some(Seq()), Some(Seq(MenasReference(None, "mapping1", 1))))
-          assert(actual == expected)
+          val expectedMongo4_4 = UsedIn(Some(Seq()), Some(Seq(MenasReference(Some("mapping_table"), "mapping1", 1))))
+          assert(actual == expectedMongo4_4)
         }
       }
     }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/mongo/EmbeddedMongo.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/mongo/EmbeddedMongo.scala
@@ -42,7 +42,7 @@ class EmbeddedMongo {
 
   @PostConstruct
   def runDummyMongo(): Unit = {
-    runningMongod = Mongod.instance().start(Version.Main.V4_0)
+    runningMongod = Mongod.instance().start(Version.Main.V8_0)
     logger.debug(s"*** mongod started at $getMongoUri")
   }
 

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/mongo/EmbeddedMongo.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/mongo/EmbeddedMongo.scala
@@ -15,10 +15,10 @@
 
 package za.co.absa.enceladus.menas.integration.mongo
 
-import de.flapdoodle.embed.mongo.config.{MongodConfigBuilder, Net}
 import de.flapdoodle.embed.mongo.distribution.Version
-import de.flapdoodle.embed.mongo.{MongodExecutable, MongodStarter}
-import de.flapdoodle.embed.process.runtime.Network
+import de.flapdoodle.embed.mongo.transitions.{Mongod, RunningMongodProcess}
+import de.flapdoodle.reverse.TransitionWalker
+
 import javax.annotation.{PostConstruct, PreDestroy}
 import org.mongodb.scala.{MongoClient, MongoDatabase}
 import org.slf4j.LoggerFactory
@@ -33,43 +33,28 @@ import za.co.absa.enceladus.menas.utils.implicits.codecRegistry
 @Profile(Array("withEmbeddedMongo"))
 class EmbeddedMongo {
   private val logger = LoggerFactory.getLogger(this.getClass)
-  private var mongodExecutable: MongodExecutable = _
-  private var mongoPort: Int = _
+  private var runningMongod: TransitionWalker.ReachedState[RunningMongodProcess] = _
 
-  def getMongoUri: String = s"mongodb://localhost:$mongoPort/?ssl=false"
-
-  def getMongoPort: Int = mongoPort
+  def getMongoUri: String = f"mongodb://${runningMongod.current().getServerAddress}"
 
   @Value("${menas.mongo.connection.database}")
   val database: String = ""
 
   @PostConstruct
   def runDummyMongo(): Unit = {
-    val starter = MongodStarter.getDefaultInstance
-
-    synchronized {
-      mongoPort = Network.getFreeServerPort()
-      val mongodConfig = new MongodConfigBuilder()
-        .version(Version.Main.V4_0)
-        .net(new Net("localhost", mongoPort, Network.localhostIsIPv6()))
-        .build()
-
-      mongodExecutable = starter.prepare(mongodConfig)
-    }
-
-    mongodExecutable.start()
-    logger.debug(s"*** mongod started at port $mongoPort")
+    runningMongod = Mongod.instance().start(Version.Main.V4_0)
+    logger.debug(s"*** mongod started at $getMongoUri")
   }
 
   @PreDestroy
   def shutdownDummyMongo(): Unit = {
-    mongodExecutable.stop()
+    runningMongod.close()
   }
 
   @Primary // will override non-primary MongoDatabase-typed bean when in scope - here: the 'defaultMongoDb' bean
   @Bean
   def embeddedMongoDb: MongoDatabase = {
+    print(f"\n===TEST MONGO DB URI===: $getMongoUri ===\n")
     MongoClient(getMongoUri).getDatabase(database).withCodecRegistry(codecRegistry)
   }
-
 }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/mongo/EmbeddedMongo.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/mongo/EmbeddedMongo.scala
@@ -54,7 +54,6 @@ class EmbeddedMongo {
   @Primary // will override non-primary MongoDatabase-typed bean when in scope - here: the 'defaultMongoDb' bean
   @Bean
   def embeddedMongoDb: MongoDatabase = {
-    print(f"\n===TEST MONGO DB URI===: $getMongoUri ===\n")
     MongoClient(getMongoUri).getDatabase(database).withCodecRegistry(codecRegistry)
   }
 }

--- a/menas/src/test/scala/za/co/absa/enceladus/menas/integration/mongo/EmbededMongoIntegrationSuite.scala
+++ b/menas/src/test/scala/za/co/absa/enceladus/menas/integration/mongo/EmbededMongoIntegrationSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.enceladus.menas.integration.mongo
+
+import org.junit.runner.RunWith
+import org.mongodb.scala.model.Filters.equal
+import org.mongodb.scala.model.Filters
+import org.mongodb.scala.model.Projections.{computed, fields, include}
+import org.mongodb.scala.{MongoCollection, MongoDatabase}
+import org.scalatest.wordspec.AnyWordSpec
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringRunner
+import za.co.absa.enceladus.menas.integration.TestContextManagement
+import za.co.absa.enceladus.model.menas.MenasReference
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+@RunWith(classOf[SpringRunner])
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(Array("withEmbeddedMongo"))
+class EmbededMongoIntegrationSuite extends AnyWordSpec with TestContextManagement {
+  @Autowired
+  val mongoDb: MongoDatabase = null
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    Await.result(mongoDb.drop().toFuture(), Duration.Inf)
+  }
+
+  s"mongo" can {
+    s"perform find" when {
+      s"version is above 4.4.1 or below 4.2.23" should {
+        s"populate or ignore computed field accordingly" in {
+
+          // Prior to v 4.4
+          //   inlcuding field in find expression purely included it in result
+          //   meaninig, original value / null value is preserved regardless of users wish to override it
+          // Since 4.4
+          //   provided value is actually respected
+          // https://www.mongodb.com/docs/v4.4/release-notes/4.4-compatibility/#projection-compatibility-changes
+
+          val collection: MongoCollection[MenasReference] = mongoDb.getCollection[MenasReference]("TestMeCollection")
+          val sampleReference = MenasReference(None, "dedo jozef", 123)
+          val filter = Filters.and(equal("name", "dedo jozef"), equal("version", 123))
+          val mongoInsertQuery = collection.insertMany(Seq(sampleReference))
+          val mongoFindQuery = collection
+            .find[MenasReference](filter)
+            .projection(fields(include("name", "version"), computed("collection", "tato zlato")))
+
+          Await.result(mongoInsertQuery.toFuture(), Duration.Inf)
+          val actual = Await.result(mongoFindQuery.toFuture(), Duration.Inf)
+
+          val expectedV4_2_23orBefore = Seq(MenasReference(None, "dedo jozef", 123))
+          val expectedV4_4_1orAfter = Seq(MenasReference(Some("tato zlato"), "dedo jozef", 123))
+          assert(actual == expectedV4_4_1orAfter)
+        }
+      }
+    }
+  }
+}

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -88,7 +88,7 @@
                     <args>
                         <arg>-Xfatal-warnings</arg>
                         <arg>-unchecked</arg>
-                        <arg>-deprecation</arg>
+                        <arg>-deprecation:false</arg>
                         <arg>-feature</arg>
                     </args>
                 </configuration>


### PR DESCRIPTION
1) Removed deprecation from build failures - otherwise cannot build it with tools that actually respect it

2) Changed embeded mongo provider for unit test with recent one (capable of hosting older versions as well for backwards compatibility)
-> and set it to v 8.0

3) Added specific unit test checking behavior of mongo, relevant to its version being after 4.4 or prior to 4.2

4) changed unit tests influenced by this behavior..... 
the "functionality" is only available since 4.4 and in older version, it is kinda ignored.... 
seems like the original code is written as if expecting the functionality being there... while unit tests are testing it being ignored

This obviously expects deployment mongo to be of version 8.0
apart from this discrepancy.... runnin unit tests, integration tests and initial manual testing of menas seems to work in either, legacy mongo 4.0 as well as mongo 8.0 (just Mongo updates needs to be done in succession on the existing database)
